### PR TITLE
Update Step2_ConvertingLabels2DataFrame.py

### DIFF
--- a/Generating_a_Training_Set/Step2_ConvertingLabels2DataFrame.py
+++ b/Generating_a_Training_Set/Step2_ConvertingLabels2DataFrame.py
@@ -99,7 +99,7 @@ for scorer in Scorers:
                 datafile = bodypart
                 try:
                     dframe = pd.read_csv(datafile + ".xls",sep=None,engine='python') #, sep='\t')
-                except FileNotFoundError:
+                except OSError as e:
                     os.rename(datafile + ".csv", datafile + ".xls")
                     dframe = pd.read_csv(datafile + ".xls",sep=None,engine='python') #, sep='\t')
 


### PR DESCRIPTION
Fixes for Python3.4. It fails because python3.4 raises `OSError` and not `FileNotFoundError`. `FileNotFoundError` is a subclass of `OSError`. Relevant https://stackoverflow.com/a/28633573/1805129 

Probably a good idea to replace all instance of `FileNotFoundError` with `OSError`.