### PR TITLE
Fix typos in multianimal tracking in UseOverviewGuide

### DIFF
--- a/docs/UseOverviewGuide.md
+++ b/docs/UseOverviewGuide.md
@@ -78,7 +78,7 @@ We highly recommend using 2.2 first in the Project Manager GUI ([Option 3](docs/
 
 ##### *What scenario do you have?*
 
-- **I have single animal videos, but I want to use DLC2.2:**
+- **I have single animal videos, but I want to use the advanced tracking features & updated network capabilities introduced (for multi-animal projects) in DLC2.2:**
    - quick start: when you `create_new_project` just set the flag `multianimal=False`.
 
 :movie_camera: [VIDEO TUTORIAL AVAILABLE!](https://youtu.be/JDsa8R5J0nQ)

--- a/docs/UseOverviewGuide.md
+++ b/docs/UseOverviewGuide.md
@@ -79,7 +79,7 @@ We highly recommend using 2.2 first in the Project Manager GUI ([Option 3](docs/
 ##### *What scenario do you have?*
 
 - **I have single animal videos, but I want to use the advanced tracking features & updated network capabilities introduced (for multi-animal projects) in DLC2.2:**
-   - quick start: when you `create_new_project` just set the flag `multianimal=False`.
+   - quick start: when you `create_new_project` just set the flag `multianimal=True`.
 
 :movie_camera: [VIDEO TUTORIAL AVAILABLE!](https://youtu.be/JDsa8R5J0nQ)
 

--- a/docs/UseOverviewGuide.md
+++ b/docs/UseOverviewGuide.md
@@ -79,18 +79,18 @@ We highly recommend using 2.2 first in the Project Manager GUI ([Option 3](docs/
 ##### *What scenario do you have?*
 
 - **I have single animal videos, but I want to use DLC2.2:**
-   - quick start: when you `create_new project` just set the flag `multianimal=True`.
+   - quick start: when you `create_new_project` just set the flag `multianimal=False`.
 
 :movie_camera: [VIDEO TUTORIAL AVAILABLE!](https://youtu.be/JDsa8R5J0nQ)
 
 
 - **I have multiple *identical-looking animals* in my videos and I need to use DLC2.2:**
-   - quick start: when you `create_new project` set the flag `multianimal=True`. If you can't tell them apart, you can assign the "individual" ID to any animal in each frame. See this [labeling w/2.2 demo video](https://www.youtube.com/watch?v=_qbEqNKApsI)
+   - quick start: when you `create_new_project` set the flag `multianimal=True`. If you can't tell them apart, you can assign the "individual" ID to any animal in each frame. See this [labeling w/2.2 demo video](https://www.youtube.com/watch?v=_qbEqNKApsI)
 
 :movie_camera: [VIDEO TUTORIAL AVAILABLE!](https://youtu.be/Kp-stcTm77g)
 
 - **I have multiple animals, *but I can tell them apart,* in my videos and want to use DLC2.2:**
-   - quick start: when you `create_new project` set the flag `multianimal=True`. And always label the "individual" ID name the same; i.e. if you have mouse1 and mouse2 but mouse2 always has a miniscope, in every frame label mouse2 consistently. See this [labeling w/2.2 demo video](https://www.youtube.com/watch?v=_qbEqNKApsI)
+   - quick start: when you `create_new_project` set the flag `multianimal=True`. And always label the "individual" ID name the same; i.e. if you have mouse1 and mouse2 but mouse2 always has a miniscope, in every frame label mouse2 consistently. See this [labeling w/2.2 demo video](https://www.youtube.com/watch?v=_qbEqNKApsI)
 
 :movie_camera: [VIDEO TUTORIAL AVAILABLE!](https://youtu.be/Kp-stcTm77g) - ALSO, if you can tell them apart, label animals them consistently!
 


### PR DESCRIPTION
Boolean flag was reversed for single animal tracking and missing underscores for the function name.

