### PR TITLE
Fix right-click bug for removing label

### DIFF
--- a/deeplabcut/gui/auxfun_drag.py
+++ b/deeplabcut/gui/auxfun_drag.py
@@ -81,7 +81,7 @@ class DraggablePoint:
             self.background = canvas.copy_from_bbox(self.point.axes.bbox)
             axes.draw_artist(self.point)
             canvas.blit(axes.bbox)
-        elif event.button == 2:
+        elif event.button == 3:
             """
             To remove a predicted label. Internally, the coordinates of the selected predicted label is replaced with nan. The user needs to right click for the event.After right
             click the data point is removed from the plot.


### PR DESCRIPTION
This Pull Request fix bug labels aren't able to be removed by right-clicking when using 'refine labels'.
Currently, for removing labels, middle-click is removed labels. But, according to the message of DLC's GUI, the correct way is right-click.

ref: [click event type for matplotlib](https://matplotlib.org/stable/api/backend_bases_api.html#matplotlib.backend_bases.MouseButton)
