### PR TITLE
Avoid deleting empty DataFrame rows

### DIFF
--- a/deeplabcut/generate_training_dataset/multiple_individuals_labeling_toolbox.py
+++ b/deeplabcut/generate_training_dataset/multiple_individuals_labeling_toolbox.py
@@ -818,6 +818,10 @@ class MainFrame(wx.Frame):
             self.dataFrame.reindex(
                 bodyparts, axis=1, level=self.dataFrame.columns.names.index("bodyparts")
             )
+        # Test whether there are missing frames and superfluous data
+        if len(old_imgs) > len(self.relativeimagenames):
+            missing_frames = set(old_imgs).difference(self.relativeimagenames)
+            self.dataFrame.drop(missing_frames, inplace=True)
 
         # Check whether new labels were added
         self.new_multi = [x for x in self.multibodyparts if x not in self._old_multi]

--- a/deeplabcut/generate_training_dataset/multiple_individuals_labeling_toolbox.py
+++ b/deeplabcut/generate_training_dataset/multiple_individuals_labeling_toolbox.py
@@ -1302,9 +1302,6 @@ class MainFrame(wx.Frame):
         MainFrame.saveEachImage(self)
         MainFrame.updateZoomPan(self)
 
-        # Drop Nan data frames
-        self.dataFrame = self.dataFrame.dropna(how="all")
-
         # Windows compatible
         self.dataFrame.sort_index(inplace=True)
         # Discard data associated with bodyparts that are no longer in the config

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@
 """
 DeepLabCut2.0 Toolbox (deeplabcut.org)
 © A. & M. Mathis Labs
-https://github.com/AlexEMG/DeepLabCut
+https://github.com/DeepLabCut/DeepLabCut
 
 Please see AUTHORS for contributors.
-https://github.com/AlexEMG/DeepLabCut/blob/master/AUTHORS
+https://github.com/DeepLabCut/DeepLabCut/blob/master/AUTHORS
 Licensed under GNU Lesser General Public License v3.0
 """
 
@@ -19,11 +19,11 @@ setuptools.setup(
     name="deeplabcut",
     version="2.1.9",
     author="A. & M. Mathis Labs",
-    author_email="alexander.mathis@bethgelab.org",
+    author_email="alexander@deeplabcut.org",
     description="Markerless pose-estimation of user-defined features with deep learning",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/AlexEMG/DeepLabCut",
+    url="https://github.com/DeepLabCut/DeepLabCut",
     install_requires=[
         "bayesian-optimization",
         "certifi",


### PR DESCRIPTION
Nasty bug introduced in #870 where deleted frames' data are set to NaNs and aggressively deleted.
Now data rows are removed upon loading only if the corresponding images are absent from the folder.

Fixes #1018