### PR TITLE
wxPython Black Box Glitch

### DIFF
--- a/deeplabcut/gui/create_new_project.py
+++ b/deeplabcut/gui/create_new_project.py
@@ -30,7 +30,6 @@ media_path = os.path.join(deeplabcut.__path__[0], 'gui' , 'media')
 logo = os.path.join(media_path,'logo.png')
 class Create_new_project(wx.Panel):
     def __init__(self, parent,gui_size):
-        wx.Panel.__init__(self, parent)
         self.gui_size = gui_size
         self.parent = parent
         h=gui_size[0]

--- a/deeplabcut/gui/welcome.py
+++ b/deeplabcut/gui/welcome.py
@@ -20,7 +20,6 @@ dlc = os.path.join(media_path,'dlc_1-01.png')
 class Welcome(wx.Panel):
 
     def __init__(self, parent,gui_size):
-        wx.Panel.__init__(self, parent)
         h=gui_size[0]
         w=gui_size[1]
         wx.Panel.__init__(self, parent, -1,style=wx.SUNKEN_BORDER,size=(h,w))


### PR DESCRIPTION
**wxPython Black Box Glitch on Windows 10**

After starting DLC GUI on windows 10, a black box appears on the upper left side of the main frame :

![blackboxglitch](https://user-images.githubusercontent.com/45032503/81514457-86a61a00-932f-11ea-8530-1bacf5c2bd15.PNG)

And that's because of initializing the `welcome` panel, `create new project` panels twice per panel:
`create_new_project`:
https://github.com/AlexEMG/DeepLabCut/blob/413ae5e2c410fb9da3da26c333b6a9b87ab6c38f/deeplabcut/gui/create_new_project.py#L33
https://github.com/AlexEMG/DeepLabCut/blob/413ae5e2c410fb9da3da26c333b6a9b87ab6c38f/deeplabcut/gui/create_new_project.py#L38
`welcome`:
https://github.com/AlexEMG/DeepLabCut/blob/413ae5e2c410fb9da3da26c333b6a9b87ab6c38f/deeplabcut/gui/welcome.py#L23
https://github.com/AlexEMG/DeepLabCut/blob/413ae5e2c410fb9da3da26c333b6a9b87ab6c38f/deeplabcut/gui/welcome.py#L26

Removing line 33 from `create_new_project` and line 23 from `welcome` fix the problem !


Cheers!