### PR TITLE
Update predict_videos.py

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -488,10 +488,19 @@ def analyze_time_lapse_frames(config,directory,frametype='.png',shuffle=1,traini
     """
     if 'TF_CUDNN_USE_AUTOTUNE' in os.environ:
         del os.environ['TF_CUDNN_USE_AUTOTUNE'] #was potentially set during training
+    
+	if gputouse is not None:  # gpu selection
+        os.environ['CUDA_VISIBLE_DEVICES'] = str(gputouse)
 
-    TF.reset_default_graph()
+    vers = (tf.__version__).split('.')
+    if int(vers[0]) == 1 and int(vers[1]) > 12:
+        TF = tf.compat.v1
+    else:
+        TF = tf
+    
+	TF.reset_default_graph()
     start_path=os.getcwd() #record cwd to return to this directory in the end
-
+    
     cfg = auxiliaryfunctions.read_config(config)
     trainFraction = cfg['TrainingFraction'][trainingsetindex]
     modelfolder=os.path.join(cfg["project_path"],str(auxiliaryfunctions.GetModelFolder(trainFraction,shuffle,cfg)))


### PR DESCRIPTION
Solves " NameError: name 'TF' is not defined`" when deeplabcut.analyze_time_lapse_frames is called.

Refer: https://github.com/AlexEMG/DeepLabCut/issues/402 (first issue)