### PR TITLE
Shuffle 0 patch1

### DIFF
--- a/deeplabcut/gui/analyze_videos.py
+++ b/deeplabcut/gui/analyze_videos.py
@@ -82,7 +82,7 @@ class Analyze_videos(wx.Panel):
 
         shuffle_text = wx.StaticBox(self, label="Specify the shuffle")
         shuffle_boxsizer = wx.StaticBoxSizer(shuffle_text, wx.VERTICAL)
-        self.shuffle = wx.SpinCtrl(self, value='1',min=1,max=100)
+        self.shuffle = wx.SpinCtrl(self, value='1',min=0,max=100)
         shuffle_boxsizer.Add(self.shuffle,1, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)
 
         trainingset = wx.StaticBox(self, label="Specify the trainingset index")

--- a/deeplabcut/gui/create_training_dataset.py
+++ b/deeplabcut/gui/create_training_dataset.py
@@ -78,7 +78,7 @@ class Create_training_dataset(wx.Panel):
 
         shuffle_text = wx.StaticBox(self, label="Or set a specific shuffle indx (1 network only)")
         shuffle_text_boxsizer = wx.StaticBoxSizer(shuffle_text, wx.VERTICAL)
-        self.shuffle = wx.SpinCtrl(self, value='1',min=0,max=100)
+        self.shuffle = wx.SpinCtrl(self, value='1',min=1,max=100)
         shuffle_text_boxsizer.Add(self.shuffle,1, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)
 
         trainingindex_box = wx.StaticBox(self, label="Specify the trainingset index")

--- a/deeplabcut/gui/create_training_dataset.py
+++ b/deeplabcut/gui/create_training_dataset.py
@@ -78,7 +78,7 @@ class Create_training_dataset(wx.Panel):
 
         shuffle_text = wx.StaticBox(self, label="Or set a specific shuffle indx (1 network only)")
         shuffle_text_boxsizer = wx.StaticBoxSizer(shuffle_text, wx.VERTICAL)
-        self.shuffle = wx.SpinCtrl(self, value='1',min=1,max=100)
+        self.shuffle = wx.SpinCtrl(self, value='1',min=0,max=100)
         shuffle_text_boxsizer.Add(self.shuffle,1, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)
 
         trainingindex_box = wx.StaticBox(self, label="Specify the trainingset index")

--- a/deeplabcut/gui/create_training_dataset.py
+++ b/deeplabcut/gui/create_training_dataset.py
@@ -78,7 +78,7 @@ class Create_training_dataset(wx.Panel):
 
         shuffle_text = wx.StaticBox(self, label="Or set a specific shuffle indx (1 network only)")
         shuffle_text_boxsizer = wx.StaticBoxSizer(shuffle_text, wx.VERTICAL)
-        self.shuffle = wx.SpinCtrl(self, value='None',min=1,max=100)
+        self.shuffle = wx.SpinCtrl(self, value='1',min=1,max=100)
         shuffle_text_boxsizer.Add(self.shuffle,1, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)
 
         trainingindex_box = wx.StaticBox(self, label="Specify the trainingset index")

--- a/deeplabcut/gui/create_videos.py
+++ b/deeplabcut/gui/create_videos.py
@@ -79,7 +79,7 @@ class Create_Labeled_Videos(wx.Panel):
 
         shuffle_text = wx.StaticBox(self, label="Specify the shuffle")
         shuffle_boxsizer = wx.StaticBoxSizer(shuffle_text, wx.VERTICAL)
-        self.shuffle = wx.SpinCtrl(self, value='1',min=1,max=100)
+        self.shuffle = wx.SpinCtrl(self, value='1',min=0,max=100)
         shuffle_boxsizer.Add(self.shuffle,1, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)
 
         trainingset = wx.StaticBox(self, label="Specify the trainingset index")

--- a/deeplabcut/gui/evaluate_network.py
+++ b/deeplabcut/gui/evaluate_network.py
@@ -60,7 +60,7 @@ class Evaluate_network(wx.Panel):
 
         shuffles_text = wx.StaticBox(self, label="Specify the shuffle")
         shuffles_text_boxsizer = wx.StaticBoxSizer(shuffles_text, wx.VERTICAL)
-        self.shuffles = wx.SpinCtrl(self, value='1',min=1,max=100)
+        self.shuffles = wx.SpinCtrl(self, value='1',min=0,max=100)
         shuffles_text_boxsizer.Add(self.shuffles,1, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)
 
         trainingset = wx.StaticBox(self, label="Specify the trainingset index")

--- a/deeplabcut/gui/extract_frames.py
+++ b/deeplabcut/gui/extract_frames.py
@@ -85,7 +85,7 @@ class Extract_frames(wx.Panel):
         self.cluster_step = wx.SpinCtrl(self, value='1')
         cluster_stepboxsizer.Add(self.cluster_step,20, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)
 
-        slider_width_text = wx.StaticBox(self, label="Specify the slider width")
+        slider_width_text = wx.StaticBox(self, label="Specify the GUI slider width")
         slider_widthboxsizer = wx.StaticBoxSizer(slider_width_text, wx.VERTICAL)
         self.slider_width = wx.SpinCtrl(self, value='25')
         slider_widthboxsizer.Add(self.slider_width,20, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)

--- a/deeplabcut/gui/extract_outlier_frames.py
+++ b/deeplabcut/gui/extract_outlier_frames.py
@@ -72,7 +72,7 @@ class Extract_outlier_frames(wx.Panel):
 
         shuffles_text = wx.StaticBox(self, label="Specify the shuffle")
         shuffles_text_boxsizer = wx.StaticBoxSizer(shuffles_text, wx.VERTICAL)
-        self.shuffles = wx.SpinCtrl(self, value='1',min=1,max=100)
+        self.shuffles = wx.SpinCtrl(self, value='1',min=0,max=100)
         shuffles_text_boxsizer.Add(self.shuffles,1, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)
 
         trainingindex = wx.StaticBox(self, label="Specify the trainingset index")

--- a/deeplabcut/gui/train_network.py
+++ b/deeplabcut/gui/train_network.py
@@ -71,7 +71,7 @@ class Train_network(wx.Panel):
 
         shuffles_text = wx.StaticBox(self, label="Specify the shuffle")
         shuffles_text_boxsizer = wx.StaticBoxSizer(shuffles_text, wx.VERTICAL)
-        self.shuffles = wx.SpinCtrl(self, value='1',min=1,max=100)
+        self.shuffles = wx.SpinCtrl(self, value='1',min=0,max=100)
         shuffles_text_boxsizer.Add(self.shuffles,1, wx.EXPAND|wx.TOP|wx.BOTTOM, 10)
 
         trainingindex = wx.StaticBox(self, label="Specify the trainingset index")
@@ -258,7 +258,7 @@ class Train_network(wx.Panel):
             maxiters = int(self.max_iters.Children[0].GetValue())
         else:
             maxiters = int(self.max_iters.GetValue())
-            
+
         deeplabcut.train_network(self.config,shuffle,
                                  trainingsetindex,gputouse=None,
                                  max_snapshots_to_keep=max_snapshots_to_keep,


### PR DESCRIPTION
fix for #646 - if shuffle 0 was used to create training set, allow for 0 to be used in subsequent GUI options. 