### PR TITLE
added opencv based video check_integrity_robust

### DIFF
--- a/deeplabcut/__init__.py
+++ b/deeplabcut/__init__.py
@@ -86,8 +86,12 @@ from deeplabcut.utils import (
     auxfun_videos,
 )
 
-from deeplabcut.utils.auxfun_videos import ShortenVideo, DownSampleVideo, CropVideo
-
+from deeplabcut.utils.auxfun_videos import (
+    ShortenVideo,
+    DownSampleVideo,
+    CropVideo,
+    check_video_integrity,
+)
 
 # Train, evaluate & predict functions / all require TF
 from deeplabcut.pose_estimation_tensorflow import (

--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -42,6 +42,15 @@ class VideoReader:
         if os.path.getsize(dest) != 0:
             warnings.warn(f'Video contains errors. See "{dest}" for a detailed report.')
 
+    def check_integrity_robust(self):
+        numframes = self.video.get(cv2.CAP_PROP_FRAME_COUNT)
+        fr = 0
+        while fr < numframes:
+            success, img = self.video.read()
+            if success == False:
+                warnings.warn(f'Opencv failed to load frame {fr}. Use ffmpeg to re-encode video file')
+            fr += 1
+
     @property
     def name(self):
         return os.path.splitext(os.path.split(self.video_path)[1])[0]

--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -45,9 +45,9 @@ class VideoReader:
     def check_integrity_robust(self):
         numframes = self.video.get(cv2.CAP_PROP_FRAME_COUNT)
         fr = 0
-        while self.video.isOpened():
-            success, img = self.video.read()
-            if success == False:
+        while fr < numframes:
+            success, frame = self.video.read()
+            if not success or frame is None:
                 warnings.warn(f'Opencv failed to load frame {fr}. Use ffmpeg to re-encode video file')
             fr += 1
 

--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -45,7 +45,7 @@ class VideoReader:
     def check_integrity_robust(self):
         numframes = self.video.get(cv2.CAP_PROP_FRAME_COUNT)
         fr = 0
-        while fr < numframes:
+        while self.video.isOpened():
             success, img = self.video.read()
             if success == False:
                 warnings.warn(f'Opencv failed to load frame {fr}. Use ffmpeg to re-encode video file')
@@ -337,6 +337,11 @@ class VideoWriter(VideoReader):
             dest_folder = self.directory
         return os.path.join(dest_folder, f"{self.name}{suffix}{self.format}")
 
+def check_video_integrity(path):
+    from deeplabcut.utils.auxfun_videos import VideoReader
+    vid = VideoReader(path)
+    vid.check_integrity()
+    vid.check_integrity_robust()
 
 # Historically DLC used: from scipy.misc import imread, imresize >> deprecated functions
 def imread(path, mode=None):

--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -43,11 +43,10 @@ class VideoReader:
             warnings.warn(f'Video contains errors. See "{dest}" for a detailed report.')
 
     def check_integrity_robust(self):
-        numframes = self.video.get(cv2.CAP_PROP_FRAME_COUNT)
         fr = 0
-        while fr < numframes:
-            success, img = self.video.read()
-            if success == False:
+        while self.video.isOpened():
+            success, _ = self.video.read()
+            if not success:
                 warnings.warn(f'Opencv failed to load frame {fr}. Use ffmpeg to re-encode video file')
             fr += 1
 

--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -337,12 +337,13 @@ class VideoWriter(VideoReader):
             dest_folder = self.directory
         return os.path.join(dest_folder, f"{self.name}{suffix}{self.format}")
 
-def check_video_integrity(path):
-    from deeplabcut.utils.auxfun_videos import VideoReader
-    vid = VideoReader(path)
+    
+def check_video_integrity(video_path):
+    vid = VideoReader(video_path)
     vid.check_integrity()
     vid.check_integrity_robust()
 
+    
 # Historically DLC used: from scipy.misc import imread, imresize >> deprecated functions
 def imread(path, mode=None):
     return cv2.cvtColor(cv2.imread(path), cv2.COLOR_BGR2RGB)


### PR DESCRIPTION
### Description

Many users experience issues with "corrupted" video files. The current `check_integrity` function uses ffmpeg to check for corruption, but deeplabcut depends on opencv for video loading in some functions.  Opencv is notoriously not robust against certain types of video file corruption, so while `check_integrity` and ffmpeg may not log problems with specific video files, functions depending on opencv may still fail.

This PR adds an opencv-based `check_integrity_robust` to the VideoReader class that uses opencv to load the video frame-by-frame until either the end of the video is reached or opencv fails to read a frame. This will take a long time for long videos, but is the only way I can think (other than simply directing users to re-encode the video as trial-and-error) to demonstrate an opencv-dependent corruption problem.

### Usage

```
>>>from deeplabcut.utils.auxfun_videos import VideoReader
>>>vid = VideoReader('path/to/video')
>>>vid.check_integrity_robust()
```

### Tests

I have tested on macOS 10.15.7, but don't have any video files that I know are corrupted to test against. It logs no error for uncorrupted videos.