### PR TITLE
Add slider_width config value to set manual frame extraction slider w…

### DIFF
--- a/deeplabcut/generate_training_dataset/frame_extraction.py
+++ b/deeplabcut/generate_training_dataset/frame_extraction.py
@@ -7,7 +7,7 @@ M Mathis, mackenzie@post.harvard.edu
 """
 
 
-def extract_frames(config,mode='automatic',algo='kmeans',crop=False,userfeedback=True,cluster_step=1,cluster_resizewidth=30,cluster_color=False,opencv=True):
+def extract_frames(config,mode='automatic',algo='kmeans',crop=False,userfeedback=True,cluster_step=1,cluster_resizewidth=30,cluster_color=False,opencv=True,slider_width=25):
     """
     Extracts frames from the videos in the config.yaml file. Only the videos in the config.yaml will be used to select the frames.\n
     Use the function ``add_new_video`` at any stage of the project to add new videos to the config file and extract their frames.
@@ -55,6 +55,8 @@ def extract_frames(config,mode='automatic',algo='kmeans',crop=False,userfeedback
     opencv: bool, default: True
         Uses openCV for loading & extractiong (otherwise moviepy (legacy))
         
+    slider_width: number, default: 25
+        Width of the video frames slider, in percent of window
         
     Examples
     --------
@@ -69,6 +71,9 @@ def extract_frames(config,mode='automatic',algo='kmeans',crop=False,userfeedback
     --------
     for selecting frames manually,
     >>> deeplabcut.extract_frames('/analysis/project/reaching-task/config.yaml','manual')
+    --------
+    for selecting frames manually, with a 60% wide frames slider
+    >>> deeplabcut.extract_frames('/analysis/project/reaching-task/config.yaml','manual', slider_width=60)
     
     While selecting the frames manually, you do not need to specify the ``crop`` parameter in the command. Rather, you will get a prompt in the graphic user interface to choose 
     if you need to crop or not.
@@ -93,7 +98,7 @@ def extract_frames(config,mode='automatic',algo='kmeans',crop=False,userfeedback
         wd = Path(config).resolve().parents[0]
         os.chdir(str(wd))
         from deeplabcut.generate_training_dataset import frame_extraction_toolbox 
-        frame_extraction_toolbox.show(config)
+        frame_extraction_toolbox.show(config, slider_width)
         
     elif mode == "automatic":
         config_file = Path(config).resolve()

--- a/deeplabcut/generate_training_dataset/frame_extraction_toolbox.py
+++ b/deeplabcut/generate_training_dataset/frame_extraction_toolbox.py
@@ -69,6 +69,9 @@ class MainFrame(wx.Frame):
     """Contains the main GUI and button boxes"""
 
     def __init__(self, parent,config):
+# Read in config
+        self.cfg = auxiliaryfunctions.read_config(config)
+
 # Settting the GUI size and panels design
         displays = (wx.Display(i) for i in range(wx.Display.GetCount())) # Gets the number of displays
         screenSizes = [display.GetGeometry().GetSize() for display in displays] # Gets the size of each display
@@ -79,6 +82,7 @@ class MainFrame(wx.Frame):
 
         wx.Frame.__init__ ( self, parent, id = wx.ID_ANY, title = 'DeepLabCut2.0 - Manual Frame Extraction',
                             size = wx.Size(self.gui_size), pos = wx.DefaultPosition, style = wx.RESIZE_BORDER|wx.DEFAULT_FRAME_STYLE|wx.TAB_TRAVERSAL )
+
         self.statusbar = self.CreateStatusBar()
         self.statusbar.SetStatusText("")
 
@@ -116,7 +120,13 @@ class MainFrame(wx.Frame):
         self.grab.Enable(False)
 
         widgetsizer.AddStretchSpacer(5)
-        self.slider = wx.Slider(self.widget_panel, id=wx.ID_ANY, value = 0, minValue=0, maxValue=1,size=(200, -1), style=wx.SL_HORIZONTAL | wx.SL_AUTOTICKS | wx.SL_LABELS )
+
+        try:
+            slider_width = self.cfg['slider_width']
+        except:
+            slider_width = 25
+        size_x = round(self.gui_size[0] * (slider_width/100), 0)
+        self.slider = wx.Slider(self.widget_panel, id=wx.ID_ANY, value = 0, minValue=0, maxValue=1,size=(size_x, -1), style=wx.SL_HORIZONTAL | wx.SL_AUTOTICKS | wx.SL_LABELS )
         widgetsizer.Add(self.slider,1, wx.ALL,5)
         self.slider.Hide()
         
@@ -170,7 +180,6 @@ class MainFrame(wx.Frame):
         self.figure = Figure()
         self.axes = self.figure.add_subplot(111)
         self.drs = []
-        self.cfg = auxiliaryfunctions.read_config(config)
         self.Task = self.cfg['Task']
         self.start = self.cfg['start']
         self.stop = self.cfg['stop']

--- a/deeplabcut/generate_training_dataset/frame_extraction_toolbox.py
+++ b/deeplabcut/generate_training_dataset/frame_extraction_toolbox.py
@@ -68,10 +68,7 @@ class WidgetPanel(wx.Panel):
 class MainFrame(wx.Frame):
     """Contains the main GUI and button boxes"""
 
-    def __init__(self, parent,config):
-# Read in config
-        self.cfg = auxiliaryfunctions.read_config(config)
-
+    def __init__(self, parent,config,slider_width=25):
 # Settting the GUI size and panels design
         displays = (wx.Display(i) for i in range(wx.Display.GetCount())) # Gets the number of displays
         screenSizes = [display.GetGeometry().GetSize() for display in displays] # Gets the size of each display
@@ -120,11 +117,6 @@ class MainFrame(wx.Frame):
         self.grab.Enable(False)
 
         widgetsizer.AddStretchSpacer(5)
-
-        try:
-            slider_width = self.cfg['slider_width']
-        except:
-            slider_width = 25
         size_x = round(self.gui_size[0] * (slider_width/100), 0)
         self.slider = wx.Slider(self.widget_panel, id=wx.ID_ANY, value = 0, minValue=0, maxValue=1,size=(size_x, -1), style=wx.SL_HORIZONTAL | wx.SL_AUTOTICKS | wx.SL_LABELS )
         widgetsizer.Add(self.slider,1, wx.ALL,5)
@@ -180,6 +172,7 @@ class MainFrame(wx.Frame):
         self.figure = Figure()
         self.axes = self.figure.add_subplot(111)
         self.drs = []
+        self.cfg = auxiliaryfunctions.read_config(config)
         self.Task = self.cfg['Task']
         self.start = self.cfg['start']
         self.stop = self.cfg['stop']
@@ -443,11 +436,11 @@ class MatplotPanel(wx.Panel):
         self.figure = Figure()
         self.axes = self.figure.add_subplot(111)
 
-def show(config):
+def show(config, slider_width=25):
     import imageio
     imageio.plugins.ffmpeg.download()
     app = wx.App()
-    frame = MainFrame(None,config).Show()
+    frame = MainFrame(None,config,slider_width).Show()
     app.MainLoop()
 
 


### PR DESCRIPTION
…idth #315

Adds a 'slider_width' config parameter to set slider width, in percentage.

Notes:
 - Allows to set a wider slider for large videos in manual frame extraction
 - Doesn't add the config parameter anywhere in the config generation
 - Defaults to 25% if not set
 - If set to a larger value (75%, maybe smaller), the widgetsizer will wrap to another line