### PR TITLE
Fix image color when labeling with epipolar lines 

### DIFF
--- a/deeplabcut/gui/labeling_toolbox.py
+++ b/deeplabcut/gui/labeling_toolbox.py
@@ -163,14 +163,12 @@ class ImagePanel(BasePanel):
         xlim = self.axes.get_xlim()
         ylim = self.axes.get_ylim()
         self.axes.clear()
-
-        im = cv2.imread(img)
-        im = cv2.cvtColor(im, cv2.COLOR_BGR2RGB)        
+        im = cv2.imread(img)[..., ::-1]
         colorIndex = np.linspace(np.max(im), np.min(im), len(bodyparts))
         # draw epipolar lines
         epLines, sourcePts, offsets = self.retrieveData_and_computeEpLines(img, itr)
         if epLines is not None:
-            im = self.drawEpLines(im, epLines, sourcePts, offsets, colorIndex, cmap)
+            im = self.drawEpLines(im.copy(), epLines, sourcePts, offsets, colorIndex, cmap)
         ax = self.axes.imshow(im, cmap=cmap)
         self.orig_xlim = self.axes.get_xlim()
         self.orig_ylim = self.axes.get_ylim()

--- a/deeplabcut/gui/labeling_toolbox.py
+++ b/deeplabcut/gui/labeling_toolbox.py
@@ -139,9 +139,7 @@ class ImagePanel(BasePanel):
             return None, None, None
 
     def drawEpLines(self, drawImage, lines, sourcePts, offsets, colorIndex, cmap):
-        drawImage = cv2.cvtColor(drawImage, cv2.COLOR_BGR2RGB)
         height, width, depth = drawImage.shape
-        labelNum = 0
         for line, pt, cIdx in zip(lines, sourcePts, colorIndex):
             if pt[0] > -1000:
                 coeffs = line[0]
@@ -166,7 +164,8 @@ class ImagePanel(BasePanel):
         ylim = self.axes.get_ylim()
         self.axes.clear()
 
-        im = cv2.imread(img)[..., ::-1]
+        im = cv2.imread(img)
+        im = cv2.cvtColor(im, cv2.COLOR_BGR2RGB)        
         colorIndex = np.linspace(np.max(im), np.min(im), len(bodyparts))
         # draw epipolar lines
         epLines, sourcePts, offsets = self.retrieveData_and_computeEpLines(img, itr)

--- a/deeplabcut/gui/labeling_toolbox.py
+++ b/deeplabcut/gui/labeling_toolbox.py
@@ -163,6 +163,7 @@ class ImagePanel(BasePanel):
         xlim = self.axes.get_xlim()
         ylim = self.axes.get_ylim()
         self.axes.clear()
+        # convert the image to RGB as you are showing the image with matplotlib
         im = cv2.imread(img)[..., ::-1]
         colorIndex = np.linspace(np.max(im), np.min(im), len(bodyparts))
         # draw epipolar lines

--- a/deeplabcut/gui/multiple_individuals_labeling_toolbox.py
+++ b/deeplabcut/gui/multiple_individuals_labeling_toolbox.py
@@ -167,8 +167,7 @@ class ImagePanel(BasePanel):
         xlim = self.axes.get_xlim()
         ylim = self.axes.get_ylim()
         self.axes.clear()
-        im = cv2.imread(img)
-        im = cv2.cvtColor(im, cv2.COLOR_BGR2RGB)
+        im = cv2.imread(img)[..., ::-1]
         colorIndex = []
         for indiv in range(len(individuals)):
             colorIndex.extend(np.linspace(np.max(im), np.min(im), len(bodyparts)))
@@ -176,8 +175,7 @@ class ImagePanel(BasePanel):
         # draw epipolar lines
         epLines, sourcePts, offsets = self.retrieveData_and_computeEpLines(img, itr)
         if epLines is not None:
-            im = self.drawEpLines(im, epLines, sourcePts, offsets, colorIndex, cmap)
-
+            im = self.drawEpLines(im.copy(), epLines, sourcePts, offsets, colorIndex, cmap)
         ax = self.axes.imshow(im, cmap=cmap)
         self.orig_xlim = self.axes.get_xlim()
         self.orig_ylim = self.axes.get_ylim()

--- a/deeplabcut/gui/multiple_individuals_labeling_toolbox.py
+++ b/deeplabcut/gui/multiple_individuals_labeling_toolbox.py
@@ -167,6 +167,7 @@ class ImagePanel(BasePanel):
         xlim = self.axes.get_xlim()
         ylim = self.axes.get_ylim()
         self.axes.clear()
+        # convert the image to RGB as you are showing the image with matplotlib
         im = cv2.imread(img)[..., ::-1]
         colorIndex = []
         for indiv in range(len(individuals)):

--- a/deeplabcut/gui/multiple_individuals_labeling_toolbox.py
+++ b/deeplabcut/gui/multiple_individuals_labeling_toolbox.py
@@ -143,7 +143,6 @@ class ImagePanel(BasePanel):
             return None, None, None
 
     def drawEpLines(self, drawImage, lines, sourcePts, offsets, colorIndex, cmap):
-        drawImage = cv2.cvtColor(drawImage, cv2.COLOR_BGR2RGB)
         height, width, depth = drawImage.shape
         for line, pt, cIdx in zip(lines, sourcePts, colorIndex):
             if pt[0] > -1000:
