### PR TITLE
WIP: Modernize conda environment

### DIFF
--- a/conda-environments/dlc-ubuntu-GPU.yaml
+++ b/conda-environments/dlc-ubuntu-GPU.yaml
@@ -1,105 +1,173 @@
-#conda env. as used on Jun 18th 2019 for Woods Hole course on new Ubuntu 18.04
-name: dlc
+name: null
 channels:
   - conda-forge
   - defaults
 dependencies:
   - _tflow_select=2.1.0=gpu
-  - blas=1.0=openblas
+  - absl-py=0.7.1=py36_0
+  - asn1crypto=0.24.0=py36_1003
+  - astor=0.7.1=py_0
+  - atk=2.32.0=haf93ef1_0
+  - backcall=0.1.0=py_0
+  - blas=1.1=openblas
+  - blosc=1.16.3=he1b5a44_1
+  - bzip2=1.0.6=h14c3975_1002
   - c-ares=1.15.0=h14c3975_1001
-  - ca-certificates=2019.5.15=0
-  - certifi=2019.3.9=py36_0
+  - ca-certificates=2019.6.16=hecc5488_0
+  - cairo=1.16.0=h18b612c_1001
+  - certifi=2019.6.16=py36_0
+  - cffi=1.12.3=py36h8022711_0
+  - chardet=3.0.4=py36_1003
+  - click=7.0=py_0
+  - cloudpickle=1.2.1=py_0
+  - cryptography=2.5=py36hb7f436b_1
   - cudatoolkit=10.0.130=0
   - cudnn=7.6.0=cuda10.0_0
   - cupti=10.0.130=0
+  - cycler=0.10.0=py_1
+  - cytoolz=0.9.0.1=py36h14c3975_1001
+  - dask-core=2.0.0=py_0
+  - dbus=1.13.6=he372182_0
+  - decorator=4.4.0=py_0
+  - easydict=1.9=py_0
+  - expat=2.2.5=he1b5a44_1003
+  - ffmpeg=4.1.3=h167e202_0
+  - fontconfig=2.13.1=he4413a7_1000
+  - freetype=2.10.0=he983fc9_0
   - gast=0.2.2=py_0
+  - gdk-pixbuf=2.36.12=h7a26e22_1003
+  - gettext=0.19.8.1=hc5be6a0_1002
+  - glib=2.58.3=h6f030ca_1001
+  - gmp=6.1.2=hf484d3e_1000
+  - gnutls=3.6.5=hd3a4fd2_1002
+  - gobject-introspection=1.58.2=py36h5503ade_1001
+  - graphite2=1.3.13=hf484d3e_1000
+  - grpcio=1.16.0=py36h4f00d22_1000
+  - gst-plugins-base=1.14.5=h0935bb2_0
+  - gstreamer=1.14.5=h36ae1b5_0
+  - gtk2=2.24.31=h4934977_1002
+  - h5py=2.9.0=nompi_py36hf008753_1102
+  - harfbuzz=2.4.0=h37c48d4_1
   - hdf5=1.10.4=nompi_h3c11f04_1106
-  - libblas=3.8.0=7_openblas
-  - libcblas=3.8.0=7_openblas
-  - libedit=3.1.20181209=hc058e9b_0
-  - libffi=3.2.1=hd88cf55_4
+  - icu=58.2=hf484d3e_1000
+  - idna=2.8=py36_1000
+  - imageio=2.3.0=py_1
+  - ipython_genutils=0.2.0=py_1
+  - jedi=0.14.0=py36_0
+  - jpeg=9c=h14c3975_1001
+  - keras-applications=1.0.7=py_1
+  - keras-preprocessing=1.0.9=py_1
+  - kiwisolver=1.1.0=py36hc9558a2_0
+  - lame=3.100=h14c3975_1001
+  - libblas=3.8.0=5_h6e990d7_netlib
+  - libcblas=3.8.0=5_h6e990d7_netlib
+  - libedit=3.1.20170329=hf8c457e_1001
+  - libffi=3.2.1=he1b5a44_1006
   - libgcc-ng=9.1.0=hdf63c60_0
+  - libgfortran=3.0.0=1
   - libgfortran-ng=7.3.0=hdf63c60_0
