### PR TITLE
Fix index error in the absence of widget children.

### DIFF
--- a/deeplabcut/gui/train_network.py
+++ b/deeplabcut/gui/train_network.py
@@ -229,12 +229,36 @@ class Train_network(wx.Panel):
             raise FileNotFoundError("File not found!")
 
     def train_network(self,event):
-        shuffle = int(self.shuffles.Children[0].GetValue())
-        trainingsetindex = int(self.trainingindex.Children[0].GetValue())
-        max_snapshots_to_keep = int(self.snapshots.Children[0].GetValue())
-        displayiters = int(self.display_iters.Children[0].GetValue())
-        saveiters = int(self.save_iters.Children[0].GetValue())
-        maxiters = int(self.max_iters.Children[0].GetValue())
+        if self.shuffles.Children:
+            shuffle = int(self.shuffles.Children[0].GetValue())
+        else:
+            shuffle = int(self.shuffles.GetValue())
+
+        if self.trainingindex.Children:
+            trainingsetindex = int(self.trainingindex.Children[0].GetValue())
+        else:
+            trainingsetindex = int(self.trainingindex.GetValue())
+
+        if self.snapshots.Children:
+            max_snapshots_to_keep = int(self.snapshots.Children[0].GetValue())
+        else:
+            max_snapshots_to_keep = int(self.snapshots.GetValue())
+
+        if self.display_iters.Children:
+            displayiters = int(self.display_iters.Children[0].GetValue())
+        else:
+            displayiters = int(self.display_iters.GetValue())
+
+        if self.save_iters.Children:
+            saveiters = int(self.save_iters.Children[0].GetValue())
+        else:
+            saveiters = int(self.save_iters.GetValue())
+
+        if self.max_iters.Children:
+            maxiters = int(self.max_iters.Children[0].GetValue())
+        else:
+            maxiters = int(self.max_iters.GetValue())
+            
         deeplabcut.train_network(self.config,shuffle,
                                  trainingsetindex,gputouse=None,
                                  max_snapshots_to_keep=max_snapshots_to_keep,


### PR DESCRIPTION
Solve #550 #552 #553.
On Ubuntu and Windows, SpinCtrl widgets have no children, such that a different treatment is needed to correctly get text inputs.