### PR TITLE
Model Zoo & project creation prep for live use

### DIFF
--- a/deeplabcut/create_project/modelzoo.py
+++ b/deeplabcut/create_project/modelzoo.py
@@ -109,6 +109,7 @@ def create_pretrained_project(
     filtered=True,
     createlabeledvideo=True,
     trainFraction=None,
+    exportmodel: dict = {}
 ):
     """
     Creates a new project directory, sub-directories and a basic configuration file.
@@ -149,6 +150,9 @@ def create_pretrained_project(
 
     trainFraction: By default value from *new* projects. (0.95)
             Fraction that will be used in dlc-model/trainingset folder name.
+
+    exportmodel : dict
+        if None or empty, don't export model (default). If dict, kwargs passed to :func:`deeplabcut.export_model`
 
     Example
     --------
@@ -327,6 +331,12 @@ def create_pretrained_project(
                 cfg, [video_dir], videotype, draw_skeleton=True, filtered=filtered
             )
             deeplabcut.plot_trajectories(cfg, [video_dir], videotype, filtered=filtered)
+
+        if exportmodel:
+            deeplabcut.export_model(cfg, **exportmodel)
+
+
+
 
         os.chdir(cwd)
         return cfg, path_train_config

--- a/deeplabcut/create_project/new.py
+++ b/deeplabcut/create_project/new.py
@@ -173,7 +173,8 @@ def create_new_project(
             os.remove(video)  # Removing the video or link from the project
 
     if not len(video_sets):
-        warnings.warn("No valid videos were found! If this is an error, verify the video files and re-create the project!")
+        warnings.warn("No valid videos were found! If this is an error, verify the video files and re-create the project!",
+                      stacklevel=2)
 
     # Set values to config file:
     if multianimal:  # parameters specific to multianimal project

--- a/deeplabcut/create_project/new.py
+++ b/deeplabcut/create_project/new.py
@@ -79,7 +79,7 @@ def create_new_project(
     # Create project and sub-directories
     if not DEBUG and project_path.exists():
         print('Project "{}" already exists!'.format(project_path))
-        return
+        return os.path.join(str(project_path), "config.yaml")
     video_path = project_path / "videos"
     data_path = project_path / "labeled-data"
     shuffles_path = project_path / "training-datasets"

--- a/deeplabcut/create_project/new.py
+++ b/deeplabcut/create_project/new.py
@@ -11,6 +11,7 @@ Licensed under GNU Lesser General Public License v3.0
 import os
 import shutil
 from pathlib import Path
+import warnings
 
 import cv2
 
@@ -172,11 +173,7 @@ def create_new_project(
             os.remove(video)  # Removing the video or link from the project
 
     if not len(video_sets):
-        # Silently sweep the files that were already written.
-        shutil.rmtree(project_path, ignore_errors=True)
-        print("WARNING: No valid videos were found. The project was not created ...")
-        print("Verify the video files and re-create the project.")
-        return "nothingcreated"
+        warnings.warn("No valid videos were found! If this is an error, verify the video files and re-create the project!")
 
     # Set values to config file:
     if multianimal:  # parameters specific to multianimal project


### PR DESCRIPTION
a number of small changes to anticipate folks wanting to make projects from pretrained weights/model zoo but without having any video files in the project -- eg. a live case

tried to be minimally impactful and follow naming/etc conventions best i could.

* `new.create_new_project` - allow projects with no videos at time of creation - did this in such a way as to be minimally impactful to existing code -- just don't raise error rather than adding new checks/calling syntax.
* `new.create_new_project` - previously: if a project was new, function returns path to its configuration file. if a project already existed, a warning was printed and `None` was returned. changed so behavior is the same if a project already exists -- return path to config file. this keeps the modelzoo function from choking.
* modelzoo - added an `exportmodel` flag to export a model at the time of download/project/creation. can be called with a boolean or a dict, in which case passed on to `export_model` as kwargs
* modelzoo - don't redownload files if they're already there unless `force` arg is `True`
