### PR TITLE
fix copy of a slice from a DataFrame Pandas error in maDLC labeling t…

### DIFF
--- a/deeplabcut/gui/multiple_individuals_labeling_toolbox.py
+++ b/deeplabcut/gui/multiple_individuals_labeling_toolbox.py
@@ -1177,6 +1177,8 @@ class MainFrame(BaseFrame):
         self.updatedCoords = []
         for j, ind in enumerate(self.individual_names):
             idcolor = self.idmap(j)
+            if ind not in self.dataFrame.columns.get_level_values(1):
+                continue
             if ind == "single":
                 for c, bp in enumerate(self.uniquebodyparts):
                     image_points = [
@@ -1259,11 +1261,11 @@ class MainFrame(BaseFrame):
         """
 
         for idx, bp in enumerate(self.updatedCoords):
-            self.dataFrame.loc[self.relativeimagenames[self.iter]][
-                self.scorer, bp[-1][2], bp[0][-1], "x"
+            self.dataFrame.loc[self.relativeimagenames[self.iter],
+                (self.scorer, bp[-1][2], bp[0][-1], "x")
             ] = bp[-1][0]
-            self.dataFrame.loc[self.relativeimagenames[self.iter]][
-                self.scorer, bp[-1][2], bp[0][-1], "y"
+            self.dataFrame.loc[self.relativeimagenames[self.iter],
+                (self.scorer, bp[-1][2], bp[0][-1], "y")
             ] = bp[-1][1]
 
     def saveDataSet(self, event):


### PR DESCRIPTION
I recently ran into two errors which might not be common to most users, but arose in my somewhat complicated workflow.

First, when the number of animals varies between videos, I ran into a key error after the following:
1. set config with max number of individuals (3 for me) in any video
2. Analyze a video with a single animal, so set `n_tracks=1` for stitching
3. extract outliers, refine labels. However, some body parts were not tracked well at all, so even with max_gap = 0, some body parts have no markers in the refine labels gui, therefore...
4. open the data in `label_frames`. `CollectedData...h5` has only one individual, but the `label_frames` GUI expects the number of individuals as described in the config (3).  This produced a keyError for "ind2" for this trial.
5. So, I added a simple check in the GUI code to essentially ignore any individuals not in the CollectedData folder.

For the second fix, while opening such files in label_frames, I got a "copy of a slice from a DataFrame" error because the column part of the slice definition was set outside of the `.loc`