### PR TITLE
fix doc string quotes and process ratio casting

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/dataset/pose_dataset_tensorpack.py
+++ b/deeplabcut/pose_estimation_tensorflow/dataset/pose_dataset_tensorpack.py
@@ -1,4 +1,4 @@
-"""
+'''
 DeepLabCut2.0 Toolbox (deeplabcut.org)
 © A. & M. Mathis Labs
 https://github.com/AlexEMG/DeepLabCut
@@ -257,7 +257,7 @@ class PoseDataset:
         df = MapData(df, self.compute_target_part_scoremap)
 
         num_cores = multiprocessing.cpu_count()
-        num_processes = num_cores * int(self.cfg['processratio'])
+        num_processes = int(num_cores * self.cfg['processratio'])
         if num_processes <= 1:
             num_processes = 2 # recommended to use more than one process for training
         if os.name == 'nt':


### PR DESCRIPTION
I fixed the doc string at the top of pose_dataset_tensporpack.py. Previously, the header was using two different types of quotes.  

Additionally, I revised how I previously attempted to fix the bug regarding the process ratio. Instead of only casting the process ratio to an integer, I casted the product of the number of cores and the process ratio to an integer in pose_dataset_tensorpack.py. 

These changes were tested on Ubuntu 16.04. The output file from testscript.py using pose_dataset.py is contained in dlc_test.txt and the output file from testscript.py using pose_dataset_tensorpack.py is contained in dlc_test_tensorpack.txt. Both of these files can be found at the following link:  https://gist.github.com/katierupp/f78e3cbbba062bc853332d8b61e5db94