### PR TITLE
Allow the extraction of additional cropped images

### DIFF
--- a/deeplabcut/generate_training_dataset/frame_extraction.py
+++ b/deeplabcut/generate_training_dataset/frame_extraction.py
@@ -34,12 +34,12 @@ def select_cropping_area(config, videos=None):
 
     cfg = auxiliaryfunctions.read_config(config)
     if videos is None:
-        videos = cfg["video_sets"]
+        videos = list(cfg.get("video_sets_original") or cfg["video_sets"])
 
     for video in videos:
         coords = auxfun_videos.draw_bbox(video)
         if coords:
-            cfg["video_sets"][video] = {
+            temp = {
                 "crop": ", ".join(
                     map(
                         str,
@@ -52,6 +52,10 @@ def select_cropping_area(config, videos=None):
                     )
                 )
             }
+            try:
+                cfg["video_sets"][video] = temp
+            except KeyError:
+                cfg["video_sets_original"][video] = temp
 
     auxiliaryfunctions.write_config(config, cfg)
     return cfg
@@ -181,14 +185,14 @@ def extract_frames(
                 "Perhaps consider extracting more, or a natural number of frames."
             )
 
-        videos = cfg["video_sets"].keys()
+        videos = cfg.get("video_sets_original") or cfg["video_sets"]
         if opencv:
             from deeplabcut.utils.auxfun_videos import VideoReader
         else:
             from moviepy.editor import VideoFileClip
 
         has_failed = []
-        for vindex, video in enumerate(videos):
+        for video in videos:
             if userfeedback:
                 print(
                     "Do you want to extract (perhaps additional) frames for video:",
@@ -241,7 +245,11 @@ def extract_frames(
 
                 if crop == "GUI":
                     cfg = select_cropping_area(config, [video])
-                coords = cfg["video_sets"][video]["crop"].split(",")
+                try:
+                    coords = cfg["video_sets"][video]["crop"].split(",")
+                except KeyError:
+                    coords = cfg["video_sets_original"][video]["crop"].split(",")
+
                 if crop and not opencv:
                     clip = clip.crop(
                         y1=int(coords[2]),

--- a/deeplabcut/generate_training_dataset/frame_extraction_toolbox.py
+++ b/deeplabcut/generate_training_dataset/frame_extraction_toolbox.py
@@ -210,7 +210,8 @@ class MainFrame(wx.Frame):
         self.date = self.cfg["date"]
         self.trainFraction = self.cfg["TrainingFraction"]
         self.trainFraction = self.trainFraction[0]
-        self.videos = self.cfg["video_sets"].keys()
+        self.videos = list(self.cfg.get("video_sets_original")
+                           or self.cfg["video_sets"])
         self.bodyparts = self.cfg["bodyparts"]
         self.colormap = plt.get_cmap(self.cfg["colormap"])
         self.colormap = self.colormap.reversed()
@@ -281,10 +282,15 @@ class MainFrame(wx.Frame):
         """
 
         videosource = self.video_source
-        self.x1 = int(self.cfg["video_sets"][videosource]["crop"].split(",")[0])
-        self.x2 = int(self.cfg["video_sets"][videosource]["crop"].split(",")[1])
-        self.y1 = int(self.cfg["video_sets"][videosource]["crop"].split(",")[2])
-        self.y2 = int(self.cfg["video_sets"][videosource]["crop"].split(",")[3])
+        try:
+            self.x1 = int(self.cfg["video_sets"][videosource]["crop"].split(",")[0])
+            self.x2 = int(self.cfg["video_sets"][videosource]["crop"].split(",")[1])
+            self.y1 = int(self.cfg["video_sets"][videosource]["crop"].split(",")[2])
+            self.y2 = int(self.cfg["video_sets"][videosource]["crop"].split(",")[3])
+        except KeyError:
+            self.x1, self.x2, self.y1, self.y2 = map(
+                int, self.cfg["video_sets_original"][videosource]["crop"].split(",")
+            )
 
         if self.cropping == True:
             # Select ROI of interest by drawing a rectangle

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -242,7 +242,7 @@ def cropimagesandlabels(
     size=(400, 400),
     userfeedback=True,
     cropdata=True,
-    excludealreadycropped=True,
+    excludealreadycropped=False,
     updatevideoentries=True,
 ):
     """
@@ -268,8 +268,10 @@ def cropimagesandlabels(
     cropdata: bool, default True:
         If true creates corresponding annotation data (from ground truth)
 
-    excludealreadycropped: bool, def true
-        If true excludes folders that already contain _cropped in their name.
+    excludealreadycropped: bool, default False:
+        If true, ignore original videos whose frames are already cropped.
+        This is only useful after adding new videos post dataset creation,
+        as folders containing no new frames are otherwise automatically ignored.
 
     updatevideoentries, bool, default true
         If true updates video_list entries to refer to cropped frames instead. This makes sense for subsequent processing.


### PR DESCRIPTION
Both extraction and cropping of additional frames are now handled. Newly extracted frames only are cropped, and their data are appended to the existing labeled data.

Fixes #912 