### PR TITLE
Define crop coordinates in GUI when analyzing videos.

### DIFF
--- a/deeplabcut/create_project/human_dataset.py
+++ b/deeplabcut/create_project/human_dataset.py
@@ -136,7 +136,7 @@ def create_pretrained_human_project(project,experimenter,videos,working_director
 
     if analyzevideo==True:
         # Analyze the videos
-        deeplabcut.analyze_videos(cfg,[video_dir],videotype,save_as_csv=True)
+        deeplabcut.analyze_videos(cfg, [video_dir], videotype, save_as_csv=True)
     if createlabeledvideo==True:
         deeplabcut.create_labeled_video(cfg,[video_dir],videotype, draw_skeleton=True)
         deeplabcut.plot_trajectories(cfg, [video_dir], videotype)

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -647,6 +647,7 @@ def create_training_dataset(config,num_shuffles=1,Shuffles=None,windows2linux=Fa
     else:
         Shuffles = [i for i in Shuffles if isinstance(i, int)]
 
+    print(trainIndexes,testIndexes, Shuffles, augmenter_type,net_type)
     if trainIndexes is None and testIndexes is None:
         splits = [(trainFraction, shuffle, SplitTrials(range(len(Data.index)), trainFraction))
                   for trainFraction in cfg['TrainingFraction'] for shuffle in Shuffles]
@@ -655,9 +656,9 @@ def create_training_dataset(config,num_shuffles=1,Shuffles=None,windows2linux=Fa
             raise ValueError('Number of train and test indexes should be equal.')
         splits = []
         for shuffle, (train_inds, test_inds) in enumerate(zip(trainIndexes, testIndexes)):
-            trainFraction = len(train_inds) / (len(train_inds) + len(test_inds))
+            trainFraction = len(train_inds) * 1./ (len(train_inds) + len(test_inds))
             print(f"You passed a split with the following fraction: {int(100 * trainFraction)}%")
-            splits.append((trainFraction, shuffle, (train_inds, test_inds)))
+            splits.append((trainFraction, Shuffles[shuffle], (train_inds, test_inds)))
 
     bodyparts = cfg['bodyparts']
     nbodyparts = len(bodyparts)
@@ -803,5 +804,5 @@ def create_training_model_comparison(config,trainindex=0,num_shuffles=1,net_type
             for idx_aug,aug in enumerate(augmenter_types):
                 get_max_shuffle_idx=(largestshuffleindex+idx_aug+idx_net*len(augmenter_types)+shuffle*len(augmenter_types)*len(net_types))+1 #get shuffle index; starts ith 0 so added 1
                 log_info = str("Shuffle index:" + str(get_max_shuffle_idx) + ", net_type:"+net +", augmenter_type:"+aug + ", trainsetindex:" +str(trainindex))
-                create_training_dataset(config,Shuffles=[get_max_shuffle_idx],net_type=net,trainIndexes=trainIndexes,testIndexes=testIndexes,augmenter_type=aug,userfeedback=userfeedback,windows2linux=windows2linux)
+                create_training_dataset(config,Shuffles=[get_max_shuffle_idx],net_type=net,trainIndexes=[trainIndexes],testIndexes=[testIndexes],augmenter_type=aug,userfeedback=userfeedback,windows2linux=windows2linux)
                 logger.info(log_info)

--- a/deeplabcut/gui/analyze_videos.py
+++ b/deeplabcut/gui/analyze_videos.py
@@ -27,6 +27,7 @@ class Analyze_videos(wx.Panel):
         self.filelist = []
         self.bodyparts = []
         self.config = cfg
+        self.cfg = auxiliaryfunctions.read_config(self.config)
         self.draw = False
         # design the panel
         self.sizer = wx.GridBagSizer(5, 10)
@@ -108,25 +109,6 @@ class Analyze_videos(wx.Panel):
         self.csv = wx.RadioBox(self, label='Want to save result(s) as csv?', choices=['Yes', 'No'],majorDimension=1, style=wx.RA_SPECIFY_COLS)
         self.csv.SetSelection(1)
 
-        self.cropping = wx.RadioBox(self, label='Want to crop the videos?', choices=['Yes', 'No'],majorDimension=1, style=wx.RA_SPECIFY_COLS)
-        self.cropping.Bind(wx.EVT_RADIOBOX, self.input_crop_coords)
-        self.cropping.SetSelection(1)
-        self.crop_text = wx.StaticBox(self, label='Crop coordinates')
-        self.crop_sizer = wx.StaticBoxSizer(self.crop_text, wx.VERTICAL)
-        self.crop_widgets = []
-        for coord in 'x1', 'x2', 'y1', 'y2':
-            temp_sizer = wx.BoxSizer(wx.HORIZONTAL)
-            label = wx.StaticText(self, label=coord)
-            text = wx.TextCtrl(self)
-            self.crop_widgets.append([label, text])
-            temp_sizer.Add(label, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)
-            temp_sizer.Add(text, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)
-            self.crop_sizer.Add(temp_sizer)
-        self.crop_sizer.ShowItems(False)
-        hbox = wx.BoxSizer(wx.HORIZONTAL)
-        hbox.Add(self.cropping, 10, wx.EXPAND|wx.TOP|wx.BOTTOM, 5)
-        hbox.Add(self.crop_sizer, 10, wx.EXPAND|wx.TOP|wx.BOTTOM, 5)
-
         self.dynamic = wx.RadioBox(self, label='Want to dynamically crop bodyparts?', choices=['Yes', 'No'],majorDimension=1, style=wx.RA_SPECIFY_COLS)
         self.dynamic.SetSelection(1)
 
@@ -166,7 +148,6 @@ class Analyze_videos(wx.Panel):
         hbox2.Add(self.trajectory_to_plot,10, wx.EXPAND|wx.TOP|wx.BOTTOM, 5)
         boxsizer.Add(hbox2,0, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)
 
-        hbox3.Add(hbox, 10, wx.EXPAND|wx.TOP|wx.BOTTOM, 5)
         hbox3.Add(self.dynamic,10, wx.EXPAND|wx.TOP|wx.BOTTOM, 5)
         hbox3.Add(self.create_labeled_videos,10, wx.EXPAND|wx.TOP|wx.BOTTOM, 5)
         boxsizer.Add(hbox3,0, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)
@@ -257,10 +238,10 @@ class Analyze_videos(wx.Panel):
         else:
             save_as_csv = False
 
-        if self.cropping.GetStringSelection() == "No":
-            crop = None
+        if self.cfg['cropping']:
+            crop = self.cfg['x1'], self.cfg['x2'], self.cfg['y1'], self.cfg['y2']
         else:
-            crop = [int(text.GetValue()) for _, text in self.crop_widgets]
+            crop = None
 
         if self.dynamic.GetStringSelection() == "No":
             dynamic = (False, .5, 10)
@@ -306,10 +287,6 @@ class Analyze_videos(wx.Panel):
         self.csv.SetSelection(1)
         self.filter.SetSelection(1)
         self.trajectory.SetSelection(1)
-        self.cropping.SetSelection(1)
-        for _, text in self.crop_widgets:
-            text.SetValue('')
-        self.crop_sizer.ShowItems(False)
         self.dynamic.SetSelection(1)
         self.create_labeled_videos.SetSelection(1)
         self.sel_destfolder.SetPath("None")
@@ -328,14 +305,6 @@ class Analyze_videos(wx.Panel):
         if self.trajectory.GetStringSelection() == 'No':
             self.trajectory_to_plot.Hide()
             self.bodyparts = []
-        self.SetSizer(self.sizer)
-        self.sizer.Fit(self)
-
-    def input_crop_coords(self, event):
-        if self.cropping.GetStringSelection() == "No":
-            self.crop_sizer.ShowItems(False)
-        elif self.cropping.GetStringSelection() == "Yes":
-            self.crop_sizer.ShowItems(True)
         self.SetSizer(self.sizer)
         self.sizer.Fit(self)
 

--- a/deeplabcut/gui/analyze_videos.py
+++ b/deeplabcut/gui/analyze_videos.py
@@ -109,7 +109,23 @@ class Analyze_videos(wx.Panel):
         self.csv.SetSelection(1)
 
         self.cropping = wx.RadioBox(self, label='Want to crop the videos?', choices=['Yes', 'No'],majorDimension=1, style=wx.RA_SPECIFY_COLS)
+        self.cropping.Bind(wx.EVT_RADIOBOX, self.input_crop_coords)
         self.cropping.SetSelection(1)
+        self.crop_text = wx.StaticBox(self, label='Crop coordinates')
+        self.crop_sizer = wx.StaticBoxSizer(self.crop_text, wx.VERTICAL)
+        self.crop_widgets = []
+        for coord in 'x1', 'x2', 'y1', 'y2':
+            temp_sizer = wx.BoxSizer(wx.HORIZONTAL)
+            label = wx.StaticText(self, label=coord)
+            text = wx.TextCtrl(self)
+            self.crop_widgets.append([label, text])
+            temp_sizer.Add(label, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)
+            temp_sizer.Add(text, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)
+            self.crop_sizer.Add(temp_sizer)
+        self.crop_sizer.ShowItems(False)
+        hbox = wx.BoxSizer(wx.HORIZONTAL)
+        hbox.Add(self.cropping, 10, wx.EXPAND|wx.TOP|wx.BOTTOM, 5)
+        hbox.Add(self.crop_sizer, 10, wx.EXPAND|wx.TOP|wx.BOTTOM, 5)
 
         self.dynamic = wx.RadioBox(self, label='Want to dynamically crop bodyparts?', choices=['Yes', 'No'],majorDimension=1, style=wx.RA_SPECIFY_COLS)
         self.dynamic.SetSelection(1)
@@ -150,7 +166,7 @@ class Analyze_videos(wx.Panel):
         hbox2.Add(self.trajectory_to_plot,10, wx.EXPAND|wx.TOP|wx.BOTTOM, 5)
         boxsizer.Add(hbox2,0, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)
 
-        hbox3.Add(self.cropping,10, wx.EXPAND|wx.TOP|wx.BOTTOM, 5)
+        hbox3.Add(hbox, 10, wx.EXPAND|wx.TOP|wx.BOTTOM, 5)
         hbox3.Add(self.dynamic,10, wx.EXPAND|wx.TOP|wx.BOTTOM, 5)
         hbox3.Add(self.create_labeled_videos,10, wx.EXPAND|wx.TOP|wx.BOTTOM, 5)
         boxsizer.Add(hbox3,0, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)
@@ -159,8 +175,6 @@ class Analyze_videos(wx.Panel):
         hbox4.Add(trail_pointsboxsizer,10, wx.EXPAND|wx.TOP|wx.BOTTOM, 5)
         boxsizer.Add(hbox4,0, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)
         self.sizer.Add(boxsizer, pos=(4, 0), span=(1, 10),flag=wx.EXPAND|wx.TOP|wx.LEFT|wx.RIGHT , border=10)
-
-
 
         self.help_button = wx.Button(self, label='Help')
         self.sizer.Add(self.help_button, pos=(5, 0), flag=wx.LEFT, border=10)
@@ -244,9 +258,9 @@ class Analyze_videos(wx.Panel):
             save_as_csv = False
 
         if self.cropping.GetStringSelection() == "No":
-            cropping = None
+            crop = None
         else:
-            cropping = True
+            crop = [int(text.GetValue()) for _, text in self.crop_widgets]
 
         if self.dynamic.GetStringSelection() == "No":
             dynamic = (False, .5, 10)
@@ -264,7 +278,9 @@ class Analyze_videos(wx.Panel):
         #     self.draw = True
 
 #        print(self.config,self.filelist,self.videotype.GetValue(),shuffle,trainingsetindex,gputouse=None,save_as_csv=save_as_csv,destfolder=self.destfolder,cropping=cropping)
-        deeplabcut.analyze_videos(self.config,self.filelist,videotype=self.videotype.GetValue(),shuffle=shuffle,trainingsetindex=trainingsetindex,gputouse=None,save_as_csv=save_as_csv,destfolder=self.destfolder,cropping=cropping, dynamic=dynamic)
+        deeplabcut.analyze_videos(self.config, self.filelist, videotype=self.videotype.GetValue(), shuffle=shuffle,
+                                  trainingsetindex=trainingsetindex, gputouse=None, save_as_csv=save_as_csv,
+                                  destfolder=self.destfolder, crop=crop, dynamic=dynamic)
         if self.filter.GetStringSelection() == "Yes":
             deeplabcut.filterpredictions(self.config, self.filelist, videotype=self.videotype.GetValue(), shuffle=shuffle, trainingsetindex=trainingsetindex, filtertype='median', windowlength=5, p_bound=0.001, ARdegree=3, MAdegree=1, alpha=0.01, save_as_csv=True, destfolder=self.destfolder)
 
@@ -291,6 +307,9 @@ class Analyze_videos(wx.Panel):
         self.filter.SetSelection(1)
         self.trajectory.SetSelection(1)
         self.cropping.SetSelection(1)
+        for _, text in self.crop_widgets:
+            text.SetValue('')
+        self.crop_sizer.ShowItems(False)
         self.dynamic.SetSelection(1)
         self.create_labeled_videos.SetSelection(1)
         self.sel_destfolder.SetPath("None")
@@ -306,13 +325,19 @@ class Analyze_videos(wx.Panel):
         if self.trajectory.GetStringSelection() == 'Yes':
             self.trajectory_to_plot.Show()
             self.getbp(event)
-            self.SetSizer(self.sizer)
-            self.sizer.Fit(self) #this sets location.
         if self.trajectory.GetStringSelection() == 'No':
             self.trajectory_to_plot.Hide()
-            self.SetSizer(self.sizer)
-            self.sizer.Fit(self)
             self.bodyparts = []
+        self.SetSizer(self.sizer)
+        self.sizer.Fit(self)
+
+    def input_crop_coords(self, event):
+        if self.cropping.GetStringSelection() == "No":
+            self.crop_sizer.ShowItems(False)
+        elif self.cropping.GetStringSelection() == "Yes":
+            self.crop_sizer.ShowItems(True)
+        self.SetSizer(self.sizer)
+        self.sizer.Fit(self)
 
     def getbp(self,event):
         self.bodyparts = list(self.trajectory_to_plot.GetCheckedStrings())

--- a/deeplabcut/pose_estimation_3d/triangulation.py
+++ b/deeplabcut/pose_estimation_3d/triangulation.py
@@ -185,7 +185,9 @@ def triangulate(config,video_path,videotype='avi',filterpredictions=True,
                         scorer_name[cam_names[j]] = DLCscorer
                     else:
                         # Analyze video if score name is different
-                        DLCscorer = predict_videos.analyze_videos(config_2d,[video],videotype=videotype,shuffle=shuffle,trainingsetindex=trainingsetindex,gputouse=gputouse,destfolder=destfolder)
+                        DLCscorer = predict_videos.analyze_videos(config_2d, [video], videotype=videotype,
+                                                                  shuffle=shuffle, trainingsetindex=trainingsetindex,
+                                                                  gputouse=gputouse, destfolder=destfolder)
                         scorer_name[cam_names[j]] = DLCscorer
                         if_video_analyzed=False
                         run_triangulate = True
@@ -195,7 +197,9 @@ def triangulate(config,video_path,videotype='avi',filterpredictions=True,
                         dataname.append(os.path.join(destfolder,vname + DLCscorer + '.h5'))
 
                 else: # need to do the whole jam.
-                    DLCscorer = predict_videos.analyze_videos(config_2d,[video],videotype=videotype,shuffle=shuffle,trainingsetindex=trainingsetindex,gputouse=gputouse,destfolder=destfolder)
+                    DLCscorer = predict_videos.analyze_videos(config_2d, [video], videotype=videotype, shuffle=shuffle,
+                                                              trainingsetindex=trainingsetindex, gputouse=gputouse,
+                                                              destfolder=destfolder)
                     scorer_name[cam_names[j]] = DLCscorer
                     run_triangulate = True
                     print(destfolder, vname , DLCscorer)

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -32,13 +32,11 @@ from skimage.util import img_as_ubyte
 # Loading data, and defining model folder
 ####################################################
 
-def analyze_videos(config,videos, videotype='avi', shuffle=1, trainingsetindex=0,
-                    gputouse=None, save_as_csv=False, destfolder=None, batchsize=None,
-                    cropping=None,get_nframesfrommetadata=True, TFGPUinference=True,dynamic=(False,.5,10)):
+def analyze_videos(config, videos, videotype='avi', shuffle=1, trainingsetindex=0, gputouse=None, save_as_csv=False,
+                   destfolder=None, batchsize=None, crop=None, get_nframesfrommetadata=True, TFGPUinference=True,
+                   dynamic=(False, .5, 10)):
     """
     Makes prediction based on a trained network. The index of the trained network is specified by parameters in the config file (in particular the variable 'snapshotindex')
-
-    You can crop the video (before analysis), by changing 'cropping'=True and setting 'x1','x2','y1','y2' in the config file. The same cropping parameters will then be used for creating the video.
 
     Output: The labels are stored as MultiIndex Pandas Array, which contains the name of the network, body part name, (x, y) label position \n
             in pixels, and the likelihood for each frame per body part. These arrays are stored in an efficient Hierarchical Data Format (HDF) \n
@@ -75,6 +73,12 @@ def analyze_videos(config,videos, videotype='avi', shuffle=1, trainingsetindex=0
     batchsize: int, default from pose_cfg.yaml
         Change batch size for inference; if given overwrites value in pose_cfg.yaml
 
+    crop: list, optional (default=None)
+        List of cropping coordinates as [x1, x2, y1, y2].
+        Note that the same cropping parameters will then be used for all videos.
+        If different video crops are desired, run 'analyze_videos' on individual videos
+        with the corresponding cropping coordinates.
+
     TFGPUinference: bool, default: True
         Perform inference on GPU with Tensorflow code. Introduced in "Pretraining boosts out-of-domain robustness for pose estimation" by
         Alexander Mathis, Mert Yüksekgönül, Byron Rogers, Matthias Bethge, Mackenzie W. Mathis Source: https://arxiv.org/abs/1909.11229
@@ -106,11 +110,11 @@ def analyze_videos(config,videos, videotype='avi', shuffle=1, trainingsetindex=0
     --------
 
     If you want to analyze multiple videos with shuffle = 2
-    >>> deeplabcut.analyze_videos('/analysis/project/reaching-task/config.yaml',['/analysis/project/videos/reachingvideo1.avi','/analysis/project/videos/reachingvideo2.avi'], shuffle=2)
+    >>> deeplabcut.analyze_videos('/analysis/project/reaching-task/config.yaml',['/analysis/project/videos/reachingvideo1.avi','/analysis/project/videos/reachingvideo2.avi'],shuffle=2)
 
     --------
     If you want to analyze multiple videos with shuffle = 2 and save results as an additional csv file too
-    >>> deeplabcut.analyze_videos('/analysis/project/reaching-task/config.yaml',['/analysis/project/videos/reachingvideo1.avi','/analysis/project/videos/reachingvideo2.avi'], shuffle=2,save_as_csv=True)
+    >>> deeplabcut.analyze_videos('/analysis/project/reaching-task/config.yaml',['/analysis/project/videos/reachingvideo1.avi','/analysis/project/videos/reachingvideo2.avi'],shuffle=2,save_as_csv=True)
     --------
 
     """
@@ -126,10 +130,10 @@ def analyze_videos(config,videos, videotype='avi', shuffle=1, trainingsetindex=0
     cfg = auxiliaryfunctions.read_config(config)
     trainFraction = cfg['TrainingFraction'][trainingsetindex]
 
-    if cropping is not None:
+    if crop is not None:
         cfg['cropping']=True
-        cfg['x1'],cfg['x2'],cfg['y1'],cfg['y2']=cropping
-        print("Overwriting cropping parameters:", cropping)
+        cfg['x1'],cfg['x2'],cfg['y1'],cfg['y2']=crop
+        print("Overwriting cropping parameters:", crop)
         print("These are used for all videos, but won't be save to the cfg file.")
 
     modelfolder=os.path.join(cfg["project_path"],str(auxiliaryfunctions.GetModelFolder(trainFraction,shuffle,cfg)))
@@ -655,7 +659,7 @@ def analyze_time_lapse_frames(config,directory,frametype='.png',shuffle=1,
     --------
 
     If you want to analyze all frames in /analysis/project/timelapseexperiment1
-    >>> deeplabcut.analyze_videos('/analysis/project/reaching-task/config.yaml','/analysis/project/timelapseexperiment1', frametype='.bmp')
+    >>> deeplabcut.analyze_videos('/analysis/project/reaching-task/config.yaml','/analysis/project/timelapseexperiment1')
     --------
 
     Note: for test purposes one can extract all frames from a video with ffmeg, e.g. ffmpeg -i testvideo.avi thumb%04d.png

--- a/examples/testscript.py
+++ b/examples/testscript.py
@@ -111,11 +111,10 @@ except: # if ffmpeg is broken
     newclip = VideoClip(make_frame, duration=1)
     newclip.write_videofile(newvideo,fps=30)
 
-
-deeplabcut.analyze_videos(path_config_file,[newvideo],save_as_csv=True, destfolder=dfolder, dynamic=(True,.1,5))
+deeplabcut.analyze_videos(path_config_file, [newvideo], save_as_csv=True, destfolder=dfolder, dynamic=(True, .1, 5))
 
 print("analyze again...")
-deeplabcut.analyze_videos(path_config_file,[newvideo],save_as_csv=True, destfolder=dfolder)
+deeplabcut.analyze_videos(path_config_file, [newvideo], save_as_csv=True, destfolder=dfolder)
 
 print("CREATE VIDEO")
 deeplabcut.create_labeled_video(path_config_file,[newvideo], destfolder=dfolder,save_frames=True)
@@ -173,7 +172,7 @@ except: # if ffmpeg is broken
 
 
 print("Inference with direct cropping")
-deeplabcut.analyze_videos(path_config_file,[newvideo2],destfolder=dfolder,cropping=[0,50,0,50],save_as_csv=True)
+deeplabcut.analyze_videos(path_config_file, [newvideo2], save_as_csv=True, destfolder=dfolder, crop=[0, 50, 0, 50])
 
 print("Extracting skeleton distances, filter and plot filtered output")
 deeplabcut.analyzeskeleton(path_config_file, [newvideo], save_as_csv=True, destfolder=dfolder)

--- a/examples/testscript_mobilenets.py
+++ b/examples/testscript_mobilenets.py
@@ -106,7 +106,7 @@ for shuffle,net_type in enumerate(['mobilenet_v2_0.35','resnet_50']): #'mobilene
         # Make super short video (so the analysis is quick!)
         newvideo=deeplabcut.ShortenVideo(video[0],start='00:00:00',stop='00:00:00.4',outsuffix='short',outpath=os.path.join(cfg['project_path'],'videos'))
         vname=Path(newvideo).stem
-    deeplabcut.analyze_videos(path_config_file,[newvideo],shuffle=shuffle,save_as_csv=True, destfolder=dfolder)
+    deeplabcut.analyze_videos(path_config_file, [newvideo], shuffle=shuffle, save_as_csv=True, destfolder=dfolder)
 
     print("CREATE VIDEO")
     deeplabcut.create_labeled_video(path_config_file,[newvideo],shuffle=shuffle, destfolder=dfolder)

--- a/examples/testscript_openfielddata_augmentationcomparison.py
+++ b/examples/testscript_openfielddata_augmentationcomparison.py
@@ -59,8 +59,6 @@ path_config_file = os.path.join(os.getcwd(),'openfield-Pranav-2018-10-30/config.
 cfg=deeplabcut.auxiliaryfunctions.read_config(path_config_file)
 
 
-
-
 deeplabcut.load_demo_data(path_config_file)
 
 ##create one split and make Shuffle 2 and 3 have the same split.
@@ -91,7 +89,7 @@ for shuffle in [2,3]:
 
 	videofile_path = os.path.join(os.getcwd(),'openfield-Pranav-2018-10-30','videos','m3v1mp4.mp4')
 
-    deeplabcut.analyze_videos(path_config_file, [videofile_path], shuffle=shuffle)
+	deeplabcut.analyze_videos(path_config_file, [videofile_path], shuffle=shuffle)
 
 	print("Create Labeled Video and plot")
 	deeplabcut.create_labeled_video(path_config_file,[videofile_path], shuffle=shuffle)

--- a/examples/testscript_openfielddata_augmentationcomparison.py
+++ b/examples/testscript_openfielddata_augmentationcomparison.py
@@ -91,7 +91,7 @@ for shuffle in [2,3]:
 
 	videofile_path = os.path.join(os.getcwd(),'openfield-Pranav-2018-10-30','videos','m3v1mp4.mp4')
 
-	deeplabcut.analyze_videos(path_config_file,[videofile_path], shuffle=shuffle)
+    deeplabcut.analyze_videos(path_config_file, [videofile_path], shuffle=shuffle)
 
 	print("Create Labeled Video and plot")
 	deeplabcut.create_labeled_video(path_config_file,[videofile_path], shuffle=shuffle)


### PR DESCRIPTION
The GUI was passing True/False rather than a list of coordinates to 'cropping' in analyze_videos.
#560 is now fixed, and the documentation has been slightly improved to avoid confusion ('cropping' has also been renamed to 'crop', consistent with all other functions expecting a list rather than a boolean).