### PR TITLE
Fix for negative coordinates in the dataset

### DIFF
--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -641,19 +641,18 @@ def create_training_dataset(config,num_shuffles=1,Shuffles=None,windows2linux=Fa
                 indexjoints=0
                 joints=np.zeros((len(bodyparts),3))*np.nan
                 for bpindex,bodypart in enumerate(bodyparts):
-                    if Data[bodypart]['x'][jj]<np.shape(im)[1] and Data[bodypart]['y'][jj]<np.shape(im)[0]: #are labels in image?
+                    # check whether the labels are positive and inside the img
+                    x_pos_n_inside = 0 < Data[bodypart]['x'][jj] < np.shape(im)[1]
+                    y_pos_n_inside = 0 < Data[bodypart]['y'][jj] < np.shape(im)[0]
+                    if x_pos_n_inside and y_pos_n_inside:
                         joints[indexjoints,0]=int(bpindex)
                         joints[indexjoints,1]=Data[bodypart]['x'][jj]
                         joints[indexjoints,2]=Data[bodypart]['y'][jj]
                         indexjoints+=1
 
-                print(joints)
-                joints[joints < 0] = np.nan  # replace negatives with nans
-                print(joints)
                 joints = joints[np.where(
                     np.prod(np.isfinite(joints),
                             1))[0], :]  # drop NaN, i.e. lines for missing body parts
-                print(joints)
 
                 assert (np.prod(np.array(joints[:, 2]) < np.shape(im)[0])
                         )  # y coordinate within image?

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -642,8 +642,8 @@ def create_training_dataset(config,num_shuffles=1,Shuffles=None,windows2linux=Fa
                 joints=np.zeros((len(bodyparts),3))*np.nan
                 for bpindex,bodypart in enumerate(bodyparts):
                     # check whether the labels are positive and inside the img
-                    x_pos_n_inside = 0 < Data[bodypart]['x'][jj] < np.shape(im)[1]
-                    y_pos_n_inside = 0 < Data[bodypart]['y'][jj] < np.shape(im)[0]
+                    x_pos_n_inside = 0 <= Data[bodypart]['x'][jj] < np.shape(im)[1]
+                    y_pos_n_inside = 0 <= Data[bodypart]['y'][jj] < np.shape(im)[0]
                     if x_pos_n_inside and y_pos_n_inside:
                         joints[indexjoints,0]=int(bpindex)
                         joints[indexjoints,1]=Data[bodypart]['x'][jj]

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -647,9 +647,13 @@ def create_training_dataset(config,num_shuffles=1,Shuffles=None,windows2linux=Fa
                         joints[indexjoints,2]=Data[bodypart]['y'][jj]
                         indexjoints+=1
 
+                print(joints)
+                joints[joints < 0] = np.nan  # replace negatives with nans
+                print(joints)
                 joints = joints[np.where(
                     np.prod(np.isfinite(joints),
                             1))[0], :]  # drop NaN, i.e. lines for missing body parts
+                print(joints)
 
                 assert (np.prod(np.array(joints[:, 2]) < np.shape(im)[0])
                         )  # y coordinate within image?


### PR DESCRIPTION
Fix for issue #493 

Apparently, few of my annotations are having negative coordinates. I've changed trainingsetmanipulation.py to not to add such examples to the dataset.

Ubuntu 18.04
tensorflow-gpu==1.14
CUDA 10
GeForce RTX 2080 Ti

How to test: 

- Please download the .csv and .h5 files from this [link](https://drive.google.com/drive/folders/1t69jf0hl2u-odIvS5ImxZff-gN6hBCMf?usp=sharing)
- You can use those with **examples/Reaching-Mackenzie-2018-08-30**. This .csv has few negative coordinates to reproduce this behavior.   
- I have added few prints for debugging purposes. Will remove them once you test this.

[testscript.log](https://github.com/AlexEMG/DeepLabCut/files/3877415/testscript.log)