-  - liblapack=3.8.0=7_openblas
-  - libopenblas=0.3.6=h5a2b251_0
+  - libglu=9.0.0=hf484d3e_1000
+  - libiconv=1.15=h516909a_1005
+  - liblapack=3.8.0=5_h6e990d7_netlib
+  - libopenblas=0.2.20=h9ac9557_7
+  - libpng=1.6.37=hed695b0_0
   - libprotobuf=3.8.0=h8b12597_0
   - libstdcxx-ng=9.1.0=hdf63c60_0
+  - libtiff=4.0.10=h57b8799_1003
+  - libuuid=2.32.1=h14c3975_1000
+  - libxcb=1.13=h14c3975_1002
+  - libxml2=2.9.9=h13577e0_0
+  - lz4-c=1.8.3=he1b5a44_1001
+  - lzo=2.10=h14c3975_1000
+  - markdown=2.6.11=py_0
+  - matplotlib=3.0.3=py36_1
+  - matplotlib-base=3.0.3=py36h5f35d83_1
   - mock=3.0.5=py36_0
-  - ncurses=6.1=he6710b0_1
-  - numpy-base=1.14.6=py36h2f8d375_4
-  - openblas=0.3.5=h9ac9557_1001
-  - openssl=1.1.1c=h7b6447c_1
+  - moviepy=0.2.3.5=py_0
+  - ncurses=6.1=hf484d3e_1002
+  - nettle=3.4.1=h1bed415_1002
+  - networkx=2.3=py_0
+  - numexpr=2.6.9=py36h637b7d7_1000
+  - numpy=1.14.5=py36_blas_openblashd3ea46f_202
+  - numpy-base=1.14.3=py36h2b20989_0
+  - olefile=0.46=py_0
+  - openblas=0.2.20=8
+  - openh264=1.8.0=hdbcaa40_1000
+  - openssl=1.0.2r=h14c3975_0
+  - pandas=0.21.0=py36_0
+  - pango=1.40.14=he7ab937_1005
+  - parso=0.5.0=py_0
+  - pathlib2=2.3.4=py36_0
+  - patsy=0.5.1=py_0
+  - pcre=8.41=hf484d3e_1003
+  - pexpect=4.7.0=py36_0
+  - pickleshare=0.7.5=py36_1000
+  - pillow=6.0.0=py36he7afcd5_0
   - pip=19.1.1=py36_0
-  - python=3.6.8=h0371630_0
-  - readline=7.0=h7b6447c_5
+  - pixman=0.38.0=h516909a_1003
+  - prompt_toolkit=1.0.15=py_1
+  - protobuf=3.8.0=py36he1b5a44_1
+  - pthread-stubs=0.4=h14c3975_1001
+  - ptyprocess=0.6.0=py_1001
+  - pycparser=2.19=py36_1
+  - pygments=2.4.2=py_0
+  - pyopenssl=19.0.0=py36_0
+  - pyparsing=2.4.0=py_0
+  - pypubsub=4.0.3=py_0
+  - pyqt=5.6.0=py36h13b7fb3_1008
+  - pysocks=1.7.0=py36_0
+  - pytables=3.5.1=py36h442f067_1
+  - python=3.6.7=hd21baee_1002
+  - python-dateutil=2.7.3=py_0
+  - pytz=2019.1=py_0
+  - pywavelets=1.0.3=py36hd352d35_1
+  - pyyaml=5.1.1=py36h516909a_0
+  - qt=5.6.2=hce4f676_1013
+  - readline=7.0=hf8c457e_1001
+  - requests=2.22.0=py36_0
+  - ruamel.yaml=0.15.0=py36_0
+  - scikit-image=0.14.2=py36hf484d3e_1
+  - scikit-learn=0.19.2=py36_blas_openblasha84fab4_201
+  - scipy=1.1.0=py36_blas_openblash7943236_201
   - setuptools=41.0.1=py36_0
-  - sqlite=3.28.0=h7b6447c_0
+  - simplegeneric=0.8.1=py_1
+  - sip=4.18.1=py36hf484d3e_1000
+  - six=1.11.0=py36_1001
+  - sqlite=3.28.0=h8b20d00_0
+  - statsmodels=0.9.0=py36h3010b51_1000
+  - tensorboard=1.13.1=py36_0
   - tensorflow=1.13.1=gpu_py36h3991807_0
   - tensorflow-base=1.13.1=gpu_py36h8d69cac_0
   - tensorflow-estimator=1.13.0=py_0