@@ -168,9 +167,8 @@ class ImagePanel(BasePanel):
         xlim = self.axes.get_xlim()
         ylim = self.axes.get_ylim()
         self.axes.clear()
-        #        im = cv2.imread(img)
-        # convert the image to RGB as you are showing the image with matplotlib
-        im = cv2.imread(img)[..., ::-1]
+        im = cv2.imread(img)
+        im = cv2.cvtColor(im, cv2.COLOR_BGR2RGB)
         colorIndex = []
         for indiv in range(len(individuals)):
             colorIndex.extend(np.linspace(np.max(im), np.min(im), len(bodyparts)))

--- a/deeplabcut/pose_estimation_tensorflow/lib/crossvalutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/crossvalutils.py
@@ -18,8 +18,6 @@ import networkx as nx
 import numpy as np
 import pandas as pd
 from scipy.spatial import cKDTree
-from scipy.spatial.distance import cdist
-from scipy.optimize import linear_sum_assignment
 from sklearn.metrics.cluster import contingency_matrix
 
 from deeplabcut.pose_estimation_tensorflow.lib.inferenceutils import (
@@ -124,10 +122,12 @@ def _calc_within_between_pafs(
         except KeyError:
             pass
         bpts = df.index.get_level_values("bodyparts").unique().to_list()
-        coords_gt = (df.unstack(["individuals", "coords"])
-                     .reindex(bpts, level="bodyparts")
-                     .to_numpy()
-                     .reshape((len(bpts), -1, 2)))
+        coords_gt = (
+            df.unstack(["individuals", "coords"])
+            .reindex(bpts, level="bodyparts")
+            .to_numpy()
+            .reshape((len(bpts), -1, 2))
+        )
         coords = dict_["prediction"]["coordinates"][0]
         # Get animal IDs and corresponding indices in the arrays of detections
         lookup = dict()
@@ -287,7 +287,9 @@ def _get_n_best_paf_graphs(
         raise ValueError('`which` must be either "best" or "worst"')
 
     (within_train, _), (between_train, _) = _calc_within_between_pafs(
-        data, metadata, train_set_only=True,
+        data,
+        metadata,
+        train_set_only=True,
     )
     # Handle unlabeled bodyparts...
     existing_edges = set(k for k, v in within_train.items() if v)
@@ -297,10 +299,7 @@ def _get_n_best_paf_graphs(
 
     if not any(between_train.values()):
         # Only 1 animal, let us return the full graph indices only
-        return (
-            [existing_edges],
-            dict(zip(existing_edges, [0] * len(existing_edges)))
-        )
+        return ([existing_edges], dict(zip(existing_edges, [0] * len(existing_edges))))
 
     scores, _ = zip(
         *[

--- a/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
@@ -135,7 +135,10 @@ class Assembly:
 
     @property
     def affinity(self):
-        return self._affinity / self.n_links
+        n_links = self.n_links
+        if not n_links:
+            return 0
+        return self._affinity / n_links
 
     @property
     def n_links(self):
@@ -914,7 +917,10 @@ def evaluate_assembly(
             "mAR": 0.0,
         }
 
-    oks = np.asarray([match[2] for match in all_matched])
+    conf_pred = np.asarray([match[0].affinity for match in all_matched])
+    idx = np.argsort(-conf_pred, kind="mergesort")
+    # Sort matching score (OKS) in descending order of assembly affinity
+    oks = np.asarray([match[2] for match in all_matched])[idx]
     ntot = len(all_matched) + len(all_unmatched)
     recall_thresholds = np.linspace(0, 1, 101)
     precisions = []
@@ -925,7 +931,11 @@ def evaluate_assembly(
         rc = tp / ntot
         pr = tp / (fp + tp + np.spacing(1))
         recall = rc[-1]
-        pr = np.sort(pr)[::-1]
+        # Guarantee precision decreases monotonically
+        # See https://jonathan-hui.medium.com/map-mean-average-precision-for-object-detection-45c121a31173)
+        for i in range(len(pr) - 1, 0, -1):
+            if pr[i] > pr[i - 1]:
+                pr[i - 1] = pr[i]
         inds_rc = np.searchsorted(rc, recall_thresholds)
         precision = np.zeros(inds_rc.shape)
         valid = inds_rc < len(pr)

--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -248,7 +248,7 @@ class VideoWriter(VideoReader):
         output_path = self.make_output_path(suffix, dest_folder)
         command = (
             f"ffmpeg -n -i {self.video_path} -ss {start} -to {end} "
-            f"-c copy {output_path}"
+            f"-c:a copy {output_path}"
         )
         subprocess.call(command, shell=True)
         return output_path


### PR DESCRIPTION
After PR #834 was merged and closed, I noticed that some of the lines that dealt with BGR --> RGB conversion had not been accepted, which resulted in images displayed with the reversed colors when labeling with epipolar lines. My previous lines to address this were clunky, so I've removed them. Now I just pass im.copy() into the drawEpLines function rather than im - this is necessary because cv2 can't work with arrays that are views of other arrays with shared memory. Separately, I added back a comment to make the multiple_individuals and basic toolboxes more similar.

Thank you in advance for your time. 