### PR TITLE
split videos without reencoding.

### DIFF
--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -248,7 +248,7 @@ class VideoWriter(VideoReader):
         output_path = self.make_output_path(suffix, dest_folder)
         command = (
             f"ffmpeg -n -i {self.video_path} -ss {start} -to {end} "
-            f"-c:a copy {output_path}"
+            f"-c copy {output_path}"
         )
         subprocess.call(command, shell=True)
         return output_path


### PR DESCRIPTION
very minor fix. modifies ffmpeg command to allow copying the codecs from input file to output file when splitting. previous code was only copying audio codec ("-c:a") and not the video resulting in re encoding and loss of quality.

