### PR TITLE
Provide ability to test on videos that weren't trained on

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/evaluate.py
@@ -29,7 +29,7 @@ def pairwisedistances(DataCombined,scorer1,scorer2,pcutoff=-1,bodyparts=None):
             RMSE=np.sqrt(Pointwisesquareddistance.xs('x',level=1,axis=1)+Pointwisesquareddistance.xs('y',level=1,axis=1)) #Euclidean distance (proportional to RMSE)
             return RMSE,RMSE[mask]
 
-def evaluate_network(config,Shuffles=[1],plotting = None,show_errors = True,comparisonbodyparts="all",gputouse=None):
+def evaluate_network(config,Shuffles=[1],plotting = None,show_errors = True,comparisonbodyparts="all",gputouse=None,suffix=''):
     """
     Evaluates the network based on the saved models at different stages of the training network.\n
     The evaluation results are stored in the .h5 and .csv file under the subdirectory 'evaluation_results'.
@@ -100,8 +100,8 @@ def evaluate_network(config,Shuffles=[1],plotting = None,show_errors = True,comp
             ##################################################
             # Load and setup CNN part detector
             ##################################################
-            datafn,metadatafn=auxiliaryfunctions.GetDataandMetaDataFilenames(trainingsetfolder,trainFraction,shuffle,cfg)
-            modelfolder=os.path.join(cfg["project_path"],str(auxiliaryfunctions.GetModelFolder(trainFraction,shuffle,cfg)))
+            datafn,metadatafn=auxiliaryfunctions.GetDataandMetaDataFilenames(trainingsetfolder,trainFraction,shuffle,cfg,suffix)
+            modelfolder=os.path.join(cfg["project_path"],str(auxiliaryfunctions.GetModelFolder(trainFraction,shuffle,cfg,suffix)))
             path_test_config = Path(modelfolder) / 'test' / 'pose_cfg.yaml'
             # Load meta data
             data, trainIndices, testIndices, trainFraction=auxiliaryfunctions.LoadMetadata(os.path.join(cfg["project_path"],metadatafn))
@@ -114,7 +114,7 @@ def evaluate_network(config,Shuffles=[1],plotting = None,show_errors = True,comp
             #change batch size, if it was edited during analysis!
             dlc_cfg['batch_size']=1 #in case this was edited for analysis.
             #Create folder structure to store results.
-            evaluationfolder=os.path.join(cfg["project_path"],str(auxiliaryfunctions.GetEvaluationFolder(trainFraction,shuffle,cfg)))
+            evaluationfolder=os.path.join(cfg["project_path"],str(auxiliaryfunctions.GetEvaluationFolder(trainFraction,shuffle,cfg,suffix)))
             auxiliaryfunctions.attempttomakefolder(evaluationfolder,recursive=True)
             #path_train_config = modelfolder / 'train' / 'pose_cfg.yaml'
             

--- a/deeplabcut/pose_estimation_tensorflow/training.py
+++ b/deeplabcut/pose_estimation_tensorflow/training.py
@@ -9,7 +9,7 @@ M Mathis, mackenzie@post.harvard.edu
 import os
 from pathlib import Path
 
-def train_network(config,shuffle=1,trainingsetindex=0,gputouse=None,max_snapshots_to_keep=5,autotune=False,displayiters=None,saveiters=None,maxiters=None):
+def train_network(config,shuffle=1,trainingsetindex=0,gputouse=None,max_snapshots_to_keep=5,autotune=False,displayiters=None,saveiters=None,maxiters=None,suffix=''):
     """Trains the network with the labels in the training dataset.
 
     Parameter
