### PR TITLE
Allow running module directly

### DIFF
--- a/deeplabcut/__init__.py
+++ b/deeplabcut/__init__.py
@@ -57,3 +57,8 @@ from deeplabcut.utils import create_labeled_video,plot_trajectories, auxiliaryfu
 from deeplabcut.utils.auxfun_videos import ShortenVideo, DownSampleVideo
 
 from deeplabcut.version import __version__, VERSION
+
+
+if __name__ == "__main__":
+    # if module is executed direcyly (i.e. `python -m deeplabcut`) launch straight into the GUI
+    launch_dlc()


### PR DESCRIPTION
Users who just want access to the GUI can run the module with `python -m deeplabcut` without the unnecessary steps of invoking an `ipython` session.

This can be built on with python's `argparse` and command line arguments.