### PR TITLE
Fix calculation of edge paf lengths

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/evaluate.py
@@ -138,7 +138,7 @@ def calculatepafdistancebounds(
                             distances = np.sqrt(
                                 (Data[ind, j1, "x"] - Data[ind2, j2, "x"]) ** 2
                                 + (Data[ind, j1, "y"] - Data[ind2, j2, "y"]) ** 2
-                            )
+                            ) / dlc_cfg["stride"]
                         else:
                             distances = None
 

--- a/deeplabcut/pose_estimation_tensorflow/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/evaluate.py
@@ -71,7 +71,7 @@ def calculatepafdistancebounds(
     # Read file path for pose_config file. >> pass it on
     cfg = auxiliaryfunctions.read_config(config)
 
-    if cfg["multianimalproject"] == True:
+    if cfg["multianimalproject"]:
         (
             individuals,
             uniquebodyparts,
@@ -119,10 +119,6 @@ def calculatepafdistancebounds(
         jointnames = [
             dlc_cfg.all_joints_names[i] for i in range(len(dlc_cfg.all_joints))
         ]
-
-        # plt.figure()
-        Cutoff = {}
-
         path_inferencebounds_config = (
             Path(modelfolder) / "test" / "inferencebounds.yaml"
         )
@@ -140,18 +136,15 @@ def calculatepafdistancebounds(
                             "y",
                         ) in Data.keys():
                             distances = np.sqrt(
-                                (Data[ind, j1, "x"] - Data[ind2, j1, "x"]) ** 2
+                                (Data[ind, j1, "x"] - Data[ind2, j2, "x"]) ** 2
                                 + (Data[ind, j1, "y"] - Data[ind2, j2, "y"]) ** 2
                             )
                         else:
                             distances = None
 
                         if distances is not None:
-                            if onlytrain:  # extracts only distances on training data.
+                            if onlytrain:
                                 distances = distances.iloc[trainIndices]
-
-                            # source=np.array(Data[ind,j1,'x'][jj],Data[ind,j1,'y'][jj])
-                            # target=np.array(Data[ind2,j1,'x'][jj],Data[ind2,j2,'y'][jj])
                             if ind == ind2:
                                 ds_within.extend(distances.values.flatten())
                             else:
@@ -170,7 +163,7 @@ def calculatepafdistancebounds(
                 inferenceboundscfg[edgeencoding]["intra_max"] = str(
                     1e5
                 )  # large number (larger than any image diameter)
-                inferenceboundscfg[edgeencoding]["intra_min"] = str(1e5)
+                inferenceboundscfg[edgeencoding]["intra_min"] = str(0)
 
             # NOTE: the inter-animal distances are currently not used, but are interesting to compare to intra_*
             if len(ds_across) > 0:
@@ -184,12 +177,7 @@ def calculatepafdistancebounds(
                 inferenceboundscfg[edgeencoding]["inter_max"] = str(
                     1e5
                 )  # large number (larger than image diameters in typical experiments)
-                inferenceboundscfg[edgeencoding]["inter_min"] = str(1e5)
-
-            # print(inferenceboundscfg)
-            # plt.subplot(len(partaffinityfield_graph),1,pi+1)
-            # plt.hist(ds_within,bins=np.linspace(0,100,21),color='red')
-            # plt.hist(ds_across,bins=np.linspace(0,100,21),color='blue')
+                inferenceboundscfg[edgeencoding]["inter_min"] = str(0)
 
         auxiliaryfunctions.write_plainconfig(
             str(path_inferencebounds_config), dict(inferenceboundscfg)


### PR DESCRIPTION
With the default `edgewisecondition` during animal assembly, graph edge lengths in downsampled images stored during evaluation are compared to distances calculated from the labeled data (thus in full image space). This mismatch results (I believe) in no valid connections found (during `extractstrongconnections`), and in turn in no assembled animals, explaining the NaNs during crossvalidation (as the vector of statistics remains unfilled if there are no animals; https://github.com/DeepLabCut/DeepLabCut/blob/a9fdb5f401893dc2dc4c16a8818371215cda1ac0/deeplabcut/pose_estimation_tensorflow/lib/crossvalutils.py#L186-L205) and the empty tracklets.
This PR fixes distance calculation and ensures lengths are normalized by the stride. 

Fixes #1006 and possibly #949.