### PR TITLE
Avoid premature video analysis stopping in the case of a corrupted frame

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/predict_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_multianimal.py
@@ -149,9 +149,6 @@ def GetPoseandCostsF(
     det_min_score = dlc_cfg.minconfidence
 
     num_idchannel = dlc_cfg.get("num_idchannel", 0)
-    # TODO Fix the code below...
-    #  We can't just break the whole thing if there is one corrupted frame
-    #  in the middle of the video. Rather iterate over all frames and simply skip corruptions
     while cap.video.isOpened():
         if counter % step == 0:
             pbar.update(step)
@@ -185,9 +182,7 @@ def GetPoseandCostsF(
                 batch_num += 1
             else:
                 batch_ind += 1
-        else:
-            nframes = counter
-            print("Detected frames: ", nframes)
+        elif counter >= nframes:
             if batch_ind > 0:
                 # pose = predict.getposeNP(frames, dlc_cfg, sess, inputs, outputs) #process the whole batch (some frames might be from previous batch!)
                 # PredicteData[batch_num*batchsize:batch_num*batchsize+batch_ind, :] = pose[:batch_ind,:]
@@ -259,8 +254,7 @@ def GetPoseandCostsS(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes, c_engine
                 det_min_score=dlc_cfg.minconfidence,
                 c_engine=c_engine,
             )
-        else:
-            nframes = counter
+        elif counter >= nframes:
             break
         counter += 1
 
@@ -275,6 +269,4 @@ def GetPoseandCostsS(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes, c_engine
         ],
         "nframes": nframes,
     }
-
-    # print(PredicteData)
     return PredicteData, nframes

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -403,9 +403,7 @@ def GetPoseF(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes, batchsize):
                 batch_num += 1
             else:
                 batch_ind += 1
-        else:
-            nframes = counter
-            print("Detected frames: ", nframes)
+        elif counter >= nframes:
             if batch_ind > 0:
                 pose = predict.getposeNP(
                     frames, dlc_cfg, sess, inputs, outputs
@@ -450,8 +448,7 @@ def GetPoseS(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes):
             ] = (
                 pose.flatten()
             )  # NOTE: thereby cfg['all_joints_names'] should be same order as bodyparts!
-        else:
-            nframes = counter
+        elif counter >= nframes:
             break
         counter += 1
 
@@ -496,8 +493,7 @@ def GetPoseS_GTF(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes):
             ] = (
                 pose.flatten()
             )  # NOTE: thereby cfg['all_joints_names'] should be same order as bodyparts!
-        else:
-            nframes = counter
+        elif counter >= nframes:
             break
         counter += 1
 
@@ -553,9 +549,7 @@ def GetPoseF_GTF(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes, batchsize):
                 batch_num += 1
             else:
                 batch_ind += 1
-        else:
-            nframes = counter
-            print("Detected frames: ", nframes)
+        elif counter >= nframes:
             if batch_ind > 0:
                 # pose = predict.getposeNP(frames, dlc_cfg, sess, inputs, outputs) #process the whole batch (some frames might be from previous batch!)
                 pose = sess.run(pose_tensor, feed_dict={inputs: frames})
@@ -643,8 +637,7 @@ def GetPoseDynamic(
                 detected = False
 
             PredictedData[counter, :] = pose
-        else:
-            nframes = counter
+        elif counter >= nframes:
             break
         counter += 1
 

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -385,6 +385,7 @@ def GetPoseF(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes, batchsize):
         if counter % step == 0:
             pbar.update(step)
         ret, frame = cap.read()
+        inds = []
         if ret:
             frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
             if cfg["cropping"]:
@@ -393,13 +394,12 @@ def GetPoseF(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes, batchsize):
                 )
             else:
                 frames[batch_ind] = img_as_ubyte(frame)
-
+            inds.append(counter)
             if batch_ind == batchsize - 1:
                 pose = predict.getposeNP(frames, dlc_cfg, sess, inputs, outputs)
-                PredictedData[
-                    batch_num * batchsize : (batch_num + 1) * batchsize, :
-                ] = pose
+                PredictedData[inds] = pose
                 batch_ind = 0
+                inds.clear()
                 batch_num += 1
             else:
                 batch_ind += 1
@@ -408,9 +408,7 @@ def GetPoseF(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes, batchsize):
                 pose = predict.getposeNP(
                     frames, dlc_cfg, sess, inputs, outputs
                 )  # process the whole batch (some frames might be from previous batch!)
-                PredictedData[
-                    batch_num * batchsize : batch_num * batchsize + batch_ind, :
-                ] = pose[:batch_ind, :]
+                PredictedData[inds[:batch_ind]] = pose[:batch_ind]
             break
         counter += 1
 
@@ -523,6 +521,7 @@ def GetPoseF_GTF(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes, batchsize):
         if counter % step == 0:
             pbar.update(step)
         ret, frame = cap.read()
+        inds = []
         if ret:
             frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
             if cfg["cropping"]:
@@ -531,7 +530,7 @@ def GetPoseF_GTF(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes, batchsize):
                 )
             else:
                 frames[batch_ind] = img_as_ubyte(frame)
-
+            inds.append(counter)
             if batch_ind == batchsize - 1:
                 # pose = predict.getposeNP(frames,dlc_cfg, sess, inputs, outputs)
                 pose = sess.run(pose_tensor, feed_dict={inputs: frames})
@@ -541,11 +540,9 @@ def GetPoseF_GTF(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes, batchsize):
                 pose = np.reshape(
                     pose, (batchsize, -1)
                 )  # bring into batchsize times x,y,conf etc.
-                PredictedData[
-                    batch_num * batchsize : (batch_num + 1) * batchsize, :
-                ] = pose
-
+                PredictedData[inds] = pose
                 batch_ind = 0
+                inds.clear()
                 batch_num += 1
             else:
                 batch_ind += 1
@@ -555,10 +552,7 @@ def GetPoseF_GTF(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes, batchsize):
                 pose = sess.run(pose_tensor, feed_dict={inputs: frames})
                 pose[:, [0, 1, 2]] = pose[:, [1, 0, 2]]
                 pose = np.reshape(pose, (batchsize, -1))
-                PredictedData[
-                    batch_num * batchsize : batch_num * batchsize + batch_ind, :
-                ] = pose[:batch_ind, :]
-
+                PredictedData[inds[:batch_ind]] = pose[:batch_ind]
             break
         counter += 1
 


### PR DESCRIPTION
Corrupted frames are now skipped during video analysis, no longer causing its early termination. Only when a frame cannot be grabbed _and_ all previous frames have been read does the analysis stop.