### PR TITLE
Progress bar fix

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -226,6 +226,7 @@ def GetPoseF(cfg,dlc_cfg, sess, inputs, outputs,cap,nframes,batchsize):
                     PredicteData[batch_num*batchsize:batch_num*batchsize+batch_ind, :] = pose[:batch_ind,:]
                 break
             counter+=1
+
     pbar.close()
     return PredicteData,nframes
 

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -226,7 +226,7 @@ def GetPoseF(cfg,dlc_cfg, sess, inputs, outputs,cap,nframes,batchsize):
                     PredicteData[batch_num*batchsize:batch_num*batchsize+batch_ind, :] = pose[:batch_ind,:]
                 break
             counter+=1
-
+    pbar.close()
     return PredicteData,nframes
 
 def GetPoseS(cfg,dlc_cfg, sess, inputs, outputs,cap,nframes):


### PR DESCRIPTION
This closes the progress bar when analyzing a video.
If the progress bar is left open, the progress bars start to pile up when DeepLabCut is run on multiple videos.

This is consistent with `GetPoseS`