@@ -63,7 +63,7 @@ def train_network(config,shuffle=1,trainingsetindex=0,gputouse=None,max_snapshot
     
     # Read file path for pose_config file. >> pass it on
     cfg = auxiliaryfunctions.read_config(config)
-    modelfoldername=auxiliaryfunctions.GetModelFolder(cfg["TrainingFraction"][trainingsetindex],shuffle,cfg)
+    modelfoldername=auxiliaryfunctions.GetModelFolder(cfg["TrainingFraction"][trainingsetindex],shuffle,cfg, suffix)
     poseconfigfile=Path(os.path.join(cfg['project_path'],str(modelfoldername),"train","pose_cfg.yaml"))
     if not poseconfigfile.is_file():
       print("The training datafile ", poseconfigfile, " is not present.")

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -196,22 +196,22 @@ def GetTrainingSetFolder(cfg):
     iterate = 'iteration-'+str(cfg['iteration'])
     return Path(os.path.join('training-datasets',iterate,'UnaugmentedDataSet_' + Task + date))
 
-def GetModelFolder(trainFraction,shuffle,cfg):
+def GetModelFolder(trainFraction,shuffle,cfg,suffix=''):
     Task = cfg['Task']
     date = cfg['date']
     iterate = 'iteration-'+str(cfg['iteration'])
-    return Path('dlc-models/'+ iterate+'/'+Task + date + '-trainset' + str(int(trainFraction * 100)) + 'shuffle' + str(shuffle))
+    return Path('dlc-models/'+ iterate+'/'+Task + date + '-trainset' + str(int(trainFraction * 100)) + 'shuffle' + str(shuffle) + suffix)
 
-def GetEvaluationFolder(trainFraction,shuffle,cfg):
+def GetEvaluationFolder(trainFraction,shuffle,cfg,suffix=''):
     Task = cfg['Task']
     date = cfg['date']
     iterate = 'iteration-'+str(cfg['iteration'])
-    return Path('evaluation-results/'+ iterate+'/'+Task + date + '-trainset' + str(int(trainFraction * 100)) + 'shuffle' + str(shuffle))
+    return Path('evaluation-results/'+ iterate+'/'+Task + date + '-trainset' + str(int(trainFraction * 100)) + 'shuffle' + str(shuffle) + suffix)
 
-def GetDataandMetaDataFilenames(trainingsetfolder,trainFraction,shuffle,cfg):
+def GetDataandMetaDataFilenames(trainingsetfolder,trainFraction,shuffle,cfg,suffix=''):
     # Filename for metadata and data relative to project path for corresponding parameters
-    metadatafn=os.path.join(str(trainingsetfolder) , 'Documentation_data-' + cfg["Task"] + "_" + str(int(trainFraction * 100)) + "shuffle" + str(shuffle) + '.pickle')
-    datafn=os.path.join(str(trainingsetfolder) ,cfg["Task"] + "_" + cfg["scorer"] + str(int(100 * trainFraction)) + "shuffle" + str(shuffle)+ '.mat')
+    metadatafn=os.path.join(str(trainingsetfolder) , 'Documentation_data-' + cfg["Task"] + "_" + str(int(trainFraction * 100)) + "shuffle" + str(shuffle) + suffix + '.pickle')
+    datafn=os.path.join(str(trainingsetfolder) ,cfg["Task"] + "_" + cfg["scorer"] + str(int(100 * trainFraction)) + "shuffle" + str(shuffle) + suffix +  '.mat')
     return datafn,metadatafn
 
 
@@ -239,7 +239,7 @@ def GetScorerName(cfg,shuffle,trainFraction,trainingsiterations='unknown'):
         else:
             snapshotindex=cfg['snapshotindex']
 
-        modelfolder=os.path.join(cfg["project_path"],str(GetModelFolder(trainFraction,shuffle,cfg)),'train')
+        modelfolder=os.path.join(cfg["project_path"],str(GetModelFolder(trainFraction,shuffle,cfg,suffix)),'train')
         Snapshots = np.array([fn.split('.')[0]for fn in os.listdir(modelfolder) if "index" in fn])
         increasing_indices = np.argsort([int(m.split('-')[1]) for m in Snapshots])
         Snapshots = Snapshots[increasing_indices]


### PR DESCRIPTION
Added the option to test on a different dataset than the dataset that was trained on.  Utilized the Shuffles parameter to perform leave-one-out cross-validation on the folders within the training dataset. Added the suffix to allow multiple training datasets to be created within the same project folder. The parameters are set to the defaults to be backwards compatible. 