### PR TITLE
Incorporate tracklet stitching in tests & GUI

### DIFF
--- a/deeplabcut/__init__.py
+++ b/deeplabcut/__init__.py
@@ -113,7 +113,7 @@ from deeplabcut.pose_estimation_3d import (
     create_labeled_video_3d,
 )
 
-from deeplabcut.refine_training_dataset.tracklets import convert_raw_tracks_to_h5
+from deeplabcut.refine_training_dataset.stitch import stitch_tracklets
 from deeplabcut.refine_training_dataset import extract_outlier_frames, merge_datasets
 from deeplabcut.post_processing import filterpredictions, analyzeskeleton
 

--- a/deeplabcut/gui/create_training_dataset.py
+++ b/deeplabcut/gui/create_training_dataset.py
@@ -171,7 +171,7 @@ class Create_training_dataset(wx.Panel):
         self.hbox3.Add(self.userfeedback, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
 
         if config_file.get("multianimalproject", False):
-            print("more networks are available soon for maDLC, but currenlty this uses DLC-ResNet50 only")
+            print("more networks are available soon for maDLC, but currently this uses DLC-ResNet50 only")
             self.model_comparison_choice = "No"
         else:
             self.model_comparison_choice = wx.RadioBox(

--- a/deeplabcut/gui/refine_tracklets.py
+++ b/deeplabcut/gui/refine_tracklets.py
@@ -11,7 +11,6 @@ Licensed under GNU Lesser General Public License v3.0
 import os
 import pydoc
 import sys
-import platform
 import subprocess
 
 import wx
@@ -30,6 +29,7 @@ class Refine_tracklets(wx.Panel):
         """Constructor"""
         wx.Panel.__init__(self, parent=parent)
         self.config = cfg
+        self.cfg = auxiliaryfunctions.read_config(self.config)
         self.datafile = ""
         self.video = ""
         self.manager = None
@@ -72,29 +72,43 @@ class Refine_tracklets(wx.Panel):
         self.sel_config.SetPath(self.config)
         self.sel_config.Bind(wx.EVT_FILEPICKER_CHANGED, self.select_config)
 
-        self.video_text = wx.StaticText(self, label="Select the video")
-        sizer.Add(self.video_text, pos=(3, 0), flag=wx.TOP | wx.LEFT, border=5)
-        self.sel_video = wx.FilePickerCtrl(
-            self, path="", style=wx.FLP_USE_TEXTCTRL, message="Open video"
-        )
-        sizer.Add(
-            self.sel_video, pos=(3, 1), span=(1, 3), flag=wx.TOP | wx.EXPAND, border=5
-        )
-        self.sel_video.Bind(wx.EVT_FILEPICKER_CHANGED, self.select_video)
-
-        self.data_text = wx.StaticText(self, label="Select the tracklet data")
-        sizer.Add(self.data_text, pos=(4, 0), flag=wx.TOP | wx.LEFT, border=5)
+        self.data_text = wx.StaticText(self, label="Select the tracklet pickle file")
+        sizer.Add(self.data_text, pos=(3, 0), flag=wx.TOP | wx.LEFT, border=5)
         self.sel_datafile = wx.FilePickerCtrl(
             self, path="", style=wx.FLP_USE_TEXTCTRL, message="Open tracklet data"
         )  # wildcard="Pickle files (*.pickle)|*.pickle")
         sizer.Add(
             self.sel_datafile,
-            pos=(4, 1),
+            pos=(3, 1),
             span=(1, 3),
             flag=wx.TOP | wx.EXPAND,
             border=5,
         )
         self.sel_datafile.Bind(wx.EVT_FILEPICKER_CHANGED, self.select_datafile)
+
+        self.ntracks_text = wx.StaticText(self, label="Number of tracks to reconstruct")
+        sizer.Add(self.ntracks_text, pos=(4, 0), flag=wx.TOP | wx.LEFT, border=5)
+        self.ntracks = wx.SpinCtrl(self, value="2", min=2, max=1000)
+        sizer.Add(
+            self.ntracks, pos=(4, 1), span=(1, 3), flag=wx.EXPAND | wx.TOP, border=5
+        )
+
+        self.create_tracks_btn = wx.Button(self, label="Step1: Create tracks")
+        sizer.Add(self.create_tracks_btn, pos=(5, 1))
+        self.create_tracks_btn.Bind(wx.EVT_BUTTON, self.create_tracks)
+
+        line2 = wx.StaticLine(self)
+        sizer.Add(line2, pos=(6, 0), span=(1, 5), flag=wx.EXPAND | wx.BOTTOM, border=10)
+
+        self.video_text = wx.StaticText(self, label="Select the video")
+        sizer.Add(self.video_text, pos=(7, 0), flag=wx.TOP | wx.LEFT, border=5)
+        self.sel_video = wx.FilePickerCtrl(
+            self, path="", style=wx.FLP_USE_TEXTCTRL, message="Open video"
+        )
+        sizer.Add(
+            self.sel_video, pos=(7, 1), span=(1, 3), flag=wx.TOP | wx.EXPAND, border=5
+        )
+        self.sel_video.Bind(wx.EVT_FILEPICKER_CHANGED, self.select_video)
 
         hbox = wx.BoxSizer(wx.HORIZONTAL)
 
@@ -104,30 +118,11 @@ class Refine_tracklets(wx.Panel):
         slider_swap_sizer.Add(self.slider_swap, 20, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
         hbox.Add(slider_swap_sizer, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
 
-        slider_track_text = wx.StaticBox(
-            self, label="Specify the min relative tracklet length"
-        )
-        slider_track_sizer = wx.StaticBoxSizer(slider_track_text, wx.VERTICAL)
-        self.slider_track = wx.SpinCtrl(self, value="2")
-        slider_track_sizer.Add(
-            self.slider_track, 20, wx.EXPAND | wx.TOP | wx.BOTTOM, 10
-        )
-        hbox.Add(slider_track_sizer, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
-
         sizer.Add(
-            hbox, pos=(5, 0), flag=wx.EXPAND | wx.TOP | wx.LEFT | wx.RIGHT, border=10
+            hbox, pos=(8, 0), flag=wx.EXPAND | wx.TOP | wx.LEFT | wx.RIGHT, border=10
         )
 
         hbox_ = wx.BoxSizer(wx.HORIZONTAL)
-        slider_gap_text = wx.StaticBox(
-            self,
-            label="Specify the max gap size to fill, in frames (used for the initial pickle file only!)",
-        )
-        slider_gap_sizer = wx.StaticBoxSizer(slider_gap_text, wx.VERTICAL)
-        self.slider_gap = wx.SpinCtrl(self, value="5")
-        slider_gap_sizer.Add(self.slider_gap, 20, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
-        hbox_.Add(slider_gap_sizer, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
-
         traillength_text = wx.StaticBox(self, label="Trail Length (for visualization)")
         traillength_sizer = wx.StaticBoxSizer(traillength_text, wx.VERTICAL)
         self.length_track = wx.SpinCtrl(self, value="25")
@@ -135,10 +130,12 @@ class Refine_tracklets(wx.Panel):
         hbox_.Add(traillength_sizer, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
 
         sizer.Add(
-            hbox_, pos=(6, 0), flag=wx.EXPAND | wx.TOP | wx.LEFT | wx.RIGHT, border=10
+            hbox_, pos=(9, 0), flag=wx.EXPAND | wx.TOP | wx.LEFT | wx.RIGHT, border=10
         )
 
-        # NEW ROW:
+        line3 = wx.StaticLine(self)
+        sizer.Add(line3, pos=(10, 0), span=(1, 5), flag=wx.EXPAND | wx.BOTTOM, border=10)
+
         hbox2 = wx.BoxSizer(wx.HORIZONTAL)
 
         videotype_text = wx.StaticBox(self, label="Specify the videotype")
@@ -182,32 +179,31 @@ class Refine_tracklets(wx.Panel):
         hbox2.Add(filter_sizer, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
         hbox2.Add(filterlength_sizer, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
         sizer.Add(
-            hbox2, pos=(7, 0), flag=wx.EXPAND | wx.TOP | wx.LEFT | wx.RIGHT, border=10
+            hbox2, pos=(11, 0), flag=wx.EXPAND | wx.TOP | wx.LEFT | wx.RIGHT, border=10
         )
 
-
         self.inf_cfg_text = wx.Button(self, label="Edit inference_config.yaml")
-        sizer.Add(self.inf_cfg_text, pos=(10, 1), flag=wx.BOTTOM | wx.RIGHT, border=10)
+        sizer.Add(self.inf_cfg_text, pos=(12, 2), flag=wx.BOTTOM | wx.RIGHT, border=10)
         self.inf_cfg_text.Bind(wx.EVT_BUTTON, self.edit_inf_config)
 
-        self.ok = wx.Button(self, label="Step1: Launch GUI")
-        sizer.Add(self.ok, pos=(6, 3))
+        self.ok = wx.Button(self, label="Optional: Refine tracks")
+        sizer.Add(self.ok, pos=(9, 1))
         self.ok.Bind(wx.EVT_BUTTON, self.refine_tracklets)
 
         self.help_button = wx.Button(self, label="Help")
-        sizer.Add(self.help_button, pos=(8, 0), flag=wx.LEFT, border=10)
+        sizer.Add(self.help_button, pos=(12, 0), flag=wx.LEFT, border=10)
         self.help_button.Bind(wx.EVT_BUTTON, self.help_function)
 
         self.reset = wx.Button(self, label="Reset")
-        sizer.Add(self.reset, pos=(8, 1), flag=wx.BOTTOM | wx.RIGHT, border=10)
+        sizer.Add(self.reset, pos=(12, 1), flag=wx.BOTTOM | wx.RIGHT, border=10)
         self.reset.Bind(wx.EVT_BUTTON, self.reset_refine_tracklets)
 
-        self.filter = wx.Button(self, label=" Step2: Filter Tracks (then you also get a CSV file!)")
-        sizer.Add(self.filter, pos=(8, 3), flag=wx.BOTTOM | wx.RIGHT, border=10)
+        self.filter = wx.Button(self, label=" Optional: Filter Tracks (then you also get a CSV file!)")
+        sizer.Add(self.filter, pos=(11, 1), flag=wx.BOTTOM | wx.RIGHT, border=10)
         self.filter.Bind(wx.EVT_BUTTON, self.filter_after_refinement)
 
         self.export = wx.Button(self, label="Optional: Merge refined data")
-        sizer.Add(self.export, pos=(10, 3), flag=wx.BOTTOM | wx.RIGHT, border=10)
+        sizer.Add(self.export, pos=(13, 1), flag=wx.BOTTOM | wx.RIGHT, border=10)
         self.export.Bind(wx.EVT_BUTTON, self.export_data)
         self.export.Disable()
 
@@ -218,13 +214,12 @@ class Refine_tracklets(wx.Panel):
 
     def edit_inf_config(self, event):
         # Read the infer config file
-        cfg = auxiliaryfunctions.read_config(self.config)
         trainingsetindex = self.trainingset.GetValue()
-        trainFraction = cfg["TrainingFraction"][trainingsetindex]
+        trainFraction = self.cfg["TrainingFraction"][trainingsetindex]
         self.inf_cfg_path = os.path.join(
-            cfg["project_path"],
+            self.cfg["project_path"],
             auxiliaryfunctions.GetModelFolder(
-                trainFraction, self.shuffle.GetValue(), cfg
+                trainFraction, self.shuffle.GetValue(), self.cfg
             ),
             "test",
             "inference_cfg.yaml",
@@ -234,6 +229,7 @@ class Refine_tracklets(wx.Panel):
             self.file_open_bool = subprocess.call(["open", self.inf_cfg_path])
             self.file_open_bool = True
         else:
+            import webbrowser
             self.file_open_bool = webbrowser.open(self.inf_cfg_path)
         if self.file_open_bool:
             self.inf_cfg = auxiliaryfunctions.read_config(self.inf_cfg_path)
@@ -297,14 +293,19 @@ class Refine_tracklets(wx.Panel):
         self.video = self.sel_video.GetPath()
         self.sel_video.SetPath(os.path.basename(self.video))
 
+    def create_tracks(self, event):
+        deeplabcut.stitch_tracklets(
+            self.datafile,
+            n_tracks=self.ntracks.GetValue(),
+            animal_names=self.cfg["individuals"],
+        )
+
     def refine_tracklets(self, event):
         self.manager, self.viz = deeplabcut.refine_tracklets(
             self.config,
-            self.datafile,
+            self.datafile.replace("pickle", "h5"),
             self.video,
             min_swap_len=self.slider_swap.GetValue(),
-            min_tracklet_len=self.slider_track.GetValue(),
-            max_gap=self.slider_gap.GetValue(),
             trail_len=self.length_track.GetValue(),
         )
         self.export.Enable()
@@ -320,7 +321,5 @@ class Refine_tracklets(wx.Panel):
         self.sel_datafile.SetPath("")
         self.sel_video.SetPath("")
         self.slider_swap.SetValue(2)
-        self.slider_track.SetValue(2)
-        self.slider_gap.SetValue(5)
         self.length_track.SetValue(25)
         # self.save.Enable(False)

--- a/docs/functionDetails.md
+++ b/docs/functionDetails.md
@@ -550,12 +550,21 @@ from deeplabcut.utils.make_labeled_video import create_video_from_pickled_tracks
 create_video_from_pickled_tracks(videopath, picklepath)
 ```
 
-**Secondly,** you need to refine the tracklets. You can fix both "major" ID swaps, i.e. perhaps when animals cross, and you can micro-refine the individual body points. You will load the `...trackertype.pickle` file that was created above, and then you can launch a GUI to interactively refine the data. This also has several options, so please check out the docstring. Note, if you see very little data once you launch the GUI, consider relaxing the `pafthreshold` value (dropping it lower), and re-running convert to tracklets (this is very fast; see the "short demo" above).
+**Secondly,** tracklets need to be stitched to reconstruct the full animal tracks in a kinematically consistent manner.
+This is conveniently (and automatically) done using:
+```python
+deeplabcut.stitch_tracklets(pickle_file, n_tracks)
+```
+where ``n_tracks`` is the number of animal tracks to reconstruct.
+By default, the `.h5` output file (akin to what you might be used to from standard DLC) will be written alongside the pickle file.
+This `.h5` file can be (1) filtered to take care of small jitters, and/or (2) refined as described below.
 
-Upon saving the refined tracks you get an `.h5` file (akin to what you might be used to from standard DLC. You can also load (1) filter this to take care of small jitters, and (2) load this `.h5` this to refine (again) in case you find another issue, etc!
+Refinement allows fixing both "major" ID swaps, i.e. perhaps when animals cross, and you can micro-refine the individual body points.
+You will load the `...trackertype.h5` file that was created above, and then you can launch a GUI to interactively refine the data.
+This also has several options, so please check out the docstring. Note, if you see very little data once you launch the GUI, consider relaxing the `pafthreshold` value (dropping it lower), and re-running convert to tracklets (this is very fast; see the "short demo" above).
 
 ```python
-deeplabcut.refine_tracklets(path_config_file, pickle_or_h5_file, videofile_path, min_swap_len=2, min_tracklet_len=2, trail_len=50)
+deeplabcut.refine_tracklets(path_config_file, h5_file, videofile_path, min_swap_len=2, min_tracklet_len=2, trail_len=50)
 ```
 HOT KEYS IN THE Tracklet GUI:
 ```
@@ -579,13 +588,6 @@ Short demo:
  <p align="center">
 <img src="https://images.squarespace-cdn.com/content/v1/57f6d51c9f74566f55ecf271/1588690928000-90ZMRIM8SN6QE20ZOMNX/ke17ZwdGBToddI8pDm48kJ1oJoOIxBAgRD2ClXVCmKFZw-zPPgdn4jUwVcJE1ZvWQUxwkmyExglNqGp0IvTJZUJFbgE-7XRK3dMEBRBhUpxBw7VlGKDQO2xTcc51Yv6DahHgScLwHgvMZoEtbzk_9vMJY_JknNFgVzVQ2g0FD_s/refineDEMO.gif?format=750w" width="70%">
 </p>
-
-
-Lastly, let's say you've optimized the `inference_cfg.yaml` (i.e., tracking) parameters, and you want to just apply this to a set of videos and by-pass the tracklet GUI, you can pass the pickle file directly from `analyze_videos` (and your `config.yaml` full path) and run:
-
-```python
-deeplabcut.convert_raw_tracks_to_h5(config_path, picklefile)
-```
 
 ### (I) Novel Video Analysis: extra features
 

--- a/docs/maDLC_AdvUserGuide.md
+++ b/docs/maDLC_AdvUserGuide.md
@@ -549,14 +549,12 @@ You should **cross-validate** the tracking parameters. ([Here is more informatio
 
 **Animal assembly and tracking quality** can be assessed via `deeplabcut.utils.make_labeled_video.create_video_from_pickled_tracks`. This function provides an additional diagnostic tool before moving on to refining tracklets.
 
-Secondly, you need to **refine the tracklets**. You can fix both "major" ID swaps, i.e. perhaps when animals cross, and you can micro-refine the individual body points. You will load the `...trackertype.pickle` file that was created above, and then you can launch a GUI to interactively refine the data. This also has several options, so please check out the docstring. Upon saving the refined tracks you get an `.h5` file (akin to what you might be used to from standard DLC. You can also load (1) filter this to take care of small jitters, and (2) load this `.h5` this to refine (again) in case you find another issue, etc!
-
+Secondly, tracklets need to be stitched to reconstruct the full animal tracks in a kinematically consistent manner.
+This is conveniently (and automatically) done using:
 ```python
-deeplabcut.refine_tracklets(path_config_file, pickle_or_h5_file, videofile_path, max_gap=0, min_swap_len=2, min_tracklet_len=2, trail_len=50)
+deeplabcut.stitch_tracklets(pickle_file, n_tracks)
 ```
-*note, setting `max_gap=0` can be used to fill in all frames across the video; otherwise, 1-n is the # of frames you want to fill in, i.e. maybe you want to fill in short gaps of 5 frames, but 15 frames indicates another issue, etc. You can test this inthe GUI. 
-
-If you fill in gaps, they will be associated to an ultra low probability, 0.01, so you are aware this is not the networks best estimate, this is the human-override! Thus, if you create a video, you need to set your pcutoff to 0 if you want to see these filled in frames.
+where ``n_tracks`` is the number of animal tracks to reconstruct.
 
 [Read more here!](functionDetails.md#madeeplabcut-critical-point---assemble--refine-tracklets)
 
@@ -564,13 +562,6 @@ Short demo:
  <p align="center">
 <img src="https://images.squarespace-cdn.com/content/v1/57f6d51c9f74566f55ecf271/1588690928000-90ZMRIM8SN6QE20ZOMNX/ke17ZwdGBToddI8pDm48kJ1oJoOIxBAgRD2ClXVCmKFZw-zPPgdn4jUwVcJE1ZvWQUxwkmyExglNqGp0IvTJZUJFbgE-7XRK3dMEBRBhUpxBw7VlGKDQO2xTcc51Yv6DahHgScLwHgvMZoEtbzk_9vMJY_JknNFgVzVQ2g0FD_s/refineDEMO.gif?format=750w" width="70%">
 </p>
-
-If you do not want to refine tracklets, but use the data "as is" after the `convert_detections2tracklets` step, you can skip refinement and just create the final h5/csv file by running: 
-
-```python
-deeplabcut.convert_raw_tracks_to_h5(config_path, picklefile)
-```
-^ this is NOT required if you run `refine_tracklets` above!
 
 ### Once you have analyzed video data (and refined your maDeepLabCut tracklets):
 


### PR DESCRIPTION
The previous pickle-to-h5 conversion is outdated and dropped in favor of graph-based tracklet stitching.
The GUI, docs, and tests were updated to reflect the improved pipeline; specifically, the GUI tab now makes track creation easy (for a number of animals specified by the user, irrespective of the number of individuals initially defined in the config.yaml), and refinement an optional step.