### PR TITLE
Update DEEPLABCUT.yaml

### DIFF
--- a/conda-environments/DEEPLABCUT.yaml
+++ b/conda-environments/DEEPLABCUT.yaml
@@ -22,7 +22,6 @@ dependencies:
   - pip
   - jupyter
   - nb_conda
-  - pytables
   - ffmpeg
   - pip:
-    - deeplabcut[gui]
+    - 'deeplabcut[gui]'==2.2rc3

--- a/conda-environments/DEEPLABCUT.yaml
+++ b/conda-environments/DEEPLABCUT.yaml
@@ -24,4 +24,4 @@ dependencies:
   - nb_conda
   - ffmpeg
   - pip:
-    - 'deeplabcut[gui]'==2.2rc3
+    - "deeplabcut[gui]==2.2rc3"


### PR DESCRIPTION
Users appear to be grabbing `DEEPLABCUT.yaml` from the repo in order to install `2.2rc3`. Unfortunately, it installs 2.1.10.4, and gets tables from conda rather than pip. Therefore, the instructions elsewhere to install the newest versions of the code with this conda env file are inaccurate. 

To eliminate confusion, the repo version of `DEEPLABCUT.yaml` should be updated to the same as the version on the blog.

On windows 10, I have tried using the existing repo file to install 2.1.10.4, then running `pip install deeplabcut[gui]==2.2rc3`. While it appears to install ok, I get a tables error (seen in #1368 and #1398 ). Uninstalling pytables with conda and reinstalling with pip works sometimes (#1368), but just now I tested it again and created a tensorflow error.