### PR TITLE
Fix: Impossible to go back up after using DOWN arrow

### DIFF
--- a/deeplabcut/gui/labeling_toolbox.py
+++ b/deeplabcut/gui/labeling_toolbox.py
@@ -552,7 +552,7 @@ class MainFrame(BaseFrame):
         """
         This function is to create a hotkey to skip up on the radio button panel.
         """
-        if self.rdb.GetSelection() < len(self.bodyparts) - 1:
+        if self.rdb.GetSelection() > 0:
             self.rdb.SetSelection(self.rdb.GetSelection() - 1)
 
     def browseDir(self, event):

--- a/deeplabcut/gui/multiple_individuals_labeling_toolbox.py
+++ b/deeplabcut/gui/multiple_individuals_labeling_toolbox.py
@@ -704,7 +704,7 @@ class MainFrame(BaseFrame):
         """
         This function is to create a hotkey to skip up on the radio button panel.
         """
-        if self.rdb.GetSelection() < len(self.multibodyparts) - 1:
+        if self.rdb.GetSelection() > 0:
             self.rdb.SetSelection(self.rdb.GetSelection() - 1)
 
     def browseDir(self, event):


### PR DESCRIPTION
When using the DOWN arrow to switch body part, and going to the last one it was impossible to go back up again. See: https://github.com/DeepLabCut/DeepLabCut/pull/319#issuecomment-500646205

This is a very small change in the code of labeling_toolbox.py, just changing a condition, no new function or functionality is added. 