### PR TITLE
shift tracklets['single'] as 'frame based' 

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -16,6 +16,7 @@ import argparse
 import os
 import os.path
 import pickle
+import re
 import time
 from pathlib import Path
 
@@ -1461,7 +1462,14 @@ def convert_detections2tracklets(
                     "uniquebodyparts"
                 ]:  # Initialize storage of the 'single' individual track
                     tracklets["single"] = {}
-                    tracklets["single"].update(ass.unique)
+                    _single = {}
+                    for index, imname in enumerate(imnames):
+                        single_detection = ass.unique.get(index)
+                        if single_detection is None:
+                            continue
+                        imindex = int(re.findall(r"\d+", imname)[0])
+                        _single[imindex] = single_detection
+                    tracklets["single"].update(_single)
 
                 keep = set(multi_bpts).difference(ignore_bodyparts or [])
                 keep_inds = sorted(multi_bpts.index(bpt) for bpt in keep)


### PR DESCRIPTION
As I was mentioning in my comment [here](https://github.com/DeepLabCut/DeepLabCut/issues/949#issuecomment-902347902) I got a problem when the detection of my unique label was not present since the first frame, the after running `            d.convert_detections2tracklets(config_path, videos=videos)` the individual where shifted as shown in my comment:
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/11966855/130233782-312d2ac9-1da9-4167-9514-70aaf59aff23.png">

this is fixed if we use the frame numbers as index, the same way that is done for the other multiparts, then the shift is not there anymore:
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/11966855/130233701-20cb00e6-3c1a-4544-b0cd-8392d20b35e0.png">
