### PR TITLE
More intelligible error message when calibration fails

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
@@ -277,10 +277,16 @@ class Assembler:
         mu = np.nanmean(dists, axis=0)
         missing = np.isnan(dists)
         dists = np.where(missing, mu, dists)
-        kde = gaussian_kde(dists.T)
-        kde.mean = mu
-        self._kde = kde
-        self.safe_edge = True
+        try:
+            kde = gaussian_kde(dists.T)
+            kde.mean = mu
+            self._kde = kde
+            self.safe_edge = True
+        except np.linalg.LinAlgError:
+            # Covariance matrix estimation fails due to numerical singularities
+            warnings.warn(
+                "The assembler could not be robustly calibrated. Continuing without it..."
+            )
 
     def calc_assembly_mahalanobis_dist(
         self, assembly, return_proba=False, nan_policy="little"


### PR DESCRIPTION
In some rare cases, the covariance matrix of the graph edge lengths is not positive definite, causing the calibration to fail. The user is now warned rather than provided with the numpy error traceback (cf https://github.com/DeepLabCut/DeepLabCut/issues/1290#issuecomment-853856481).