### PR TITLE
Deleted markers are no longer considered annotated

### DIFF
--- a/deeplabcut/generate_training_dataset/labeling_toolbox.py
+++ b/deeplabcut/generate_training_dataset/labeling_toolbox.py
@@ -309,6 +309,9 @@ class MainFrame(wx.Frame):
             )
             if msg == 2:
                 closest_dp.delete_data()
+                self.buttonCounter.remove(
+                    self.bodyparts.index(closest_dp.bodyParts)
+                )
 
     @staticmethod
     def calc_distance(x1, y1, x2, y2):


### PR DESCRIPTION
The issue occurred only with the single animal labeling toolbox.
Fixes #774.