### PR TITLE
fix mpl rectangle bbox

### DIFF
--- a/deeplabcut/generate_training_dataset/frame_extraction.py
+++ b/deeplabcut/generate_training_dataset/frame_extraction.py
@@ -105,8 +105,12 @@ def extract_frames(config,mode,algo='uniform',crop=False,checkcropping=False):
                     fig,ax = plt.subplots(1)
                     # Display the image
                     ax.imshow(image)
-                    # Create a Rectangle patch
-                    rect = patches.Rectangle((int(coords[0]),int(coords[2])),int(coords[1]),int(coords[3]),linewidth=3,edgecolor='r',facecolor='none')
+                    # Create a Rectangle 
+                    x1, x2, y1, y2 = [int(s) for s in coords]
+                    rect = patches.Rectangle((x1, y1), x2-x1, y2-y1,
+                                             linewidth=3,
+                                             edgecolor='r',
+                                             facecolor='none')
                     # Add the patch to the Axes
                     ax.add_patch(rect)
                     plt.show()
@@ -126,11 +130,11 @@ def extract_frames(config,mode,algo='uniform',crop=False,checkcropping=False):
                             io.imsave(saveimg, image)
                             
                             # crop and move on with extraction of frames:
-                            clip=clip.crop(y1 = int(coords[2]),y2 = int(coords[3]),x1 = int(coords[0]), x2 = int(coords[1]))
+                            clip=clip.crop(y1=y1, y2=y2, x1=x1, x2=x2)
                       else:
                           askuser=input ("The directory already contains some frames. Do you want to add to it?(yes/no): ")
                           if askuser=='y' or askuser=='yes' or askuser=='Y' or askuser=='Yes':
-                              clip=clip.crop(y1 = int(coords[2]),y2 = int(coords[3]),x1 = int(coords[0]), x2 = int(coords[1]))
+                              clip=clip.crop(y1=y1, y2=y2, x1=x1, x2=x2)
                           else:
                               sys.exit("Delete the frames and try again later!")
                     else:


### PR DESCRIPTION
Use width/height instead of absolute coordinates when creating the MPL cropping preview rectangle