### PR TITLE
Unpin numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ jupyter-book>=0.7.0b
 numba
 matplotlib
 networkx
-numpy>=1.21
+numpy
 opencv-python-headless
 pandas>=1.0.1
 patsy

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
         "numba",
         "matplotlib",
         "networkx",
-        "numpy>=1.21",
+        "numpy",
         "opencv-python-headless",
         "pandas>=1.0.1",
         "scikit-image>=0.17",


### PR DESCRIPTION
Unpin numpy in order for tensorflow >= 2.2 to function.

Fixes #1486 #1487 