### PR TITLE
Modify fixed fps with keypoint only option

### DIFF
--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -680,7 +680,7 @@ def proc_video(
             print(e)
 
 
-DEFAULT_FRAME_RATE_WITH_KEYPOINTS_ONLY = 25
+DEFAULT_FRAME_RATE_FOR_LABELLED_VIDEO = 25
 def create_video_with_keypoints_only(
     df,
     output_name,
@@ -703,7 +703,7 @@ def create_video_with_keypoints_only(
     ny = int(np.nanmax(df.xs("y", axis=1, level="coords")))
 
     if fps is None:
-        fps = DEFAULT_FRAME_RATE_WITH_KEYPOINTS_ONLY
+        fps = DEFAULT_FRAME_RATE_FOR_LABELLED_VIDEO
 
     n_frames = df.shape[0]
     xyp = df.values.reshape((n_frames, -1, 3))

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -599,6 +599,7 @@ def proc_video(
                 if bodyparts2connect:
                     all_bpts = df.columns.get_level_values("bodyparts")[::3]
                     inds = get_segment_indices(bodyparts2connect, all_bpts)
+                clip = vp(fname=video, fps=outputframerate)
                 create_video_with_keypoints_only(
                     df,
                     videooutname,
@@ -609,7 +610,9 @@ def proc_video(
                     skeleton_color=skeleton_color,
                     color_by=color_by,
                     colormap=cfg["colormap"],
+                    fps=clip.fps(),
                 )
+                clip.close()
             elif not fastmode:
                 tmpfolder = os.path.join(str(videofolder), "temp-" + vname)
                 if save_frames:
@@ -676,6 +679,7 @@ def proc_video(
             print(e)
 
 
+DEFAULT_FRAME_RATE_WITH_KEYPOINTS_ONLY = 25
 def create_video_with_keypoints_only(
     df,
     output_name,
@@ -687,7 +691,7 @@ def create_video_with_keypoints_only(
     skeleton_color="navy",
     color_by="bodypart",
     colormap="viridis",
-    fps=25,
+    fps=None,
     dpi=200,
     codec="h264",
 ):
@@ -696,6 +700,9 @@ def create_video_with_keypoints_only(
     n_bodyparts = len(bodypart_names)
     nx = int(np.nanmax(df.xs("x", axis=1, level="coords")))
     ny = int(np.nanmax(df.xs("y", axis=1, level="coords")))
+
+    if fps is None:
+        fps = DEFAULT_FRAME_RATE_WITH_KEYPOINTS_ONLY
 
     n_frames = df.shape[0]
     xyp = df.values.reshape((n_frames, -1, 3))

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -394,7 +394,7 @@ def create_labeled_video(
 
     keypoints_only: bool, optional
         By default, both video frames and keypoints are visible. If true, only the keypoints are shown. These clips are an hommage to Johansson movies,
-        see https://www.youtube.com/watch?v=1F5ICP9SYLU and of course his seminal paper: "Visual perception of biological motion and a model for its analysis" 
+        see https://www.youtube.com/watch?v=1F5ICP9SYLU and of course his seminal paper: "Visual perception of biological motion and a model for its analysis"
         by Gunnar Johansson in Perception & Psychophysics 1973.
 
     Frames2plot: List of indices
@@ -680,7 +680,6 @@ def proc_video(
             print(e)
 
 
-DEFAULT_FRAME_RATE_WITH_KEYPOINTS_ONLY = 25
 def create_video_with_keypoints_only(
     df,
     output_name,
@@ -692,7 +691,7 @@ def create_video_with_keypoints_only(
     skeleton_color="navy",
     color_by="bodypart",
     colormap="viridis",
-    fps=None,
+    fps=25,
     dpi=200,
     codec="h264",
 ):
@@ -701,9 +700,6 @@ def create_video_with_keypoints_only(
     n_bodyparts = len(bodypart_names)
     nx = int(np.nanmax(df.xs("x", axis=1, level="coords")))
     ny = int(np.nanmax(df.xs("y", axis=1, level="coords")))
-
-    if fps is None:
-        fps = DEFAULT_FRAME_RATE_WITH_KEYPOINTS_ONLY
 
     n_frames = df.shape[0]
     xyp = df.values.reshape((n_frames, -1, 3))

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -643,6 +643,7 @@ def proc_video(
                     displaycropped,
                     color_by,
                 )
+                clip.close()
             else:
                 if displaycropped:  # then the cropped video + the labels is depicted
                     clip = vp(

--- a/deeplabcut/utils/video_processor.py
+++ b/deeplabcut/utils/video_processor.py
@@ -148,5 +148,7 @@ class VideoProcessorCV(VideoProcessor):
         self.svid.write(np.flip(frame, 2))
 
     def close(self):
-        self.svid.release()
-        self.vid.release()
+        if hasattr(self, 'svid') and self.svid is not None:
+            self.svid.release()
+        if hasattr(self, 'vid') and self.vid is not None:
+            self.vid.release()


### PR DESCRIPTION
When using `keypoints_only` option in `create_labeled_video`, created video is **fixed 25**.
So, This PR modifies the same fps of the selected video when labeled videos with keypoints_only option are created.

### before modification
##### selected video
![Screenshot from 2021-10-12 17-17-16](https://user-images.githubusercontent.com/43847020/136927320-3f8ba5b9-0efe-49ee-8d02-0a769a68a787.png)
##### created video
![Screenshot from 2021-10-12 17-16-58](https://user-images.githubusercontent.com/43847020/136927356-eaa7f7b7-ef5c-46a6-8e6e-7877ffe925de.png)

### after modification
##### selected video
![Screenshot from 2021-10-12 17-14-25](https://user-images.githubusercontent.com/43847020/136927817-dbfb51f6-bf7f-4025-821b-28e6907a0019.png)
##### created video
![Screenshot from 2021-10-12 17-13-40](https://user-images.githubusercontent.com/43847020/136927729-38844032-7c11-4168-84a7-d5259fee1d63.png)

