### PR TITLE
Adding format and resolution arguments to plot_trajectories

### DIFF
--- a/deeplabcut/utils/plotting.py
+++ b/deeplabcut/utils/plotting.py
@@ -211,7 +211,7 @@ def plot_trajectories(
         Specifies the destination folder that was used for storing analysis data (default is the path of the video).
 
     imagetype: string, default ".png"
-        Specifies the output image format, tested '.tif', '.jpg', '.svg'
+        Specifies the output image format, tested '.tif', '.jpg', '.svg' and ".png". 
 
     resolution: int, default 100
         Specifies the resolution (in dpi) of saved figures. Note higher resolution figures take longer to generate.

--- a/deeplabcut/utils/plotting.py
+++ b/deeplabcut/utils/plotting.py
@@ -31,7 +31,7 @@ def Histogram(vector, color, bins, ax=None, linewidth=1.0):
         ax = fig.add_subplot(111)
     ax.hist(dvector, color=color, histtype="step", bins=bins, linewidth=linewidth)
 
-             
+
 def PlottingResults(
     tmpfolder,
     Dataframe,
@@ -41,7 +41,7 @@ def PlottingResults(
     showfigures=False,
     suffix=".png",
     resolution=100,
-    linewidth=1.0
+    linewidth=1.0,
 ):
     """ Plots poses vs time; pose x vs pose y; histogram of differences and likelihoods."""
     pcutoff = cfg["pcutoff"]
@@ -95,10 +95,28 @@ def PlottingResults(
                 )
                 ax1.plot(temp_x, temp_y, ".", color=colors(bpindex), alpha=alphavalue)
 
-                ax2.plot(temp_x, "--", color=colors(bpindex), linewidth=linewidth, alpha=alphavalue)
-                ax2.plot(temp_y, "-", color=colors(bpindex), linewidth=linewidth, alpha=alphavalue)
+                ax2.plot(
+                    temp_x,
+                    "--",
+                    color=colors(bpindex),
+                    linewidth=linewidth,
+                    alpha=alphavalue,
+                )
+                ax2.plot(
+                    temp_y,
+                    "-",
+                    color=colors(bpindex),
+                    linewidth=linewidth,
+                    alpha=alphavalue,
+                )
 
-                ax3.plot(prob, "-", color=colors(bpindex), linewidth=linewidth, alpha=alphavalue)
+                ax3.plot(
+                    prob,
+                    "-",
+                    color=colors(bpindex),
+                    linewidth=linewidth,
+                    alpha=alphavalue,
+                )
 
                 Histogram(temp_x, colors(bpindex), bins, ax4, linewidth=linewidth)
                 Histogram(temp_y, colors(bpindex), bins, ax4, linewidth=linewidth)
@@ -112,10 +130,22 @@ def PlottingResults(
         cbar = plt.colorbar(sm, ax=ax, ticks=range(len(bodyparts2plot)))
         cbar.set_ticklabels(bodyparts2plot)
 
-    fig1.savefig(os.path.join(tmpfolder, "trajectory" + suffix), bbox_inches='tight', dpi=resolution)
-    fig2.savefig(os.path.join(tmpfolder, "plot" + suffix), bbox_inches='tight', dpi=resolution)
-    fig3.savefig(os.path.join(tmpfolder, "plot-likelihood" + suffix), bbox_inches='tight', dpi=resolution)
-    fig4.savefig(os.path.join(tmpfolder, "hist" + suffix), bbox_inches='tight', dpi=resolution)
+    fig1.savefig(
+        os.path.join(tmpfolder, "trajectory" + suffix),
+        bbox_inches="tight",
+        dpi=resolution,
+    )
+    fig2.savefig(
+        os.path.join(tmpfolder, "plot" + suffix), bbox_inches="tight", dpi=resolution
+    )
+    fig3.savefig(
+        os.path.join(tmpfolder, "plot-likelihood" + suffix),
+        bbox_inches="tight",
+        dpi=resolution,
+    )
+    fig4.savefig(
+        os.path.join(tmpfolder, "hist" + suffix), bbox_inches="tight", dpi=resolution
+    )
 
     if not showfigures:
         plt.close("all")
@@ -141,9 +171,9 @@ def plot_trajectories(
     destfolder=None,
     modelprefix="",
     track_method="",
-    imagetype =".png",
-    resolution = 100,
-    linewidth = 1.0
+    imagetype=".png",
+    resolution=100,
+    linewidth=1.0,
 ):
     """
     Plots the trajectories of various bodyparts across the video.
@@ -179,13 +209,13 @@ def plot_trajectories(
 
     destfolder: string, optional
         Specifies the destination folder that was used for storing analysis data (default is the path of the video).
-        
+
     imagetype: string, default ".png"
         Specifies the output image format, tested '.tif', '.jpg', '.svg'
 
     resolution: int, default 100
         Specifies the resolution (in dpi) of saved figures. Note higher resolution figures take longer to generate.
-        
+
     linewidth: float, default 1.0
         Specifies width of line for line and histogram plots.
 
@@ -246,7 +276,7 @@ def plot_trajectories(
                     showfigures,
                     suffix + animal + imagetype,
                     resolution=resolution,
-                    linewidth=linewidth
+                    linewidth=linewidth,
                 )
         except FileNotFoundError as e:
             failed.append(True)

--- a/deeplabcut/utils/plotting.py
+++ b/deeplabcut/utils/plotting.py
@@ -40,6 +40,7 @@ def PlottingResults(
     individuals2plot,
     showfigures=False,
     suffix=".png",
+    resolution=100
 ):
     """ Plots poses vs time; pose x vs pose y; histogram of differences and likelihoods."""
     pcutoff = cfg["pcutoff"]
@@ -110,10 +111,10 @@ def PlottingResults(
         cbar = plt.colorbar(sm, ax=ax, ticks=range(len(bodyparts2plot)))
         cbar.set_ticklabels(bodyparts2plot)
 
-    fig1.savefig(os.path.join(tmpfolder, "trajectory" + suffix))
-    fig2.savefig(os.path.join(tmpfolder, "plot" + suffix))
-    fig3.savefig(os.path.join(tmpfolder, "plot-likelihood" + suffix))
-    fig4.savefig(os.path.join(tmpfolder, "hist" + suffix))
+    fig1.savefig(os.path.join(tmpfolder, "trajectory" + suffix), dpi=resolution)
+    fig2.savefig(os.path.join(tmpfolder, "plot" + suffix), dpi=resolution)
+    fig3.savefig(os.path.join(tmpfolder, "plot-likelihood" + suffix), dpi=resolution)
+    fig4.savefig(os.path.join(tmpfolder, "hist" + suffix), dpi=resolution)
 
     if not showfigures:
         plt.close("all")
@@ -139,6 +140,7 @@ def plot_trajectories(
     destfolder=None,
     modelprefix="",
     track_method="",
+    resolution = 100
 ):
     """
     Plots the trajectories of various bodyparts across the video.
@@ -231,6 +233,7 @@ def plot_trajectories(
                     animal,
                     showfigures,
                     suffix + animal + ".png",
+                    resolution=resolution
                 )
         except FileNotFoundError as e:
             failed.append(True)

--- a/deeplabcut/utils/plotting.py
+++ b/deeplabcut/utils/plotting.py
@@ -23,15 +23,15 @@ import numpy as np
 from deeplabcut.utils import auxiliaryfunctions, auxfun_multianimal, visualization
 
 
-def Histogram(vector, color, bins, ax=None):
+def Histogram(vector, color, bins, ax=None, linewidth=1.0):
     dvector = np.diff(vector)
     dvector = dvector[np.isfinite(dvector)]
     if ax is None:
         fig = plt.figure()
         ax = fig.add_subplot(111)
-    ax.hist(dvector, color=color, histtype="step", bins=bins)
+    ax.hist(dvector, color=color, histtype="step", bins=bins, linewidth=linewidth)
 
-
+             
 def PlottingResults(
     tmpfolder,
     Dataframe,
@@ -40,7 +40,8 @@ def PlottingResults(
     individuals2plot,
     showfigures=False,
     suffix=".png",
-    resolution=100
+    resolution=100,
+    linewidth=1.0
 ):
     """ Plots poses vs time; pose x vs pose y; histogram of differences and likelihoods."""
     pcutoff = cfg["pcutoff"]
@@ -94,13 +95,13 @@ def PlottingResults(
                 )
                 ax1.plot(temp_x, temp_y, ".", color=colors(bpindex), alpha=alphavalue)
 
-                ax2.plot(temp_x, "--", color=colors(bpindex), alpha=alphavalue)
-                ax2.plot(temp_y, "-", color=colors(bpindex), alpha=alphavalue)
+                ax2.plot(temp_x, "--", color=colors(bpindex), linewidth=linewidth, alpha=alphavalue)
+                ax2.plot(temp_y, "-", color=colors(bpindex), linewidth=linewidth, alpha=alphavalue)
 
-                ax3.plot(prob, "-", color=colors(bpindex), alpha=alphavalue)
+                ax3.plot(prob, "-", color=colors(bpindex), linewidth=linewidth, alpha=alphavalue)
 
-                Histogram(temp_x, colors(bpindex), bins, ax4)
-                Histogram(temp_y, colors(bpindex), bins, ax4)
+                Histogram(temp_x, colors(bpindex), bins, ax4, linewidth=linewidth)
+                Histogram(temp_y, colors(bpindex), bins, ax4, linewidth=linewidth)
 
     sm = plt.cm.ScalarMappable(
         cmap=plt.get_cmap(cfg["colormap"]),
@@ -111,10 +112,10 @@ def PlottingResults(
         cbar = plt.colorbar(sm, ax=ax, ticks=range(len(bodyparts2plot)))
         cbar.set_ticklabels(bodyparts2plot)
 
-    fig1.savefig(os.path.join(tmpfolder, "trajectory" + suffix), dpi=resolution)
-    fig2.savefig(os.path.join(tmpfolder, "plot" + suffix), dpi=resolution)
-    fig3.savefig(os.path.join(tmpfolder, "plot-likelihood" + suffix), dpi=resolution)
-    fig4.savefig(os.path.join(tmpfolder, "hist" + suffix), dpi=resolution)
+    fig1.savefig(os.path.join(tmpfolder, "trajectory" + suffix), bbox_inches='tight', dpi=resolution)
+    fig2.savefig(os.path.join(tmpfolder, "plot" + suffix), bbox_inches='tight', dpi=resolution)
+    fig3.savefig(os.path.join(tmpfolder, "plot-likelihood" + suffix), bbox_inches='tight', dpi=resolution)
+    fig4.savefig(os.path.join(tmpfolder, "hist" + suffix), bbox_inches='tight', dpi=resolution)
 
     if not showfigures:
         plt.close("all")
@@ -140,7 +141,9 @@ def plot_trajectories(
     destfolder=None,
     modelprefix="",
     track_method="",
-    resolution = 100
+    imagetype =".png",
+    resolution = 100,
+    linewidth = 1.0
 ):
     """
     Plots the trajectories of various bodyparts across the video.
@@ -176,6 +179,15 @@ def plot_trajectories(
 
     destfolder: string, optional
         Specifies the destination folder that was used for storing analysis data (default is the path of the video).
+        
+    imagetype: string, default ".png"
+        Specifies the output image format, tested '.tif', '.jpg', '.svg'
+
+    resolution: int, default 100
+        Specifies the resolution (in dpi) of saved figures. Note higher resolution figures take longer to generate.
+        
+    linewidth: float, default 1.0
+        Specifies width of line for line and histogram plots.
 
     Example
     --------
@@ -232,8 +244,9 @@ def plot_trajectories(
                     labeled_bpts,
                     animal,
                     showfigures,
-                    suffix + animal + ".png",
-                    resolution=resolution
+                    suffix + animal + imagetype,
+                    resolution=resolution,
+                    linewidth=linewidth
                 )
         except FileNotFoundError as e:
             failed.append(True)


### PR DESCRIPTION
Hi,
This pull request adds 3 optional arguments to dlc.plot_trajectories():

Described as added to plot_trajectories DOCSTRING:
```
    imagetype: string, default ".png"
        Specifies the output image format, tested '.tif', '.jpg', '.svg'

    resolution: int, default 100
        Specifies the resolution (in dpi) of saved figures. Note higher resolution figures take longer to generate.
        
    linewidth: float, default 1.0
        Specifies width of line for line and histogram plots.
```

Example:
```
dlc.plot_trajectories(path_config_file, vids, videotype='.mp4', resolution=300, imagetype='.svg', linewidth=0.5)
```

Being able to save high resolution images as SVGs is particularly nice for downstream editing in vector graphic software (e.g. Adobe Illustrator), making nice figures for papers/talks etc.

The line width is a bit of a personal preference, but the matplotlib default of 1.0 is too thick for me, makes it difficult to distinguish dashed from solid lines, for example.

This has been tested on Ubuntu 18.04 with no additional dependencies.

I'll suggest @AlexEMG as a reviewer, arbitrarily.

Hope these additions make sense.

Thanks,
Alex