### PR TITLE
windows long file path (>260 characters) error

### DIFF
--- a/deeplabcut/utils/visualization.py
+++ b/deeplabcut/utils/visualization.py
@@ -9,7 +9,6 @@ import os
 import numpy as np
 import matplotlib as mpl
 from pathlib import Path
-import shutil
 
 if os.environ.get('DLClight', default=False) == 'True':
     mpl.use('AGG') #anti-grain geometry engine #https://matplotlib.org/faq/usage_faq.html

--- a/deeplabcut/utils/visualization.py
+++ b/deeplabcut/utils/visualization.py
@@ -9,6 +9,7 @@ import os
 import numpy as np
 import matplotlib as mpl
 from pathlib import Path
+import shutil
 
 if os.environ.get('DLClight', default=False) == 'True':
     mpl.use('AGG') #anti-grain geometry engine #https://matplotlib.org/faq/usage_faq.html
@@ -66,7 +67,13 @@ def PlottingandSaveLabeledFrame(DataCombined,ind,trainIndices,cfg,colors,compari
         MakeLabeledImage(DataCombined,ind,cfg["pcutoff"],cfg["project_path"],[cfg["scorer"],DLCscorer],comparisonbodyparts,colors,cfg)
 
         if ind in trainIndices:
-            plt.savefig(os.path.join(foldername,'Training-'+imfoldername+'-'+imagename)) #create filename comprising videofolder + imagename
+            full_path = os.path.join(foldername,'Training-'+imfoldername+'-'+imagename)
         else:
-            plt.savefig(os.path.join(foldername,'Test-'+imfoldername+'-'+imagename))
+            full_path = os.path.join(foldername,'Test-'+imfoldername+'-'+imagename)
+
+        # windows throws error if file path is > 260 characters, can fix with prefix. see https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file#maximum-path-length-limitation
+        if (len(full_path) >= 260) and (os.name == 'nt'):
+            full_path = '\\\\?\\'+full_path
+        plt.savefig(full_path)
+
         plt.close("all")


### PR DESCRIPTION
Error thrown on windows if the file path to an image is > 260 characters, can be fixed by adding the prefix: '\\?\' to the file path (https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file#maximum-path-length-limitation)