### PR TITLE
Efficient plotting when evaluating network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /examples/multi*
 /examples/3D*
 /examples/OUT
+.local
 
 # Tensorflow checkpoints
 *.ckpt

--- a/conda-environments/README.md
+++ b/conda-environments/README.md
@@ -23,6 +23,7 @@ or
 
 ``conda env create -f DLC-GPU.yaml``
 
+Note in a fresh ubuntu install, you will often have to run: ``sudo apt-get install gcc python3-dev`` to install the GNU Compiler Collection and the python developing environment.
 (3) You can now use this environment from anywhere on your comptuer (i.e. no need to go back into the conda- folder). Just enter your environment by running:
 
 - Ubuntu/MacOS: ``source/conda activate nameoftheenv`` (i.e. on your Mac: ``conda activate DLC-CPU``)
@@ -46,7 +47,7 @@ Some users might want to create their own customize env. -  Here is an example.
 
 In the terminal type:
 
-`conda create -n DLC python=3.7 tensorflow=1.13.1` 
+`conda create -n DLC python=3.7 tensorflow=1.13.1`
 
 (this would be for CPU-based tensorflow; for GPU support use `tensorflow-gpu=1.13.1`).
 

--- a/deeplabcut/pose_estimation_tensorflow/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/evaluate.py
@@ -208,8 +208,9 @@ def Plotting(
 
     colors = visualization.get_cmap(len(comparisonbodyparts), name=cfg["colormap"])
     NumFrames = np.size(DataCombined.index)
+    fig, ax = visualization.create_minimal_figure()
     for ind in tqdm(np.arange(NumFrames)):
-        visualization.plot_and_save_labeled_frame(
+        ax = visualization.plot_and_save_labeled_frame(
             DataCombined,
             ind,
             trainIndices,
@@ -218,7 +219,10 @@ def Plotting(
             comparisonbodyparts,
             DLCscorer,
             foldername,
+            fig,
+            ax,
         )
+        visualization.erase_artists(ax)
 
 
 def return_evaluate_network_data(
@@ -728,7 +732,7 @@ def evaluate_network(
                 final_result = []
 
                 ########################### RESCALING (to global scale)
-                if rescale == True:
+                if rescale:
                     scale = dlc_cfg["global_scale"]
                     Data = (
                         pd.read_hdf(
@@ -871,7 +875,7 @@ def evaluate_network(
                         ]
                         final_result.append(results)
 
-                        if show_errors == True:
+                        if show_errors:
                             print(
                                 "Results for",
                                 trainingsiterations,
@@ -902,7 +906,7 @@ def evaluate_network(
                                 "Thereby, the errors are given by the average distances between the labels by DLC and the scorer."
                             )
 
-                        if plotting == True:
+                        if plotting:
                             print("Plotting...")
                             foldername = os.path.join(
                                 str(evaluationfolder),
@@ -925,7 +929,7 @@ def evaluate_network(
                         # print(final_result)
                     else:
                         DataMachine = pd.read_hdf(resultsfilename, "df_with_missing")
-                        if plotting == True:
+                        if plotting:
                             DataCombined = pd.concat(
                                 [Data.T, DataMachine.T], axis=0, sort=False
                             ).T

--- a/deeplabcut/pose_estimation_tensorflow/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/evaluate_multianimal.py
@@ -337,6 +337,7 @@ def evaluate_multianimal_full(
                                 fig.set_size_inches(w / 100, h / 100)
                                 ax.set_xlim(0, w)
                                 ax.set_ylim(0, h)
+                                ax.invert_yaxis()
                                 ax = visualization.make_multianimal_labeled_image(
                                     frame,
                                     groundtruthcoordinates,
@@ -713,6 +714,7 @@ def evaluate_multianimal_crossvalidate(
                 fig.set_size_inches(w / 100, h / 100)
                 ax.set_xlim(0, w)
                 ax.set_ylim(0, h)
+                ax.invert_yaxis()
                 ax = visualization.make_multianimal_labeled_image(
                     frame,
                     groundtruthcoordinates,

--- a/deeplabcut/pose_estimation_tensorflow/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/evaluate_multianimal.py
@@ -251,6 +251,7 @@ def evaluate_multianimal_full(
                                 + Snapshots[snapindex],
                             )
                             auxiliaryfunctions.attempttomakefolder(foldername)
+                            fig, ax = visualization.create_minimal_figure()
 
                         # print(dlc_cfg)
                         # Specifying state of model (snapshot / training state)
@@ -332,7 +333,11 @@ def evaluate_multianimal_full(
                                     dist[inds[inds_gt[rows]], imageindex] = min_dists
 
                             if plotting:
-                                fig = visualization.make_multianimal_labeled_image(
+                                h, w, _ = np.shape(frame)
+                                fig.set_size_inches(w / 100, h / 100)
+                                ax.set_xlim(0, w)
+                                ax.set_ylim(0, h)
+                                ax = visualization.make_multianimal_labeled_image(
                                     frame,
                                     groundtruthcoordinates,
                                     coords_pred,
@@ -341,14 +346,15 @@ def evaluate_multianimal_full(
                                     cfg["dotsize"],
                                     cfg["alphavalue"],
                                     cfg["pcutoff"],
+                                    ax=ax
                                 )
-
                                 visualization.save_labeled_frame(
                                     fig,
                                     image_path,
                                     foldername,
                                     imageindex in trainIndices,
                                 )
+                                visualization.erase_artists(ax)
 
                         sess.close()  # closes the current tf session
 
@@ -695,6 +701,7 @@ def evaluate_multianimal_crossvalidate(
                 "LabeledImages_" + DLCscorer + "_" + Snapshots[snapindex],
             )
             auxiliaryfunctions.attempttomakefolder(foldername)
+            fig, ax = visualization.create_minimal_figure()
             for imageindex, imagename in tqdm(enumerate(Data.index)):
                 image_path = os.path.join(cfg["project_path"], imagename)
                 image = io.imread(image_path)
@@ -702,7 +709,11 @@ def evaluate_multianimal_crossvalidate(
                 groundtruthcoordinates = poses_gt[imageindex]
                 coords_pred = poses[imageindex][:, :, :2]
                 probs_pred = poses[imageindex][:, :, -1:]
-                fig = visualization.make_multianimal_labeled_image(
+                h, w, _ = np.shape(frame)
+                fig.set_size_inches(w / 100, h / 100)
+                ax.set_xlim(0, w)
+                ax.set_ylim(0, h)
+                ax = visualization.make_multianimal_labeled_image(
                     frame,
                     groundtruthcoordinates,
                     coords_pred,
@@ -711,7 +722,9 @@ def evaluate_multianimal_crossvalidate(
                     cfg["dotsize"],
                     cfg["alphavalue"],
                     cfg["pcutoff"],
+                    ax=ax
                 )
                 visualization.save_labeled_frame(
                     fig, image_path, foldername, imageindex in trainIndices
                 )
+                visualization.erase_artists(ax)

--- a/deeplabcut/utils/visualization.py
+++ b/deeplabcut/utils/visualization.py
@@ -182,13 +182,13 @@ def save_labeled_frame(fig, image_path, dest_folder, belongs_to_train):
 
 def create_minimal_figure(dpi=100):
     fig, ax = plt.subplots(frameon=False, dpi=dpi)
-    ax.invert_yaxis()
     ax.axis("off")
+    ax.invert_yaxis()
     return fig, ax
 
 
 def erase_artists(ax):
-    for artist in ax.lines + ax.collections:
+    for artist in ax.lines + ax.collections + ax.artists + ax.patches + ax.images:
         artist.remove()
     ax.figure.canvas.draw_idle()
 

--- a/deeplabcut/utils/visualization.py
+++ b/deeplabcut/utils/visualization.py
@@ -90,7 +90,6 @@ def make_labeled_image(
                         alpha=alphavalue,
                         color=colors(int(bpindex)),
                     )
-    fig.subplots_adjust(left=0, bottom=0, right=1, top=1, wspace=0, hspace=0)
     return fig
 
 
@@ -104,9 +103,11 @@ def make_multianimal_labeled_image(
     alphavalue=0.7,
     pcutoff=0.6,
     labels=["+", ".", "x"],
+    ax=None
 ):
-    h, w, numcolors = np.shape(frame)
-    fig, ax = prepare_figure_axes(w, h)
+    if ax is None:
+        h, w, _ = np.shape(frame)
+        _, ax = prepare_figure_axes(w, h)
     ax.imshow(frame, "gray")
     for n, data in enumerate(zip(coords_truth, coords_pred, probs_pred)):
         color = colors(n)
@@ -132,8 +133,7 @@ def make_multianimal_labeled_image(
                 alpha=alphavalue,
                 color=color,
             )
-    fig.subplots_adjust(left=0, bottom=0, right=1, top=1, wspace=0, hspace=0)
-    return fig
+    return ax
 
 
 def plot_and_save_labeled_frame(
@@ -176,8 +176,21 @@ def save_labeled_frame(fig, image_path, dest_folder, belongs_to_train):
     # See https://docs.microsoft.com/en-us/windows/desktop/fileio/naming-a-file#maximum-path-length-limitation
     if len(full_path) >= 260 and os.name == "nt":
         full_path = "\\\\?\\" + full_path
+    fig.subplots_adjust(left=0, bottom=0, right=1, top=1, wspace=0, hspace=0)
     fig.savefig(full_path)
-    plt.close(fig)
+
+
+def create_minimal_figure(dpi=100):
+    fig, ax = plt.subplots(frameon=False, dpi=dpi)
+    ax.invert_yaxis()
+    ax.axis("off")
+    return fig, ax
+
+
+def erase_artists(ax):
+    for artist in ax.lines + ax.collections:
+        artist.remove()
+    ax.figure.canvas.draw_idle()
 
 
 def prepare_figure_axes(width, height, scale=1.0, dpi=100):


### PR DESCRIPTION
Figure is now created only once, and efficiently drawn and erased in the loop.
I tested it over a folder of 3000+ images and this successfully keeps memory use constant.
- [x] multi-animal project
- [x] single-animal project

Fixes #910 