### PR TITLE
Create videos with all detections from a folder path

### DIFF
--- a/deeplabcut/gui/analyze_videos.py
+++ b/deeplabcut/gui/analyze_videos.py
@@ -491,7 +491,11 @@ class Analyze_videos(wx.Panel):
             )
             if self.create_video_with_all_detections.GetStringSelection() == "Yes":
                 deeplabcut.create_video_with_all_detections(
-                    self.config, self.filelist, shuffle, trainingsetindex
+                    self.config,
+                    self.filelist,
+                    videotype=self.videotype.GetValue(),
+                    shuffle=shuffle,
+                    trainingsetindex=trainingsetindex,
                 )
         else:
             scorername = deeplabcut.analyze_videos(

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -759,6 +759,7 @@ def create_video_with_keypoints_only(
 def create_video_with_all_detections(
     config,
     videos,
+    videotype="avi",
     shuffle=1,
     trainingsetindex=0,
     displayedbodyparts="all",
@@ -776,6 +777,9 @@ def create_video_with_all_detections(
     videos : list of str
         A list of strings containing the full paths to videos for analysis or a path to the directory,
         where all the videos with same extension are stored.
+
+    videotype: string, optional
+        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed. The default is ``.avi``
 
     shuffle : int, optional
         Number of shuffles of training dataset. Default is set to 1.
@@ -800,6 +804,11 @@ def create_video_with_all_detections(
     DLCscorername, _ = auxiliaryfunctions.GetScorerName(
         cfg, shuffle, trainFraction, modelprefix=modelprefix
     )
+
+    videos = auxiliaryfunctions.Getlistofvideos(videos, videotype)
+    if not videos:
+        print("No video(s) were found. Please check your paths and/or 'video_type'.")
+        return
 
     for video in videos:
         videofolder = os.path.splitext(video)[0]

--- a/docs/maDLC_UserGuide.md
+++ b/docs/maDLC_UserGuide.md
@@ -422,7 +422,7 @@ Please run:
 
 ```python
 scorername = deeplabcut.analyze_videos(config_path,['/fullpath/project/videos/testVideo.mp4'], videotype='.mp4')
-deeplabcut.create_video_with_all_detections(config_path, ['/fullpath/project/videos/testVideo.mp4'])
+deeplabcut.create_video_with_all_detections(config_path, ['/fullpath/project/videos/testVideo.mp4'], videotype='.mp4')
 ```
 Please note that you do **not** get the .h5/csv file you might be used to getting (this comes after tracking). You will get a `pickle` file that is used in `create_video_with_all_detections`. IF you have good clean out video, ending in `....full.mp4` (and the evaluation metrics look good, scoremaps look good, plotted evaluation images), then go forward!!!
 


### PR DESCRIPTION
Add the option to pass a list of folder to produce all videos at once (similar to `analyze_videos`).

Fixes #1378 