### PR TITLE
Keep counting iterations when retraining

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/core/train.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train.py
@@ -177,9 +177,11 @@ def train(
         tf.compat.v1.summary.scalar(k, t)
     merged_summaries = tf.compat.v1.summary.merge_all()
 
-    if "snapshot" in Path(cfg["init_weights"]).stem and keepdeconvweights:
+    stem = Path(cfg["init_weights"]).stem
+    if "snapshot" in stem and keepdeconvweights:
         print("Loading already trained DLC with backbone:", net_type)
         variables_to_restore = slim.get_variables_to_restore()
+        start_iter = int(stem.split("-")[1])
     else:
         print("Loading ImageNet-pretrained", net_type)
         # loading backbone from ResNet, MobileNet etc.
@@ -200,6 +202,7 @@ def train(
             }
         else:
             print("Wait for DLC 2.3.")
+        start_iter = 0
 
     restorer = tf.compat.v1.train.Saver(variables_to_restore)
     saver = tf.compat.v1.train.Saver(
@@ -260,7 +263,7 @@ def train(
     print("Training parameter:")
     print(cfg)
     print("Starting training....")
-    for it in range(max_iter + 1):
+    for it in range(start_iter, max_iter + 1):
         if "efficientnet" in net_type:
             dict = {tstep: it}
             current_lr = sess.run(learning_rate, feed_dict=dict)

--- a/deeplabcut/pose_estimation_tensorflow/core/train.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train.py
@@ -277,7 +277,7 @@ def train(
         cum_loss += loss_val
         train_writer.add_summary(summary, it)
 
-        if it % display_iters == 0 and it > 0:
+        if it % display_iters == 0 and it > start_iter:
             average_loss = cum_loss / display_iters
             cum_loss = 0.0
             logging.info(
@@ -289,7 +289,7 @@ def train(
             lrf.flush()
 
         # Save snapshot
-        if (it % save_iters == 0 and it != 0) or it == max_iter:
+        if (it % save_iters == 0 and it != start_iter) or it == max_iter:
             model_name = cfg["snapshot_prefix"]
             saver.save(sess, model_name, global_step=it)
 

--- a/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
@@ -167,7 +167,7 @@ def train(
         cumloss += loss_val
         train_writer.add_summary(summary, it)
 
-        if it % display_iters == 0 and it > 0:
+        if it % display_iters == 0 and it > start_iter:
             logging.info(
                 "iteration: {} loss: {} scmap loss: {} locref loss: {} limb loss: {} lr: {}".format(
                     it,
@@ -194,7 +194,7 @@ def train(
             lrf.flush()
 
         # Save snapshot
-        if (it % save_iters == 0 and it != 0) or it == max_iter:
+        if (it % save_iters == 0 and it != start_iter) or it == max_iter:
             model_name = cfg["snapshot_prefix"]
             saver.save(sess, model_name, global_step=it)
 

--- a/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
@@ -73,9 +73,11 @@ def train(
     merged_summaries = tf.compat.v1.summary.merge_all()
     net_type = cfg["net_type"]
 
-    if "snapshot" in Path(cfg["init_weights"]).stem and keepdeconvweights:
+    stem = Path(cfg["init_weights"]).stem
+    if "snapshot" in stem and keepdeconvweights:
         print("Loading already trained DLC with backbone:", net_type)
         variables_to_restore = slim.get_variables_to_restore()
+        start_iter = int(stem.split("-")[1])
     else:
         print("Loading ImageNet-pretrained", net_type)
         # loading backbone from ResNet, MobileNet etc.
@@ -93,6 +95,7 @@ def train(
             }
         else:
             print("Wait for DLC 2.3.")
+        start_iter = 0
 
     restorer = tf.compat.v1.train.Saver(variables_to_restore)
     saver = tf.compat.v1.train.Saver(
@@ -142,7 +145,7 @@ def train(
     print("Training parameters:")
     print(cfg)
     print("Starting multi-animal training....")
-    for it in range(max_iter + 1):
+    for it in range(start_iter, max_iter + 1):
         if "efficientnet" in net_type:
             dict = {tstep: it}
             current_lr = sess.run(learning_rate, feed_dict=dict)

--- a/deeplabcut/pose_estimation_tensorflow/util/logging.py
+++ b/deeplabcut/pose_estimation_tensorflow/util/logging.py
@@ -10,7 +10,7 @@ def setup_logging():
     FORMAT = "%(asctime)-15s %(message)s"
     logging.basicConfig(
         filename=os.path.join("log.txt"),
-        filemode="w",
+        filemode="a",
         datefmt="%Y-%m-%d %H:%M:%S",
         level=logging.INFO,
         format=FORMAT,


### PR DESCRIPTION
Training from a user-specified snapshot resets the number of iterations to 0, independently of how long the network has been previously trained for. This is undesirable as it is confusing, overwrites previous weights, and possibly causes the snapshot with the highest # of iterations to be mistaken for the most recent one.
The iteration counter will now start back from where the model was last left.