### PR TITLE
fix two nasty bugs

### DIFF
--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -559,7 +559,9 @@ def MakeInference_yaml(itemstochange, saveasconfigfile, defaultconfigfile):
 
 def _robust_path_split(path):
     sep = "\\" if "\\" in path else "/"
-    parent, file = path.rsplit(sep, 1)
+    #import pdb; pdb.set_trace()
+    #parent, file = path.rsplit(sep, 1)
+    parent, file = os.path.split(sep)
     filename, ext = os.path.splitext(file)
     return parent, filename, ext
 

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -559,7 +559,14 @@ def MakeInference_yaml(itemstochange, saveasconfigfile, defaultconfigfile):
 
 def _robust_path_split(path):
     sep = "\\" if "\\" in path else "/"
-    parent, file = path.rsplit(sep, 1)
+    splits = path.rsplit(sep, 1)
+    if len(splits) == 1:
+        parent = '.'
+        file = splits[0]
+    elif len(splits) == 2:
+        parent, file = splits
+    else:
+        raise('Unknown filepath split for path {}'.format(path))
     filename, ext = os.path.splitext(file)
     return parent, filename, ext
 

--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -438,7 +438,6 @@ def CropVideo(
 
     Crops the video to a width of 220 and height of 320 starting at the origin (top left) and saves it in C:\\yourusername\\rig-95\\Videos as reachingvideo1cropped.avi
     """
-#    import pdb; pdb.set_trace()
     writer = VideoWriter(vname)
 
     if useGUI:

--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -286,9 +286,9 @@ class VideoWriter(VideoReader):
         x1, _, y1, _ = self.get_bbox()
         output_path = self.make_output_path(suffix, dest_folder)
         command = (
-            f"ffmpeg -n -i {self.video_path} "
+            f"ffmpeg -n -i \"{self.video_path}\" "
             f"-filter:v crop={self.width}:{self.height}:{x1}:{y1} "
-            f"-c:a copy {output_path}"
+            f"-c:a copy \"{output_path}\""
         )
         subprocess.call(command, shell=True)
         return output_path

--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -286,9 +286,9 @@ class VideoWriter(VideoReader):
         x1, _, y1, _ = self.get_bbox()
         output_path = self.make_output_path(suffix, dest_folder)
         command = (
-            f"ffmpeg -n -i {self.video_path} "
+            f"ffmpeg -n -i \"{self.video_path}\" "
             f"-filter:v crop={self.width}:{self.height}:{x1}:{y1} "
-            f"-c:a copy {output_path}"
+            f"-c:a copy \"{output_path}\""
         )
         subprocess.call(command, shell=True)
         return output_path
@@ -438,6 +438,7 @@ def CropVideo(
 
     Crops the video to a width of 220 and height of 320 starting at the origin (top left) and saves it in C:\\yourusername\\rig-95\\Videos as reachingvideo1cropped.avi
     """
+#    import pdb; pdb.set_trace()
     writer = VideoWriter(vname)
 
     if useGUI:


### PR DESCRIPTION
1. ffmpeg gets paths as quoted to handle spaces
2. os.path.split instead of .rsplit to handle non-parented files