### PR TITLE
Update video_processor.py

### DIFF
--- a/deeplabcut/utils/video_processor.py
+++ b/deeplabcut/utils/video_processor.py
@@ -125,6 +125,11 @@ class VideoProcessorCV(VideoProcessor):
         self.w = int(self.vid.get(cv2.CAP_PROP_FRAME_WIDTH))
         self.h = int(self.vid.get(cv2.CAP_PROP_FRAME_HEIGHT))
         all_frames = int(self.vid.get(cv2.CAP_PROP_FRAME_COUNT))
+        infourcc = int(self.vid.get(cv2.CAP_PROP_FOURCC)) #read fourcc code from original video
+        if infourcc == 844516695: #This fourcc code is not read properly/does not contain FPS information
+            self.FPS = self.FPS #Set FPS to init 30 fps
+        else:
+            self.FPS = self.vid.get(cv2.CAP_PROP_FPS)
         self.FPS = self.vid.get(cv2.CAP_PROP_FPS)
         self.nc = 3
         if self.nframes == -1 or self.nframes>all_frames:


### PR DESCRIPTION
Following issue #475 , I modified slightly `video_processor.py` .
Picking up FPS correctly from the original video is essential to obtain a labeled video of correct duration. Both openCV and ffmpeg implementations depend on OpenCV to read this tag from the header in the original video file.
At least one type of file (that with fourcc code `844516695` ) is read by OpenCV as to have 1000 fps (being original 30 fps), which gives rise to a labeled video 33.33 times shorter than the original.
If other file types were found to have the same problem, the `if` condition could be easily expanded to include them.