### PR TITLE
change fractions for randomly applying augmentation, fix process ratio bug

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/dataset/pose_dataset_tensorpack.py
+++ b/deeplabcut/pose_estimation_tensorflow/dataset/pose_dataset_tensorpack.py
@@ -153,7 +153,7 @@ class PoseDataset:
         # Randomly adds brightness within the range [-brightness_dif, brightness_dif]
         # to augment training data
         cfg['brightness_dif']= cfg.get('brightness_dif', 0.3)
-        cfg['brightnessratio']=cfg.get('brightnessratio', 0.2)  # what is the fraction of training samples with brightness augmentation?
+        cfg['brightnessratio']=cfg.get('brightnessratio', 0.0)  # what is the fraction of training samples with brightness augmentation?
 
         # Randomly applies x = (x - mean) * contrast_factor + mean`` to each
         # color channel within the range [contrast_factor_lo, contrast_factor_up]
@@ -165,12 +165,12 @@ class PoseDataset:
         # Randomly adjusts saturation within range 1 + [-saturation_max_dif, saturation_max_dif]
         # to augment training data
         cfg['saturation_max_dif']= cfg.get('saturation_max_dif', 0.5)
-        cfg['saturationratio']=cfg.get('saturationratio', 0.2) # what is the fraction of training samples with saturation augmentation?
+        cfg['saturationratio']=cfg.get('saturationratio', 0.0) # what is the fraction of training samples with saturation augmentation?
 
         # Randomly applies gaussian noise N(0, noise_sigma^2) to an image
         # to augment training data
         cfg['noise_sigma']= cfg.get('noise_sigma', 0.1)
-        cfg['noiseratio']=cfg.get('noiseratio', 0.2) # what is the fraction of training samples with noise augmentation?
+        cfg['noiseratio']=cfg.get('noiseratio', 0.0) # what is the fraction of training samples with noise augmentation?
 
         # Randomly applies gaussian blur to an image with a random window size
         # within the range [0, 2 * blur_max_window_size + 1] to augment training data
@@ -250,8 +250,8 @@ class PoseDataset:
         df = MapData(df, self.compute_target_part_scoremap)
 
         num_cores = multiprocessing.cpu_count()
-        num_processes = num_cores * self.cfg['processratio']
-        if num_processes == 1:
+        num_processes = num_cores * int(self.cfg['processratio'])
+        if num_processes <= 1:
             num_processes = 2 # recommended to use more than one process for training
         if os.name == 'nt':
             df2 = MultiProcessRunner(df, num_proc = num_processes, num_prefetch = self.cfg['num_prefetch'])


### PR DESCRIPTION
I changed a few of the default ratios for randomly applying Tensorpack augmentation based on some analyses I ran on our data. To determine how each type of augmentation impacts the performance of a network, I trained multiple networks on the same data. Each network had a different type of augmentation excluded during the training process. The networks were tested on the same camera view, one that they hadn't been trained on. Results are shown in the bar chart attached below. The horizontal black line represents the test error when all types of augmentation were used. On our data, saturation and brightness augmentation had no significant effect on the test error, and removing scaling and noise augmentation improved the performance of the respective networks. Thus, I set the default ratios to randomly apply saturation, brightness, and noise augmentation to 0.0 in pose_dataset_tensorpack.py. I did not change the default ratio for scaling, since scaling augmentation is included in pose_dataset.py. 

Additionally, I fixed a small bug regarding the process ratio. It should be an integer value, so I casted the process ratio to an integer in pose_dataset_tensorpack.py. This will ensure that the number of processes will always be an integer as well. 

These changes were tested on Ubuntu 16.04. The output files from testscript.py using pose_dataset.py and pose_dataset_tensorpack.py can be found here: https://gist.github.com/katierupp/f204e1ac329a81f044f8df4af7b9c823.

![removing-aug-pcutoff](https://user-images.githubusercontent.com/48692614/65555170-a55eba00-dee0-11e9-9568-d22fd8462640.png)
