### PR TITLE
ignore example content to avoid versioning noise (good catch by Evan!)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# examples
+/examples


### PR DESCRIPTION
running the examples generates various files in the repo, which then
shows up in versioning as dirty state. ignoring these by default makes
development a little simpler.

to add new example content, do `git add -f` to override the ignore
setting.