### PR TITLE
Platform independent training set creation for autocropped DLC2.2b5

### DIFF
--- a/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
@@ -96,15 +96,12 @@ def create_multianimaltraining_dataset(
     scorer = cfg["scorer"]
     project_path = cfg["project_path"]
     # Create path for training sets & store data there
-    trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(
-        cfg
-    )  # Path concatenatn OS platform independent
-    auxiliaryfunctions.attempttomakefolder(
-        Path(os.path.join(project_path, str(trainingsetfolder))), recursive=True
-    )
+    trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(cfg)
+    full_training_path = Path(project_path, trainingsetfolder)
+    auxiliaryfunctions.attempttomakefolder(full_training_path, recursive=True)
 
     Data = trainingsetmanipulation.merge_annotateddatasets(
-        cfg, Path(os.path.join(project_path, trainingsetfolder)), windows2linux
+        cfg, full_training_path, windows2linux
     )
     if Data is None:
         return

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -581,24 +581,24 @@ def _robust_path_split(path):
 def merge_annotateddatasets(cfg, trainingsetfolder_full, windows2linux):
     """
     Merges all the h5 files for all labeled-datasets (from individual videos).
-    This is a bit of a mess because of cross platform compatablity.
+    This is a bit of a mess because of cross platform compatibility.
 
     Within platform comp. is straightforward. But if someone labels on windows and wants to train on a unix cluster or colab...
     """
     AnnotationData = []
     data_path = Path(os.path.join(cfg["project_path"], "labeled-data"))
     videos = cfg["video_sets"].keys()
-    video_names = [Path(i).stem for i in videos]
-    for i in video_names:
+    for video in videos:
+        _, filename, _ = _robust_path_split(video)
         if cfg.get("croppedtraining", False):
-            i += "_cropped"
-        filename = os.path.join(data_path / i, f'CollectedData_{cfg["scorer"]}.h5')
+            filename += "_cropped"
+        file_path = os.path.join(data_path / filename, f'CollectedData_{cfg["scorer"]}.h5')
         try:
-            data = pd.read_hdf(filename, "df_with_missing")
+            data = pd.read_hdf(file_path, "df_with_missing")
             AnnotationData.append(data)
         except FileNotFoundError:
             print(
-                filename,
+                file_path,
                 " not found (perhaps not annotated). If training on cropped data, "
                 "make sure to call `cropimagesandlabels` prior to creating the dataset.",
             )

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -14,6 +14,7 @@ import numpy as np
 import pandas as pd
 import os.path
 import logging
+import shutil
 from functools import lru_cache
 from skimage import io
 import yaml
@@ -333,7 +334,7 @@ def cropimagesandlabels(
                 frame = ic[i]
                 h, w = np.shape(frame)[:2]
                 if size[0] >= h or size[1] >= w:
-                    os.remove(output_path)
+                    shutil.rmtree(output_path, ignore_errors=True)
                     raise ValueError("Crop dimensions are larger than image size")
 
                 imagename = os.path.relpath(ic.files[i], cfg["project_path"])

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -339,12 +339,14 @@ def cropimagesandlabels(
                 while cropindex < numcrops:
                     dd = np.array(data[ind].copy(), dtype=float)
                     y0, x0 = (
-                        np.random.randint(h - size[0]),
-                        np.random.randint(w - size[1]),
+                        np.random.randint(max(1, h - size[0])),
+                        np.random.randint(max(1, w - size[1])),
                     )
+                    y1 = min(h, y0 + size[0])
+                    x1 = min(w, x0 + size[1])
                     with np.errstate(invalid="ignore"):
                         within = np.all(
-                            (dd >= [x0, y0]) & (dd < [x0 + size[1], y0 + size[0]]),
+                            (dd >= [x0, y0]) & (dd < [x1, y1]),
                             axis=1,
                         )
                     if cropdata:
@@ -360,7 +362,7 @@ def cropimagesandlabels(
                         )
                         cropppedimgname = os.path.join(output_path, newimname)
                         io.imsave(
-                            cropppedimgname, frame[y0 : y0 + size[0], x0 : x0 + size[1]]
+                            cropppedimgname, frame[y0 : y1, x0 : x1]
                         )
                         cropindex += 1
                         pd_index.append(
@@ -388,7 +390,7 @@ def cropimagesandlabels(
                 )
                 cfg["video_sets"][
                     os.path.join(vidpath, str(folder) + "_cropped" + str(videotype))
-                ] = {"crop": ", ".join(map(str, [0, size[1], 0, size[0]]))}
+                ] = {"crop": ", ".join(map(str, [0, x1 - x0, 0, y1 - y0]))}
 
     cfg["croppedtraining"] = True
     auxiliaryfunctions.write_config(config, cfg)

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -645,9 +645,7 @@ def merge_annotateddatasets(cfg, trainingsetfolder_full, windows2linux):
     else:
         askuser = "no"
 
-    filename = str(
-        str(trainingsetfolder_full) + "/" + "/CollectedData_" + cfg["scorer"]
-    )
+    filename = os.path.join(trainingsetfolder_full, f'CollectedData_{cfg["scorer"]}')
     if (
         windows2linux or askuser == "yes" or askuser == "y" or askuser == "Ja"
     ):  # convert windows path in pandas array \\ to unix / !

--- a/deeplabcut/gui/create_training_dataset.py
+++ b/deeplabcut/gui/create_training_dataset.py
@@ -143,8 +143,24 @@ class Create_training_dataset(wx.Panel):
                 majorDimension=1,
                 style=wx.RA_SPECIFY_COLS,
             )
+            self.cropandlabel.Bind(wx.EVT_RADIOBOX, self.input_crop_size)
             self.cropandlabel.SetSelection(0)
+            self.crop_text = wx.StaticBox(self, label='Crop settings')
+            self.crop_sizer = wx.StaticBoxSizer(self.crop_text, wx.VERTICAL)
+            self.crop_widgets = []
+            for name, val in [('# of crops', '10'),
+                              ('height', '400'),
+                              ('width', '400')]:
+                temp_sizer = wx.BoxSizer(wx.HORIZONTAL)
+                label = wx.StaticText(self, label=name)
+                text = wx.TextCtrl(self, value=val)
+                self.crop_widgets.append([label, text])
+                temp_sizer.Add(label, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
+                temp_sizer.Add(text, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
+                self.crop_sizer.Add(temp_sizer)
+            self.crop_sizer.ShowItems(True)
             self.hbox3.Add(self.cropandlabel, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
+            self.hbox3.Add(self.crop_sizer, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
 
         self.hbox2.Add(shuffle_text_boxsizer, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
         self.hbox2.Add(trainingindex_boxsizer, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
@@ -265,6 +281,13 @@ class Create_training_dataset(wx.Panel):
         self.sizer.Fit(self)
         self.Layout()
 
+    def input_crop_size(self, event):
+        if self.cropandlabel.GetStringSelection() == 'No':
+            self.crop_sizer.ShowItems(False)
+        else:
+            self.crop_sizer.ShowItems(True)
+        self.SetSizer(self.sizer)
+
     def on_focus(self, event):
         pass
 
@@ -336,7 +359,8 @@ class Create_training_dataset(wx.Panel):
 
         if config_file.get("multianimalproject", False):
             if self.cropandlabel.GetStringSelection() == "Yes":
-                deeplabcut.cropimagesandlabels(self.config, userfeedback=userfeedback)
+                n_crops, height, width = [int(text.GetValue()) for _, text in self.crop_widgets]
+                deeplabcut.cropimagesandlabels(self.config, n_crops, (height, width), userfeedback)
             else:
                 random = False
             deeplabcut.create_multianimaltraining_dataset(


### PR DESCRIPTION
Images can now be labeled locally, and training set created on another platform (e.g., in Colab).
More options are given in the GUI to define the number and size of random crops (for augmentation). If the crop dimensions exceed that of the images, an error is raised and the xxx_cropped folder is removed.
Fixes #704 