### PR TITLE
Fixed frame index in video when restarting the labeling process

### DIFF
--- a/Analysis-tools/MakingLabeledVideo.py
+++ b/Analysis-tools/MakingLabeledVideo.py
@@ -91,6 +91,7 @@ def CreateVideo(clip,Dataframe):
         
         imagename = tmpfolder + "/file%04d.png" % index
         if os.path.isfile(tmpfolder + "/file%04d.png" % index):
+            clip.reader.skip_frames(1)
             pass
         else:
             plt.axis('off')

--- a/Analysis-tools/MakingLabeledVideo.py
+++ b/Analysis-tools/MakingLabeledVideo.py
@@ -92,6 +92,8 @@ def CreateVideo(clip,Dataframe):
         imagename = tmpfolder + "/file%04d.png" % index
         if os.path.isfile(tmpfolder + "/file%04d.png" % index):
             clip.reader.skip_frames(1)
+            if index==0:
+                print("Attention: some frames were already labeled and the code will skip those. If you want to change the style,                      or redo the frames, you need to manually delete the corresponding folder", tmpfolder, " first.")
             pass
         else:
             plt.axis('off')


### PR DESCRIPTION
If some labeled frames already exist, the function will start with the first unlabeled frame. However, the index in the video file did not change leading to an offset between labels and frames. 
This is fixed now by simply skipping a frame if already extracted.