### PR TITLE
Update Demo_labeledexample_Openfield.ipynb

### DIFF
--- a/examples/Demo_labeledexample_Openfield.ipynb
+++ b/examples/Demo_labeledexample_Openfield.ipynb
@@ -515,7 +515,7 @@
    "source": [
     "## Manually correct labels\n",
     "\n",
-    "This step allows the user to correct the labels in the extracted frames. Navigate to the folder corresponding to the video 'MovieS2_Perturbation_noLaser_compressed' and use the GUI as described in the protocol to update the labels."
+    "This step allows the user to correct the labels in the extracted frames. Navigate to the folder corresponding to the video 'm3v1mp4' and use the GUI as described in the protocol to update the labels."
    ]
   },
   {


### PR DESCRIPTION
A minor PR -- the name of file in the open field demo is of movie from the reaching task rather than the open field task. It is in markdown of an ipynb file, not code, so there would be no functional repercussions. 