### PR TITLE
Ensure scikit-image>=0.17 in the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
         "numpy",
         "opencv-python-headless",
         "pandas>=1.0.1",
-        "scikit-image",
+        "scikit-image>=0.17",
         "scikit-learn",
         "scipy>=1.4",
         "statsmodels>=0.11",


### PR DESCRIPTION
Scikit-image>=0.17 is needed (as is already the case in the requirements.txt) to guarantee skimage.draw.disk works.

Fixes #1384 