### PR TITLE
Labeling data no longer causes small keypoint shifts

### DIFF
--- a/deeplabcut/generate_training_dataset/auxfun_drag_label.py
+++ b/deeplabcut/generate_training_dataset/auxfun_drag_label.py
@@ -134,7 +134,7 @@ class DraggablePoint:
             self.point.set_animated(False)
             self.background = None
             self.point.figure.canvas.draw()
-            self.final_point = (event.xdata, event.ydata, self.bodyParts)
+            self.final_point = (self.point.center[0], self.point.center[1], self.bodyParts)
             self.coords.append(self.final_point)
 
     def on_hover(self, event):

--- a/deeplabcut/generate_training_dataset/auxfun_drag_label_multiple_individuals.py
+++ b/deeplabcut/generate_training_dataset/auxfun_drag_label_multiple_individuals.py
@@ -138,8 +138,8 @@ class DraggablePoint:
             self.background = None
             self.point.figure.canvas.draw()
             self.final_point = (
-                event.xdata,
-                event.ydata,
+                self.point.center[0],
+                self.point.center[1],
                 self.individual_names,
                 self.bodyParts,
             )


### PR DESCRIPTION
Previously, the final keypoint coordinates were set to the last position of the mouse cursor, therefore causing a discrepancy between the location the point was dragged to and what underlying data was stored (unless the keypoint was displaced exactly from its center...). Correctly storing the circle center now addresses that issue.
 
Fixes #854.