### PR TITLE
fall back to config.yaml for num_outputs

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -164,7 +164,7 @@ def analyze_videos(config,videos, videotype='avi', shuffle=1, trainingsetindex=0
     dlc_cfg['init_weights'] = os.path.join(modelfolder , 'train', Snapshots[snapshotindex])
     trainingsiterations = (dlc_cfg['init_weights'].split(os.sep)[-1]).split('-')[-1]
     # Update number of output and batchsize
-    dlc_cfg['num_outputs'] = dlc_cfg.get('num_outputs', 1)
+    dlc_cfg['num_outputs'] = dlc_cfg.get('num_outputs', cfg.get('num_outputs', 1))
 
     if batchsize==None:
         #update batchsize (based on parameters in config.yaml)

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -164,7 +164,7 @@ def analyze_videos(config,videos, videotype='avi', shuffle=1, trainingsetindex=0
     dlc_cfg['init_weights'] = os.path.join(modelfolder , 'train', Snapshots[snapshotindex])
     trainingsiterations = (dlc_cfg['init_weights'].split(os.sep)[-1]).split('-')[-1]
     # Update number of output and batchsize
-    dlc_cfg['num_outputs'] = dlc_cfg.get('num_outputs', cfg.get('num_outputs', 1))
+    dlc_cfg['num_outputs'] = cfg.get('num_outputs', dlc_cfg.get('num_outputs', 1))
 
     if batchsize==None:
         #update batchsize (based on parameters in config.yaml)


### PR DESCRIPTION
This is a simple fix to go back to the old behavior for "num_outputs".
That is, it reads from the num_outputs in the `test/pose_cfg.yaml` as is current behavior, then if it doesn't find it there, reads from the `config.yaml` file. 

I find it much easier to modify the `config.yaml` file than the `test/pose_cfg.yaml` for each network