### PR TITLE
Update python-package.yml

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip
-          - os: macos-latest
+          - os: macOS-10.15
             path: ~/Library/Caches/pip
           - os: windows-latest
             path: ~\AppData\Local\pip\Cache

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -56,9 +56,6 @@ jobs:
 
       - name: Run functional tests
         run: |
-          if [ "$RUNNER_OS" == "macOS" ]; then
-              pass
-          else
-            pip install git+git://github.com/${{ github.repository }}.git@${{ github.sha }}
-            python examples/testscript.py
-            python examples/testscript_multianimal.py
+          pip install git+git://github.com/${{ github.repository }}.git@${{ github.sha }}
+          python examples/testscript.py
+          python examples/testscript_multianimal.py

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run functional tests
         run: |
           if [ "$RUNNER_OS" == "macOS" ]; then
-              print('skipping fxn tests on MacOS only')
+              pass
           else
             pip install git+git://github.com/${{ github.repository }}.git@${{ github.sha }}
             python examples/testscript.py

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip
-          - os: macOS-10.15
+          - os: macos-latest #macOS-10.15
             path: ~/Library/Caches/pip
           - os: windows-latest
             path: ~\AppData\Local\pip\Cache

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -56,6 +56,9 @@ jobs:
 
       - name: Run functional tests
         run: |
-          pip install git+git://github.com/${{ github.repository }}.git@${{ github.sha }}
-          python examples/testscript.py
-          python examples/testscript_multianimal.py
+          if [ "$RUNNER_OS" == "macOS" ]; then
+              print('skipping fxn tests on MacOS only')
+          else
+            pip install git+git://github.com/${{ github.repository }}.git@${{ github.sha }}
+            python examples/testscript.py
+            python examples/testscript_multianimal.py

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip
-          - os: macos-latest #macOS-10.15
+          - os: macOS-10.15
             path: ~/Library/Caches/pip
           - os: windows-latest
             path: ~\AppData\Local\pip\Cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,6 @@ tensorflow>=2.0
 tables
 tensorpack
 tf_slim
-tqdm
+tqdm>=4.50
 moviepy
 Pillow>=7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,6 @@ tensorflow>=2.0
 tables
 tensorpack
 tf_slim
-tqdm>=4.50
+tqdm
 moviepy
 Pillow>=7.1


### PR DESCRIPTION
note, macOS support is being rolled up to big sur + by default; propose to leave at 10.15 for now... https://github.com/actions/virtual-environments/issues/4060

https://dbaontap.com/2019/11/11/python-abort-trap-6-fix-after-catalina-update/