### PR TITLE
Small docstring fix

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/evaluate_multianimal.py
@@ -380,12 +380,6 @@ def evaluate_multianimal_crossvalidate(
     config: string
         Full path of the config.yaml file as a string.
 
-    videos: list
-        A list of strings containing the full paths to videos for analysis or a path to the directory, where all the videos with same extension are stored.
-
-    videotype: string, optional
-        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed. The default is ``.avi``
-
     shuffle: int, optional
         An integer specifying the shuffle index of the training dataset used for training the network. The default is 1.
 


### PR DESCRIPTION
Removed parameters related to video files (`videos` and `videotype`) from deeplabcut/pose_estimation_tensorflow/evaluate_multianimal.py 
as they are not input parameters of the function.