### PR TITLE
Close video reader after selecting frames

### DIFF
--- a/Generating_a_Training_Set/Step1_SelectRandomFrames_fromVideos.py
+++ b/Generating_a_Training_Set/Step1_SelectRandomFrames_fromVideos.py
@@ -113,6 +113,7 @@ def SelectFrames(videopath,filename,x1,x2,y1,y2,cropping, videotype,start,stop,T
                     io.imsave(os.path.join(basefolder,folder,"img" + str(index).zfill(indexlength) + ".png"),image)
                 except FileNotFoundError:
                     print("Frame # ", index, " does not exist.")
+            clip.reader.close()
 
 if __name__ == "__main__":
     if checkcropping==True:


### PR DESCRIPTION
On Windows, a `clip.reader.close()` is necessary to avoid errors such as `OSError: [WinError 6] The handle is invalid`.

See https://stackoverflow.com/a/45393619