### PR TITLE
Allow user-defined PAF graphs upon dataset creation

### DIFF
--- a/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
@@ -129,7 +129,7 @@ def create_multianimaltraining_dataset(
         partaffinityfield_graph = [
             edge for i, edge in enumerate(paf_graph) if i not in to_ignore
         ]
-        auxfun_multianimal.validate_paf_graph(cfg, paf_graph)
+        auxfun_multianimal.validate_paf_graph(cfg, partaffinityfield_graph)
 
 
     print("Utilizing the following graph:", partaffinityfield_graph)

--- a/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
@@ -17,7 +17,6 @@ import numpy as np
 from tqdm import tqdm
 
 from deeplabcut.generate_training_dataset import trainingsetmanipulation
-from deeplabcut.pose_estimation_tensorflow.lib import crossvalutils
 from deeplabcut.utils import auxiliaryfunctions, auxfun_models, auxfun_multianimal
 
 
@@ -124,12 +123,14 @@ def create_multianimaltraining_dataset(
     else:
         # Ignore possible connections between 'multi' and 'unique' body parts;
         # one can never be too careful...
-        to_ignore = crossvalutils._filter_unwanted_paf_connections(
-            config, paf_graph
+        to_ignore = auxfun_multianimal.filter_unwanted_paf_connections(
+            cfg, paf_graph
         )
         partaffinityfield_graph = [
             edge for i, edge in enumerate(paf_graph) if i not in to_ignore
         ]
+        auxfun_multianimal.validate_paf_graph(cfg, paf_graph)
+
 
     print("Utilizing the following graph:", partaffinityfield_graph)
     num_limbs = len(partaffinityfield_graph)

--- a/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
@@ -14,10 +14,10 @@ from itertools import combinations
 from pathlib import Path
 
 import numpy as np
-import pandas as pd
 from tqdm import tqdm
 
 from deeplabcut.generate_training_dataset import trainingsetmanipulation
+from deeplabcut.pose_estimation_tensorflow.lib import crossvalutils
 from deeplabcut.utils import auxiliaryfunctions, auxfun_models, auxfun_multianimal
 
 
@@ -28,6 +28,7 @@ def create_multianimaltraining_dataset(
     windows2linux=False,
     net_type=None,
     numdigits=2,
+    paf_graph=None,
 ):
     """
     Creates a training dataset for multi-animal datasets. Labels from all the extracted frames are merged into a single .h5 file.\n
@@ -57,6 +58,10 @@ def create_multianimaltraining_dataset(
 
     numdigits: int, optional
 
+    paf_graph: list of lists, optional (default=None)
+        If not None, overwrite the default complete graph. This is useful for advanced users who
+        already know a good graph, or simply want to use a specific one. Note that, in that case,
+        the data-driven selection procedure upon model evaluation will be skipped.
 
     Example
     --------
@@ -111,10 +116,21 @@ def create_multianimaltraining_dataset(
         uniquebodyparts,
         multianimalbodyparts,
     ) = auxfun_multianimal.extractindividualsandbodyparts(cfg)
-    # Automatically form a complete PAF graph
-    partaffinityfield_graph = [
-        list(edge) for edge in combinations(range(len(multianimalbodyparts)), 2)
+
+    if paf_graph is None:  # Automatically form a complete PAF graph
+        partaffinityfield_graph = [
+            list(edge) for edge in combinations(range(len(multianimalbodyparts)), 2)
     ]
+    else:
+        # Ignore possible connections between 'multi' and 'unique' body parts;
+        # one can never be too careful...
+        to_ignore = crossvalutils._filter_unwanted_paf_connections(
+            config, paf_graph
+        )
+        partaffinityfield_graph = [
+            edge for i, edge in enumerate(paf_graph) if i not in to_ignore
+        ]
+
     print("Utilizing the following graph:", partaffinityfield_graph)
     num_limbs = len(partaffinityfield_graph)
     partaffinityfield_predict = True

--- a/deeplabcut/pose_estimation_tensorflow/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/evaluate_multianimal.py
@@ -533,19 +533,22 @@ def evaluate_multianimal_full(
 
                         tf.reset_default_graph()
 
-                    # Data-driven skeleton selection
-                    uncropped_data_path = data_path.replace(
-                        ".pickle", "_uncropped.pickle"
-                    )
-                    if not os.path.isfile(uncropped_data_path):
-                        print("Selecting best skeleton...")
-                        crossvalutils._rebuild_uncropped_in(evaluationfolder)
-                        crossvalutils.cross_validate_paf_graphs(
-                            config,
-                            str(path_test_config).replace("pose_", "inference_"),
-                            uncropped_data_path,
-                            uncropped_data_path.replace("_full_", "_meta_"),
+                    # Skip data-driven skeleton selection unless
+                    # the model was trained on the full graph.
+                    max_n_edges = dlc_cfg["num_joints"] * (dlc_cfg["num_joints"] - 1) // 2
+                    if len(dlc_cfg["partaffinityfield_graph"]) == max_n_edges:
+                        uncropped_data_path = data_path.replace(
+                            ".pickle", "_uncropped.pickle"
                         )
+                        if not os.path.isfile(uncropped_data_path):
+                            print("Selecting best skeleton...")
+                            crossvalutils._rebuild_uncropped_in(evaluationfolder)
+                            crossvalutils.cross_validate_paf_graphs(
+                                config,
+                                str(path_test_config).replace("pose_", "inference_"),
+                                uncropped_data_path,
+                                uncropped_data_path.replace("_full_", "_meta_"),
+                            )
 
                 if len(final_result) > 0:  # Only append if results were calculated
                     make_results_file(final_result, evaluationfolder, DLCscorer)

--- a/deeplabcut/pose_estimation_tensorflow/lib/crossvalutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/crossvalutils.py
@@ -514,16 +514,6 @@ def _get_n_best_paf_graphs(
     return paf_inds, dict(zip(existing_edges, scores))
 
 
-def _filter_unwanted_paf_connections(config, paf_graph):
-    """Get rid of skeleton connections between multi and unique body parts."""
-    from itertools import combinations
-
-    cfg = auxiliaryfunctions.read_config(config)
-    multi = auxfun_multianimal.extractindividualsandbodyparts(cfg)[2]
-    desired = list(combinations(range(len(multi)), 2))
-    return [i for i, edge in enumerate(paf_graph) if tuple(edge) not in desired]
-
-
 def cross_validate_paf_graphs(
     config,
     inference_config,
@@ -547,7 +537,9 @@ def cross_validate_paf_graphs(
         metadata = pickle.load(file)
 
     params = _set_up_evaluation(data)
-    to_ignore = _filter_unwanted_paf_connections(config, params["paf_graph"])
+    to_ignore = auxfun_multianimal.filter_unwanted_paf_connections(
+        config, params["paf_graph"]
+    )
     paf_inds, paf_scores = _get_n_best_paf_graphs(
         data, metadata, params["paf_graph"], ignore_inds=to_ignore
     )

--- a/deeplabcut/pose_estimation_tensorflow/lib/crossvalutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/crossvalutils.py
@@ -538,7 +538,7 @@ def cross_validate_paf_graphs(
 
     params = _set_up_evaluation(data)
     to_ignore = auxfun_multianimal.filter_unwanted_paf_connections(
-        config, params["paf_graph"]
+        cfg, params["paf_graph"]
     )
     paf_inds, paf_scores = _get_n_best_paf_graphs(
         data, metadata, params["paf_graph"], ignore_inds=to_ignore

--- a/deeplabcut/utils/auxfun_multianimal.py
+++ b/deeplabcut/utils/auxfun_multianimal.py
@@ -10,6 +10,7 @@ Licensed under GNU Lesser General Public License v3.0
 
 import os
 import pickle
+from itertools import combinations
 from pathlib import Path
 
 import numpy as np
@@ -34,6 +35,28 @@ def IntersectionofIndividualsandOnesGivenbyUser(cfg, individuals):
         return all_indivs
     else:  # take only items in list that are actually bodyparts...
         return [ind for ind in individuals if ind in all_indivs]
+
+
+def filter_unwanted_paf_connections(cfg, paf_graph):
+    """Get rid of skeleton connections between multi and unique body parts."""
+    multi = extractindividualsandbodyparts(cfg)[2]
+    desired = list(combinations(range(len(multi)), 2))
+    return [i for i, edge in enumerate(paf_graph) if tuple(edge) not in desired]
+
+
+def validate_paf_graph(cfg, paf_graph):
+    multianimalbodyparts = extractindividualsandbodyparts(cfg)[2]
+    connected = set()
+    for bpt1, bpt2 in paf_graph:
+        connected.add(bpt1)
+        connected.add(bpt2)
+    unconnected = set(range(len(multianimalbodyparts))).difference(connected)
+    if unconnected and len(multianimalbodyparts) > 1:  # for single bpt not important!
+        raise ValueError(
+            f'Unconnected {", ".join(multianimalbodyparts[i] for i in unconnected)}. '
+            f"For multi-animal projects, all multianimalbodyparts should be connected. "
+            f"Ideally there should be at least one (multinode) path from each multianimalbodyparts to each other multianimalbodyparts. "
+        )
 
 
 def getpafgraph(cfg, printnames=True):
@@ -64,15 +87,6 @@ def getpafgraph(cfg, printnames=True):
             partaffinityfield_graph.append([bp1, bp2])
         else:
             print("Attention, parts do not exist!", link)
-
-    unconnected = set(range(len(multianimalbodyparts))).difference(connected)
-    if unconnected and len(multianimalbodyparts) > 1:  # for single bpt not important!
-        raise ValueError(
-            f'Unconnected {", ".join(multianimalbodyparts[i] for i  in unconnected)}. '
-            f"For multi-animal projects, all multianimalbodyparts should be connected. "
-            f"Ideally there should be at least one (multinode) path from each multianimalbodyparts to each other multianimalbodyparts. "
-            f"Please verify the skeleton in the config.yaml."
-        )
 
     if printnames:
         graph2names(cfg, partaffinityfield_graph)

--- a/docs/maDLC_UserGuide.md
+++ b/docs/maDLC_UserGuide.md
@@ -260,7 +260,20 @@ are listed in Box 2.
 
 - At this step, the ImageNet pre-trained networks (i.e. ResNet-50) weights will be downloaded. If they do not download (you will see this downloading in the terminal, then you may not have permission to do so (something we have seen with some Windows users - see the **[WIKI troubleshooting for more help!](https://github.com/AlexEMG/DeepLabCut/wiki/Troubleshooting-Tips)**).
 
-**CRITICAL POINT:** For **create_multianimaltraining_dataset** we already change this such that you will use imgaug, ADAM optimization, and batch training. We suggest these defaults at this time.
+**CRITICAL POINTS:**
+
+For **create_multianimaltraining_dataset** we already change this such that you will use imgaug, ADAM optimization, and batch training. We suggest these defaults at this time.
+
+Furthermore, with the data-driven skeleton selection introduced in 2.2rc1, DLC networks are trained by default
+on complete skeletons (i.e., they learn all possible redundant connections), before being pruned
+at model evaluation. Although this procedure is by far superior to manually defining a graph,
+we leave it as an option for the advanced user:
+
+```python
+my_better_graph = [[0, 1], [1, 2], [2, 3]]  # These are indices in the list of multianimalbodyparts
+deeplabcut.create_multianimaltraining_dataset(path_config_file, paf_graph=my_better_graph)
+```
+Importantly, a user-defined graph is still required to cover all multianimalbodyparts at least once. 
 
 **DATA AUGMENTATION:** At this stage you can also decide what type of augmentation to use. The default loaders work well for most all tasks (as shown on www.deeplabcut.org), but there are many options, more data augmentation, intermediate supervision, etc. Please look at the [**pose_cfg.yaml**](https://github.com/AlexEMG/DeepLabCut/blob/master/deeplabcut/pose_cfg.yaml) file for a full list of parameters **you might want to change before running this step.** There are several data loaders that can be used. For example, you can use the default loader (introduced and described in the Nature Protocols paper), [TensorPack](https://github.com/tensorpack/tensorpack) for data augmentation (currently this is easiest on Linux only), or [imgaug](https://imgaug.readthedocs.io/en/latest/). We recommend `imgaug` (which is default now!). You can set this by passing:``` deeplabcut.create_training_dataset(config_path, augmenter_type='imgaug')  ```
 
@@ -387,6 +400,11 @@ labeled accurately
 • consider labeling additional images and make another iteration of the training data set
 
 **maDeepLabCut: (or on normal projects!)**
+
+In multi-animal projects, model evaluation is crucial as this is when
+the data-driven selection of the optimal skeleton is carried out. Skipping that step
+causes video analysis to use the redundant skeleton by default, which is not only slow
+but does not guarantee best performance.
 
 You should also plot the scoremaps, locref layers, and PAFs to assess performance:
 

--- a/docs/maDLC_UserGuide.md
+++ b/docs/maDLC_UserGuide.md
@@ -229,8 +229,6 @@ deeplabcut.cropimagesandlabels(path_config_file, userfeedback=False)
 
 Ideally for training DNNs, one uses large batch sizes. Thus, for mutli-animal training batch processing is preferred. This means that we'd like the images to be similarly sized. You can of course have differing size of images you label (but we suggest cropping out useless pixels!). So, we have a new function that can pre-process your data to be compatible with batch training. As noted above, please run this function before you `create_multianmialtraining_dataset`. This function assures that each crop is "small", by default 400 x 400, which allows larger batchsizes and that there are multiple crops so that different parts of larger images are covered. 
 
-At this point you also select your neural network type. Please see Lauer et al. 2021 for options.
-
 You **should also first run** `deeplabcut.cropimagesandlabels(config_path)` before creating a training set, as we use batch processing and many users have smaller GPUs that cannot accommodate larger images + larger batchsizes. This is also a type of data augmentation.
 
 NOTE: you can edit the crop size. If your images are very large (2k, 4k pixels), consider increasing this size, but be aware unless you have a lagre GPU (24 GB or more), you will hit memory errors. _You can lower the batchsize, but this may affect performance._
@@ -238,7 +236,8 @@ NOTE: you can edit the crop size. If your images are very large (2k, 4k pixels),
 ```python
 deeplabcut.cropimagesandlabels(path_config_file, size=(400, 400), userfeedback=False)
 ```
-Then run:
+At this point you also select your neural network type. Please see Lauer et al. 2021 for options. For **create_multianimaltraining_dataset** we already changed this such that by default you will use imgaug, ADAM optimization, our new DLCRNet, and batch training. We suggest these defaults at this time. Then run:
+
 ```python
 deeplabcut.create_multianimaltraining_dataset(path_config_file)
 ```
@@ -260,14 +259,12 @@ are listed in Box 2.
 
 - At this step, the ImageNet pre-trained networks (i.e. ResNet-50) weights will be downloaded. If they do not download (you will see this downloading in the terminal, then you may not have permission to do so (something we have seen with some Windows users - see the **[WIKI troubleshooting for more help!](https://github.com/AlexEMG/DeepLabCut/wiki/Troubleshooting-Tips)**).
 
-**CRITICAL POINTS:**
+**OPTIONAL POINTS:**
 
-For **create_multianimaltraining_dataset** we already change this such that you will use imgaug, ADAM optimization, and batch training. We suggest these defaults at this time.
-
-Furthermore, with the data-driven skeleton selection introduced in 2.2rc1, DLC networks are trained by default
-on complete skeletons (i.e., they learn all possible redundant connections), before being pruned
+With the data-driven skeleton selection introduced in 2.2rc1, DLC networks are trained by default
+on complete skeletons (i.e., they learn all possible redundant connections), before being optimially pruned
 at model evaluation. Although this procedure is by far superior to manually defining a graph,
-we leave it as an option for the advanced user:
+we leave manually-defining a skeleton as an option for the advanced user:
 
 ```python
 my_better_graph = [[0, 1], [1, 2], [2, 3]]  # These are indices in the list of multianimalbodyparts


### PR DESCRIPTION
The default full graph can now be overwritten (programmatically) passing the graph definition to `deeplabcut.create_multianimaltraining_dataset(..., paf_graph=graph)`. Erroneous multi-to-unique body part connections are automatically removed, and the graph validated to ensure all body parts are reached at least once.

Fixes #1244 