### PR TITLE
Add cuda toolkit 10.0 dependency to GPU yaml file

### DIFF
--- a/conda-environments/DLC-GPU.yaml
+++ b/conda-environments/DLC-GPU.yaml
@@ -21,6 +21,7 @@ dependencies:
   - python=3.7
   - pip
   - cudnn=7
+  - cudatoolkit=10.0
   - jupyter
   - nb_conda
   - Shapely


### PR DESCRIPTION
I believe conda-forge built cudnn=7 with both cuda toolkit 10.0 and cuda toolkit 10.1. Therefore you have to specify to use the appropriate version of cuda toolkit otherwise the conda solver will default to 10.1

I believe this is what you need, but I'm not too sure.

Let me know.