### PR TITLE
Replace config path with cfg as input for auxiliaryfunctions.GetScorerName in COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb

### DIFF
--- a/examples/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb
+++ b/examples/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb
@@ -377,6 +377,7 @@
         "Specific_videofile = '/content/drive/My Drive/yourproject/videos/demo.mp4'\n",
         "\n",
         "from deeplabcut.utils import auxiliaryfunctions\n",
+        "cfg = auxiliaryfunctions.read_config(path_config_file)\n",
         "scorername, DLCscorerlegacy = auxiliaryfunctions.GetScorerName(path_config_file, shuffle, trainFraction=0)\n",
         "print(\"scorename is: \"+scorername)\n",
         "\n",

--- a/examples/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb
+++ b/examples/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb
@@ -379,7 +379,7 @@
         "from deeplabcut.utils import auxiliaryfunctions\n",
         "cfg = auxiliaryfunctions.read_config(path_config_file)\n",
         "scorername, DLCscorerlegacy = auxiliaryfunctions.GetScorerName(path_config_file, shuffle, trainFraction=0)\n",
-        "print(\"scorename is: \"+scorername)\n",
+        "print(\"scorername is: \"+scorername)\n",
         "\n",
         "deeplabcut.create_video_with_all_detections(path_config_file, [Specific_videofile], scorername)\n",
         "\n",

--- a/examples/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb
+++ b/examples/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb
@@ -378,7 +378,7 @@
         "\n",
         "from deeplabcut.utils import auxiliaryfunctions\n",
         "cfg = auxiliaryfunctions.read_config(path_config_file)\n",
-        "scorername, DLCscorerlegacy = auxiliaryfunctions.GetScorerName(path_config_file, shuffle, trainFraction=0)\n",
+        "scorername, DLCscorerlegacy = auxiliaryfunctions.GetScorerName(cfg, shuffle, trainFraction=0)\n",
         "print(\"scorername is: \"+scorername)\n",
         "\n",
         "deeplabcut.create_video_with_all_detections(path_config_file, [Specific_videofile], scorername)\n",


### PR DESCRIPTION
Hi,
This is my first pull request so if I did anything wrong please let me know (I started with a small one).

## Bug:
When running `` in COLAB I got the following error:
![image](https://user-images.githubusercontent.com/26007590/120958016-139bec80-c757-11eb-966c-eb3b5567a5ac.png)

## Proposed Change:
As  `testscript_multianimal.py` uses `scorer, _ = auxiliaryfunctions.GetScorerName(cfg, 1, TRAIN_SIZE)` I updated the COLAB script to use the same format.
There was also a typo in a print right after (I assume).

After fix the output of the cell looks good:
![image](https://user-images.githubusercontent.com/26007590/120958103-447c2180-c757-11eb-87ef-ae04e0283b74.png)

## Testing:
- Tested on COLAB and on Windows10 (did not run `testscript_multianimal.py` since I did not edit the module, I hope that is okay?)
- 
## Issues encountered when creating Pull request:
- Running `black` (version 21.5b2) edited all the files so I did not push post `black`, is there a specific version you use? Should I still push changes after running black?
- Editing the COLAB notebooks using my local jupyter lead to changes in the metadata, especially losing `"accelerator": "GPU"`, I ended up doing the change in the pycharm text editor directly which was okay because the change was very small but of course not the correct way of doing it, how should the COLAB scripts be edited to avoid changing the metadata?


Looking forward to contributing more!