### PR TITLE
Rotateccw to rotatecw, unnoticed mistake in name

### DIFF
--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -297,7 +297,7 @@ class VideoWriter(VideoReader):
         self,
         width,
         height=-1,
-        rotateccw="No",
+        rotatecw="No",
         angle=0.0,
         suffix="rescale",
         dest_folder=None,
@@ -309,10 +309,10 @@ class VideoWriter(VideoReader):
         )
         # Rotate, see: https://stackoverflow.com/questions/3937387/rotating-videos-with-ffmpeg
         # interesting option to just update metadata.
-        if rotateccw == "Arbitrary":
+        if rotatecw == "Arbitrary":
             angle = np.deg2rad(angle)
             command = command.format(f", rotate={angle}")
-        elif rotateccw == "Yes":
+        elif rotatecw == "Yes":
             command = command.format(f", transpose=1")
         else:
             command = command.format("")
@@ -462,7 +462,7 @@ def DownSampleVideo(
     height=200,
     outsuffix="downsampled",
     outpath=None,
-    rotateccw="No",
+    rotatecw="No",
     angle=0.0,
 ):
     """
@@ -489,7 +489,7 @@ def DownSampleVideo(
     outpath: str
         Output path for saving video to (by default will be the same folder as the video)
 
-    rotateccw: str
+    rotatecw: str
         Default "No", rotates clockwise if "Yes", "Arbitrary" for arbitrary rotation by specified angle.
         
     angle: float
@@ -509,7 +509,7 @@ def DownSampleVideo(
     Downsamples the video to a width of 220 and height of 320 and saves it in C:\\yourusername\\rig-95\\Videos as reachingvideo1cropped.avi
     """
     writer = VideoWriter(vname)
-    return writer.rescale(width, height, rotateccw, angle, outsuffix, outpath)
+    return writer.rescale(width, height, rotatecw, angle, outsuffix, outpath)
 
 
 def draw_bbox(video):


### PR DESCRIPTION
Either left and copypasted or brainfroze on parameter naming for rotation

closes https://github.com/DeepLabCut/DeepLabCut/issues/1285