### PR TITLE
fixed GUI copy vids not copying

### DIFF
--- a/deeplabcut/create_project/new.py
+++ b/deeplabcut/create_project/new.py
@@ -115,7 +115,7 @@ def create_new_project(project, experimenter, videos, working_directory=None, co
         p.mkdir(parents = True, exist_ok = True)
 
     destinations = [video_path.joinpath(vp.name) for vp in videos]
-    if copy_videos==True:
+    if copy_videos==True or copy_videos=="Yes":
         print("Copying the videos")
         for src, dst in zip(videos, destinations):
             shutil.copy(os.fspath(src),os.fspath(dst)) #https://www.python.org/dev/peps/pep-0519/
@@ -140,7 +140,7 @@ def create_new_project(project, experimenter, videos, working_directory=None, co
             print('Created the symlink of {} to {}'.format(src, dst))
             videos = destinations
 
-    if copy_videos==True:
+    if copy_videos==True or copy_videos=="Yes":
         videos=destinations # in this case the *new* location should be added to the config file
 
     # adds the video list to the config.yaml file

--- a/deeplabcut/gui/create_new_project.py
+++ b/deeplabcut/gui/create_new_project.py
@@ -101,8 +101,10 @@ class Create_new_project(wx.Panel):
         self.copy_choice.Bind(wx.EVT_CHECKBOX,self.activate_copy_videos)
         hbox3.Add(self.copy_choice)
         hbox3.AddSpacer(155)
-        self.yes = wx.RadioButton( self, -1, "No", style = wx.RB_GROUP)
-        self.no = wx.RadioButton( self, -1, "Yes")
+        self.yes = wx.RadioButton( self, -1, "Yes", style = wx.RB_GROUP)
+        self.no = wx.RadioButton( self, -1, "No")
+        self.yes.Bind(wx.EVT_RADIOBUTTON, self.select_copy_videos)
+        self.no.Bind(wx.EVT_RADIOBUTTON, self.select_copy_videos)
         self.yes.Enable(False)
         self.no.Enable(False)
         hbox3.Add(self.yes, 0, wx.ALL, -1)
@@ -227,7 +229,7 @@ class Create_new_project(wx.Panel):
         """
         self.change_copy = event.GetEventObject()
         if self.change_copy.GetValue() == True:
-            self.yes.Enable(False)
+            self.yes.Enable(True)
             self.no.Enable(True)
         else:
             self.yes.Enable(False)


### PR DESCRIPTION
Fixes issue  #580 

GUI copy videos radio buttons were not bound to the function that set self.copy, and when bound it was passing the radio button label ("Yes", "No") rather than True/False.

The GUI checkbox was also not Enabling/Disabling the radio buttons completely. 

This pull request fixes the binding and enabling, and changes the booleans in new.py to also accept "Yes" and "No". 