-  - tk=8.6.8=hbc83047_0
+  - tensorflow-gpu=1.13.1=h0d30ee6_0
+  - termcolor=1.1.0=py_2
+  - tk=8.6.9=hed695b0_1002
+  - toolz=0.9.0=py_1
+  - tornado=6.0.3=py36h516909a_0
+  - tqdm=4.32.2=py_0
+  - traitlets=4.3.2=py36_1000
+  - urllib3=1.24.3=py36_0
+  - wcwidth=0.1.7=py_1
   - werkzeug=0.15.4=py_0
-  - xz=5.2.4=h14c3975_4
-  - zlib=1.2.11=h7b6447c_3
+  - wheel=0.31.1=py36_1001
+  - wxpython=4.0.6=py36h812d2d3_0
+  - x264=1!152.20180806=h14c3975_0
+  - xorg-kbproto=1.0.7=h14c3975_1002
+  - xorg-libice=1.0.9=h516909a_1004
+  - xorg-libsm=1.2.3=h84519dc_1000
+  - xorg-libx11=1.6.7=h14c3975_1000
+  - xorg-libxau=1.0.9=h14c3975_0
+  - xorg-libxdmcp=1.1.3=h516909a_0
+  - xorg-libxext=1.3.4=h516909a_0
+  - xorg-libxrender=0.9.10=h516909a_1002
+  - xorg-libxt=1.2.0=h516909a_0
+  - xorg-renderproto=0.11.1=h14c3975_1002
+  - xorg-xextproto=7.3.0=h14c3975_1002
+  - xorg-xproto=7.0.31=h14c3975_1007
+  - xz=5.2.4=h14c3975_1001
+  - yaml=0.1.7=h14c3975_1001
+  - zlib=1.2.11=h14c3975_1004
+  - zstd=1.4.0=h3b9ef0a_0
   - pip:
-    - absl-py==0.7.1
-    - astor==0.8.0
-    - chardet==3.0.4
-    - click==7.0
-    - cloudpickle==1.2.1
-    - cycler==0.10.0
-    - decorator==4.4.0
-    - deeplabcut==2.0.6.3
-    - easydict==1.9
-    - grpcio==1.21.1
-    - h5py==2.9.0
-    - idna==2.8
-    - imageio==2.3.0
-    - intel-openmp==2019.0
-    - ipython==6.0.0
-    - ipython-genutils==0.2.0
-    - jedi==0.13.3
-    - keras-applications==1.0.8
-    - keras-preprocessing==1.1.0
-    - kiwisolver==1.1.0
-    - markdown==3.1.1
-    - matplotlib==3.0.3
-    - moviepy==0.2.3.5
-    - networkx==2.3
-    - numexpr==2.6.9
-    - numpy==1.14.6
     - opencv-python==3.4.5.20
-    - pandas==0.21.0
-    - parso==0.4.0
-    - patsy==0.5.1
-    - pexpect==4.7.0
-    - pickleshare==0.7.5
-    - pillow==6.0.0
-    - prompt-toolkit==1.0.16
-    - protobuf==3.8.0
-    - ptyprocess==0.6.0
-    - pygments==2.4.2
-    - pyparsing==2.4.0
-    - pypubsub==4.0.3
-    - python-dateutil==2.7.3
-    - pytz==2019.1
-    - pywavelets==1.0.3
-    - pyyaml==5.1.1
-    - requests==2.22.0
-    - ruamel-yaml==0.15.0
-    - scikit-image==0.14.3
-    - scikit-learn==0.19.2
-    - scipy==1.1.0
-    - simplegeneric==0.8.1
-    - six==1.11.0
-    - statsmodels==0.9.0
-    - tables==3.5.2
-    - tensorboard==1.12.2
-    - tensorflow-gpu==1.12.0
-    - termcolor==1.1.0
-    - tqdm==4.32.1
-    - traitlets==4.3.2
-    - urllib3==1.25.3
-    - wcwidth==0.1.7
-    - wheel==0.31.1
-    - wxpython==4.0.3
+    - deeplabcut==2.0.7

--- a/conda-environments/dlc-ubuntu-GPU.yaml
+++ b/conda-environments/dlc-ubuntu-GPU.yaml
@@ -170,4 +170,4 @@ dependencies:
   - zstd=1.4.0=h3b9ef0a_0
   - pip:
     - opencv-python==3.4.5.20
-    - deeplabcut==2.0.7
+    - deeplabcut


### PR DESCRIPTION
Remake conda environment using the dev environment in #340 and then re-exporting to have specific versions.

This fixes the tons of packages install by pip *and* the fact that the old environment was installing things and then upgrading them with pip.