### PR TITLE
Get rid of uninitialized arrays

### DIFF
--- a/deeplabcut/utils/frameselectiontools.py
+++ b/deeplabcut/utils/frameselectiontools.py
@@ -284,8 +284,8 @@ def KmeansbasedFrameselectioncv2(
                         if (
                             not allocated
                         ):  #'DATA' not in locals(): #allocate memory in first pass
-                            DATA = np.empty(
-                                (nframes, np.shape(image)[0], np.shape(image)[1] * 3)
+                            DATA = np.full(
+                                (nframes, np.shape(image)[0], np.shape(image)[1] * 3), np.nan
                             )
                             allocated = True
                         DATA[counter, :, :] = np.hstack(
@@ -315,8 +315,8 @@ def KmeansbasedFrameselectioncv2(
                         if (
                             not allocated
                         ):  #'DATA' not in locals(): #allocate memory in first pass
-                            DATA = np.empty(
-                                (nframes, np.shape(image)[0], np.shape(image)[1])
+                            DATA = np.full(
+                                (nframes, np.shape(image)[0], np.shape(image)[1]), np.nan
                             )
                             allocated = True
                         DATA[counter, :, :] = np.mean(image, 2)
@@ -346,8 +346,8 @@ def KmeansbasedFrameselectioncv2(
                         if (
                             not allocated
                         ):  #'DATA' not in locals(): #allocate memory in first pass
-                            DATA = np.empty(
-                                (nframes, np.shape(image)[0], np.shape(image)[1] * 3)
+                            DATA = np.full(
+                                (nframes, np.shape(image)[0], np.shape(image)[1] * 3), np.nan
                             )
                             allocated = True
                         DATA[counter, :, :] = np.hstack(
@@ -376,13 +376,14 @@ def KmeansbasedFrameselectioncv2(
                         if (
                             not allocated
                         ):  #'DATA' not in locals(): #allocate memory in first pass
-                            DATA = np.empty(
-                                (nframes, np.shape(image)[0], np.shape(image)[1])
+                            DATA = np.full(
+                                (nframes, np.shape(image)[0], np.shape(image)[1]), np.nan
                             )
                             allocated = True
                         DATA[counter, :, :] = np.mean(image, 2)
 
         print("Kmeans clustering ... (this might take a while)")
+        DATA = DATA[~np.isnan(DATA).any(axis=(1, 2))]
         data = DATA - DATA.mean(axis=0)
         data = data.reshape(nframes, -1)  # stacking
 


### PR DESCRIPTION
Oddly enough, I have faced a case where a NaN was present in the array returned by np.empty.
<img width="536" alt="Capture d’écran 2021-01-04 à 2 38 59 PM" src="https://user-images.githubusercontent.com/30733203/103540843-abd93100-4e9a-11eb-97b9-ae17af005a6f.png">
Together with the fact that some rows may not be set due to a frame being None, it is safer to initialize the array with NaNs and drop them before computing average/subtraction.

Fixes #1032.