### PR TITLE
windows2unixstyle: handle case where .h5 file is missing

### DIFF
--- a/deeplabcut/utils/conversioncode.py
+++ b/deeplabcut/utils/conversioncode.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pandas as pd
 
 from deeplabcut.utils import auxiliaryfunctions
+import warnings
 
 
 def convertannotationdata_fromwindows2unixstyle(
@@ -52,11 +53,14 @@ def convertannotationdata_fromwindows2unixstyle(
 
         if askuser == "y" or askuser == "yes" or askuser == "Ja" or askuser == "ha":
             fn = os.path.join(str(folder), "CollectedData_" + cfg["scorer"])
-            Data = pd.read_hdf(fn + ".h5", "df_with_missing")
-            if win2linux:
-                convertpaths_to_unixstyle(Data, fn)
+            if os.path.exists(fn + ".h5"):
+                Data = pd.read_hdf(fn + ".h5", "df_with_missing")
+                if win2linux:
+                    convertpaths_to_unixstyle(Data, fn)
+                else:
+                    convertpaths_to_windowsstyle(Data, fn)
             else:
-                convertpaths_to_windowsstyle(Data, fn)
+                warnings.warn(f"Could not find '{fn+'.h5'}'. skipping")
 
 
 def convertpaths_to_unixstyle(Data, fn):


### PR DESCRIPTION
Rather than crash, gracefully skip & warn user.