### PR TITLE
DLC 2.2 for macoS M1 chips

### DIFF
--- a/conda-environments/DEEPLABCUT_M1.yaml
+++ b/conda-environments/DEEPLABCUT_M1.yaml
@@ -1,0 +1,36 @@
+# DEEPLABCUT_M1.yaml
+
+#DeepLabCut2.0 Toolbox (deeplabcut.org)
+#© A. & M. Mathis Labs
+#https://github.com/DeepLabCut/DeepLabCut
+#Please see AUTHORS for contributors.
+
+#https://github.com/DeepLabCut/DeepLabCut/blob/master/AUTHORS
+#Licensed under GNU Lesser General Public License v3.0
+#
+# DeepLabCut M1 environment instructions:
+# For the M1 chip, please first download the Rosetta wheel for tensorflow 2.4.1:
+# https://drive.google.com/file/d/17pSwfoNuyf3YR8vCaVggHeI-pMQ3xL7l/view?usp=sharing
+#
+# Then, run:
+#
+# conda env create -f DEEPLABCUT_M1.yaml
+#
+# Next, activate the environment, and in the terminal cd to  Downloads, and then run:
+# pip install tensorflow-2.4.1-py3-none-any.whl --no-dependencies --force-reinstall
+#
+# Next, launch DLC with pythonw -m deeplabcut
+
+name: DEEPLABCUT_M1
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.7
+  - pip
+  - jupyter
+  - nb_conda
+  - python.app
+  - ffmpeg
+  - pip:
+    - "deeplabcut[gui]>=2.2rc3"

--- a/docs/recipes/installTips.md
+++ b/docs/recipes/installTips.md
@@ -287,3 +287,34 @@ done
 Activate! `conda activate DEEPLABCUT` and then run: `conda install -c conda-forge wxpython` ... after this finishes, run: `pip install deeplabcut[gui]`
 
 Now you might get some warnings, but for me it was then totally fine to run `python -m deeplabcut` which launches the DLC GUI!
+
+
+
+## DeepLabCut M1 chip installation environment instructions:
+
+This only assumes you have anaconda installed!
+
+Use the `DEEPLABCUT_M1.yaml` conda file if you have an Macbok with an M1 chip, and follow these steps:
+
+(1) git clone the deeplabcut cut repo:
+
+`git clone https://github.com/DeepLabCut/DeepLabCut.git`
+
+(2) in the program terminal, `cd DeepLabCut/conda-environments`
+
+(3) Click here to download the Rosetta wheel for TensorFlow 2.4.1:
+https://drive.google.com/file/d/17pSwfoNuyf3YR8vCaVggHeI-pMQ3xL7l/view?usp=sharing
+
+(4) Then, run:
+
+`conda env create -f DEEPLABCUT_M1.yaml`
+
+(5) Next, **activate the environment,** and in the terminal `cd` to  Downloads, and then run:
+
+`pip install tensorflow-2.4.1-py3-none-any.whl --no-dependencies --force-reinstall`
+
+(6) Next, launch DLC with `pythonw -m deeplabcut`
+
+GUI will open!
+
+Note: Based on issue #1380 thanks!

--- a/docs/recipes/installTips.md
+++ b/docs/recipes/installTips.md
@@ -302,8 +302,11 @@ Use the `DEEPLABCUT_M1.yaml` conda file if you have an Macbok with an M1 chip, a
 
 (2) in the program terminal, `cd DeepLabCut/conda-environments`
 
-(3) Click here to download the Rosetta wheel for TensorFlow 2.4.1:
+(3) Click here to download the Rosetta wheel for TensorFlow.
+
+For instance, for 2.4.1:
 https://drive.google.com/file/d/17pSwfoNuyf3YR8vCaVggHeI-pMQ3xL7l/view?usp=sharing
+(for different versions see here: https://github.com/tensorflow/tensorflow/issues/46044)
 
 (4) Then, run:
 


### PR DESCRIPTION
Based on issue #1380, and in particular comment https://github.com/DeepLabCut/DeepLabCut/issues/1380#issuecomment-880386594, here is a DLC environment that works on M1 chips (freshly acquired - today - macbook pro was used for testing that had High Sierra installed). 

Use this (DEEPLABCUT_M1.yaml) conda file if you have an M1, and follow these steps:

### DeepLabCut M1 chip installation environment instructions (assuming you have anaconda installed!):

(1) git clone the deeplabcut cut repo:

`git clone https://github.com/DeepLabCut/DeepLabCut.git`

(2) in the program terminal, `cd DeepLabCut/conda-environments`

(3) Click here to download the Rosetta wheel for TensorFlow 2.4.1:
https://drive.google.com/file/d/17pSwfoNuyf3YR8vCaVggHeI-pMQ3xL7l/view?usp=sharing

(4) Then, run:

`conda env create -f DEEPLABCUT_M1.yaml`

(5) Next, **activate the environment,** and in the terminal `cd` to  Downloads, and then run:

`pip install tensorflow-2.4.1-py3-none-any.whl --no-dependencies --force-reinstall`

(6) Next, launch DLC with `pythonw -m deeplabcut`

GUI will open!