### PR TITLE
Update print statements for video analysis, evaluation, tracking

### DIFF
--- a/deeplabcut/generate_training_dataset/frame_extraction.py
+++ b/deeplabcut/generate_training_dataset/frame_extraction.py
@@ -1,10 +1,10 @@
 """
 DeepLabCut2.0 Toolbox (deeplabcut.org)
 © A. & M. Mathis Labs
-https://github.com/AlexEMG/DeepLabCut
+https://github.com/DeepLabCut/DeepLabCut
 
 Please see AUTHORS for contributors.
-https://github.com/AlexEMG/DeepLabCut/blob/master/AUTHORS
+https://github.com/DeepLabCut/DeepLabCut/blob/master/AUTHORS
 Licensed under GNU Lesser General Public License v3.0
 """
 
@@ -393,10 +393,10 @@ def extract_frames(
         elif any(has_failed):
             print("Although most frames were extracted, some were invalid.")
         else:
-            print("Frames were successfully extracted, for the videos of interest.")
+            print("Frames were successfully extracted, for the videos listed in the config.yaml file.")
         print(
             "\nYou can now label the frames using the function 'label_frames' "
-            "(if you extracted enough frames for all videos)."
+            "(Note, you should label frames extracted from diverse videos (and many videos; we do not recommend training on single videos!))."
         )
 
     elif mode == "match":

--- a/deeplabcut/gui/analyze_videos.py
+++ b/deeplabcut/gui/analyze_videos.py
@@ -454,7 +454,7 @@ class Analyze_videos(wx.Panel):
         trainingsetindex = self.trainingset.GetValue()
 
         if self.cfg.get("multianimalproject", False):
-            print("Analyzing ... ")
+            print("DLC network loading and video analysis starting ... ")
         else:
             if self.csv.GetStringSelection() == "Yes":
                 save_as_csv = True

--- a/deeplabcut/gui/create_training_dataset.py
+++ b/deeplabcut/gui/create_training_dataset.py
@@ -144,7 +144,6 @@ class Create_training_dataset(wx.Panel):
         if config_file.get("multianimalproject", False):
 
             self.model_comparison_choice = "No"
-            print("currently DLCRNet is only supported in multi-animal mode")
         else:
             self.model_comparison_choice = wx.RadioBox(
                 self,

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -751,7 +751,7 @@ def evaluate_network(
                     print(
                         "Running ",
                         DLCscorer,
-                        " with # of trainingiterations:",
+                        " with # of training iterations:",
                         trainingsiterations,
                     )
                     (
@@ -771,7 +771,7 @@ def evaluate_network(
                         PredicteData = np.zeros(
                             (Numimages, 3 * len(dlc_cfg["all_joints_names"]))
                         )
-                        print("Analyzing data...")
+                        print("Running evaluation ...")
                         for imageindex, imagename in tqdm(enumerate(Data.index)):
                             image = imread(
                                 os.path.join(cfg["project_path"], imagename), mode="RGB"
@@ -818,7 +818,7 @@ def evaluate_network(
                         )
 
                         print(
-                            "Done and results stored for snapshot: ",
+                            "Analysis is done and the results are stored (see evaluation-results) for snapshot: ",
                             Snapshots[snapindex],
                         )
                         DataCombined = pd.concat(
@@ -938,10 +938,10 @@ def evaluate_network(
                         "The network is evaluated and the results are stored in the subdirectory 'evaluation_results'."
                     )
                     print(
-                        "If it generalizes well, choose the best model for prediction and update the config file with the appropriate index for the 'snapshotindex'.\nUse the function 'analyze_video' to make predictions on new videos."
+                        "Please check the results, then choose the best model (snapshot) for prediction. You can update the config.yaml file with the appropriate index for the 'snapshotindex'.\nUse the function 'analyze_video' to make predictions on new videos."
                     )
                     print(
-                        "Otherwise consider retraining the network (see DeepLabCut workflow Fig 2)"
+                        "Otherwise, consider adding more labeled-data and retraining the network (see DeepLabCut workflow Fig 2, Nath 2019)"
                     )
 
     # returning to intial folder

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -1,10 +1,10 @@
 """
 DeepLabCut2.0 Toolbox (deeplabcut.org)
 © A. & M. Mathis Labs
-https://github.com/AlexEMG/DeepLabCut
+https://github.com/DeepLabCut/DeepLabCut
 
 Please see AUTHORS for contributors.
-https://github.com/AlexEMG/DeepLabCut/blob/master/AUTHORS
+https://github.com/DeepLabCut/DeepLabCut/blob/master/AUTHORS
 Licensed under GNU Lesser General Public License v3.0
 """
 

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -467,7 +467,7 @@ def evaluate_multianimal_full(
 
                         if show_errors:
                             string = (
-                                "Results for {} training iterations: {}, shuffle {}:\n"
+                                "Results for {} training iterations, training fraction of {}, and shuffle {}:\n"
                                 "Train error: {} pixels. Test error: {} pixels.\n"
                                 "With pcutoff of {}:\n"
                                 "Train error: {} pixels. Test error: {} pixels."

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -307,7 +307,7 @@ def evaluate_multianimal_full(
                         PredicteData = {}
                         dist = np.full((len(Data), len(all_bpts)), np.nan)
                         conf = np.full_like(dist, np.nan)
-                        print("Analyzing data...")
+                        print("Network Evaluation underway...")
                         for imageindex, imagename in tqdm(enumerate(Data.index)):
                             image_path = os.path.join(cfg["project_path"], imagename)
                             image = io.imread(image_path)

--- a/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
@@ -198,10 +198,11 @@ def train(
             model_name = cfg["snapshot_prefix"]
             saver.save(sess, model_name, global_step=it)
 
+    sess.close()
     lrf.close()
     coord.request_stop()
     coord.join([thread])
-    sess.close()
+    
         
     # return to original path.
     os.chdir(str(start_path))

--- a/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
@@ -202,6 +202,10 @@ def train(
     coord.request_stop()
     coord.join([thread])
     sess.close()
+    
+    from numba import cuda
+        cuda.close()
+        
     # return to original path.
     os.chdir(str(start_path))
 

--- a/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
@@ -199,10 +199,9 @@ def train(
             saver.save(sess, model_name, global_step=it)
 
     lrf.close()
-
-    sess.close()
     coord.request_stop()
     coord.join([thread])
+    sess.close()
     # return to original path.
     os.chdir(str(start_path))
 

--- a/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
@@ -202,9 +202,6 @@ def train(
     coord.request_stop()
     coord.join([thread])
     sess.close()
-    
-    from numba import cuda
-    cuda.close()
         
     # return to original path.
     os.chdir(str(start_path))

--- a/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
@@ -198,8 +198,8 @@ def train(
             model_name = cfg["snapshot_prefix"]
             saver.save(sess, model_name, global_step=it)
 
-    
     lrf.close()
+    
     sess.close()
     coord.request_stop()
     coord.join([thread])

--- a/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
@@ -204,7 +204,7 @@ def train(
     sess.close()
     
     from numba import cuda
-        cuda.close()
+    cuda.close()
         
     # return to original path.
     os.chdir(str(start_path))

--- a/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
@@ -198,8 +198,9 @@ def train(
             model_name = cfg["snapshot_prefix"]
             saver.save(sess, model_name, global_step=it)
 
-    sess.close()
+    
     lrf.close()
+    sess.close()
     coord.request_stop()
     coord.join([thread])
     

--- a/deeplabcut/pose_estimation_tensorflow/predict_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_multianimal.py
@@ -74,7 +74,7 @@ def AnalyzeMultiAnimalVideo(
         )
         start = time.time()
 
-        print("Starting to extract posture")
+        print("Starting to extract posture from the video(s) with batchsize:", dlc_cfg["batch_size"])
         if int(dlc_cfg["batch_size"]) > 1:
             PredicteData, nframes = GetPoseandCostsF(
                 cfg,
@@ -114,7 +114,7 @@ def AnalyzeMultiAnimalVideo(
             "cropping_parameters": coords,
         }
         metadata = {"data": dictionary}
-        print("Saving results in %s..." % (destfolder))
+        print("Video Analyzed. Saving results in %s..." % (destfolder))
 
         _ = auxfun_multianimal.SaveFullMultiAnimalData(PredicteData, metadata, dataname)
 

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1503,8 +1503,7 @@ def convert_detections2tracklets(
 
         os.chdir(str(start_path))
 
-        print("The tracklets were created. Now you can 'refine_tracklets'.")
-        # print("If the tracking is not satisfactory for some videos, consider expanding the training set. You can use the function 'extract_outlier_frames' to extract any outlier frames!")
+        print("The tracklets were created (i.e., under the hood deeplabcut.convert_detections2tracklets was run). Now you can 'refine_tracklets' in the GUI, or run 'deeplabcut.stitch_tracklets'.")
     else:
         print("No video(s) found. Please check your path!")
 

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -291,7 +291,7 @@ def attempttomakefolder(foldername, recursive=False):
         )  # https://github.com/AlexEMG/DeepLabCut/issues/105 (windows)
 
     if os.path.isdir(foldername):
-        print(foldername, " already exists!")
+        pass
     else:
         if recursive:
             os.makedirs(foldername)

--- a/examples/testscript.py
+++ b/examples/testscript.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
     print("EXTRACTING FRAMES")
     if platform.system() == "Darwin":
         deeplabcut.extract_frames(path_config_file, mode="automatic", userfeedback=False, opencv=False) 
-    else 
+    else: 
         deeplabcut.extract_frames(path_config_file, mode="automatic", userfeedback=False, opencv=True) 
         
     print("CREATING-SOME LABELS FOR THE FRAMES")

--- a/examples/testscript.py
+++ b/examples/testscript.py
@@ -71,10 +71,7 @@ if __name__ == "__main__":
     deeplabcut.auxiliaryfunctions.write_config(path_config_file, cfg)
 
     print("EXTRACTING FRAMES")
-    if platform.system() == "Darwin":
-        deeplabcut.extract_frames(path_config_file, mode="automatic", userfeedback=False, opencv=False) 
-    else: 
-        deeplabcut.extract_frames(path_config_file, mode="automatic", userfeedback=False, opencv=True) 
+    deeplabcut.extract_frames(path_config_file, mode="automatic", userfeedback=False) 
         
     print("CREATING-SOME LABELS FOR THE FRAMES")
     frames = os.listdir(os.path.join(cfg["project_path"], "labeled-data", videoname))

--- a/examples/testscript.py
+++ b/examples/testscript.py
@@ -71,8 +71,11 @@ if __name__ == "__main__":
     deeplabcut.auxiliaryfunctions.write_config(path_config_file, cfg)
 
     print("EXTRACTING FRAMES")
-    deeplabcut.extract_frames(path_config_file, mode="automatic", userfeedback=False)
-
+    if platform.system() == "Darwin" 
+        deeplabcut.extract_frames(path_config_file, mode="automatic", userfeedback=False, opencv=False) 
+    else 
+        deeplabcut.extract_frames(path_config_file, mode="automatic", userfeedback=False, opencv=True) 
+        
     print("CREATING-SOME LABELS FOR THE FRAMES")
     frames = os.listdir(os.path.join(cfg["project_path"], "labeled-data", videoname))
     # As this next step is manual, we update the labels by putting them on the diagonal (fixed for all frames)

--- a/examples/testscript.py
+++ b/examples/testscript.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
     deeplabcut.auxiliaryfunctions.write_config(path_config_file, cfg)
 
     print("EXTRACTING FRAMES")
-    if platform.system() == "Darwin" 
+    if platform.system() == "Darwin":
         deeplabcut.extract_frames(path_config_file, mode="automatic", userfeedback=False, opencv=False) 
     else 
         deeplabcut.extract_frames(path_config_file, mode="automatic", userfeedback=False, opencv=True) 

--- a/testscript_cli.py
+++ b/testscript_cli.py
@@ -71,7 +71,7 @@ cfg["skeleton"] = [["bodypart1", "bodypart2"], ["bodypart1", "bodypart3"]]
 dlc.auxiliaryfunctions.write_config(path_config_file, cfg)
 
 print("EXTRACTING FRAMES")
-dlc.extract_frames(path_config_file, mode="automatic", userfeedback=False, opencv=False)
+dlc.extract_frames(path_config_file, mode="automatic", userfeedback=False, opencv=True)
 
 print("CREATING SOME LABELS FOR THE FRAMES")
 frames = os.listdir(os.path.join(cfg["project_path"], "labeled-data", videoname))

--- a/testscript_cli.py
+++ b/testscript_cli.py
@@ -71,7 +71,7 @@ cfg["skeleton"] = [["bodypart1", "bodypart2"], ["bodypart1", "bodypart3"]]
 dlc.auxiliaryfunctions.write_config(path_config_file, cfg)
 
 print("EXTRACTING FRAMES")
-dlc.extract_frames(path_config_file, mode="automatic", userfeedback=False, opencv=True)
+dlc.extract_frames(path_config_file, mode="automatic", userfeedback=False)
 
 print("CREATING SOME LABELS FOR THE FRAMES")
 frames = os.listdir(os.path.join(cfg["project_path"], "labeled-data", videoname))

--- a/testscript_cli.py
+++ b/testscript_cli.py
@@ -71,7 +71,7 @@ cfg["skeleton"] = [["bodypart1", "bodypart2"], ["bodypart1", "bodypart3"]]
 dlc.auxiliaryfunctions.write_config(path_config_file, cfg)
 
 print("EXTRACTING FRAMES")
-dlc.extract_frames(path_config_file, mode="automatic", userfeedback=False)
+dlc.extract_frames(path_config_file, mode="automatic", userfeedback=False, opencv=False)
 
 print("CREATING SOME LABELS FOR THE FRAMES")
 frames = os.listdir(os.path.join(cfg["project_path"], "labeled-data", videoname))


### PR DESCRIPTION
I cleaned up print statements to be more informative; i.e. "analyzing data.." (what data? what step?); video analysis, what batch size, so I don't have to check config.yaml if speed is not what I anticipated, for example. Also cleaned up print statement from convert2tracklets onwards to be clear one can either run stitchtracklets or jump to tracking GUI.

i.e., as an example changed output:

```
DLC network loading and video analysis starting ...
Using snapshot-50 for model /Users/mwmathis/Desktop/testing-MWM-2021-10-03/dlc-models/iteration-0/testingOct3-trainset95shuffle1
Activating extracting of PAFs
Starting to analyze %  /Users/mwmathis/Downloads/split6_movie1_reconst.mp4
Loading  /Users/mwmathis/Downloads/split6_movie1_reconst.mp4
Duration of video [s]:  30.0 , recorded with  30.0 fps!
Overall # of frames:  900  found with (before cropping) frame dimensions:  608 608
Starting to extract posture from the video(s) with batchsize: 8
```

also statements/errors for crashing out after training, fixed with suggestion from @yeshaokai thanks!