### PR TITLE
Update dlc entrypoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ),
     entry_points="""[console_scripts]
-            dlc=dlc:main""",
+            dlc=deeplabcut.cli:main""",
 )
 
 # https://www.python.org/dev/peps/pep-0440/#compatible-release


### PR DESCRIPTION
I believe the current entry-point no longer exists now that the package name is `deeplabcut` and not `dlc`.

Is this is the intended entry point?