### PR TITLE
Consider symmetric keypoints when computing OKS

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -547,6 +547,9 @@ def evaluate_multianimal_full(
                         data_path.replace("_full.", "_meta."),
                         n_graphs=n_graphs,
                         paf_inds=paf_inds,
+                        oks_sigma=dlc_cfg.get("oks_sigma", 0.1),
+                        margin=dlc_cfg.get("bbox_margin", 0),
+                        symmetric_kpts=dlc_cfg.get("symmetric_kpts"),
                     )
                     df = results[1].copy()
                     df.loc(axis=0)[('mAP_train', 'mean')] = [d[0]['mAP'] for d in results[2]]

--- a/deeplabcut/pose_estimation_tensorflow/lib/crossvalutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/crossvalutils.py
@@ -182,6 +182,8 @@ def _benchmark_paf_graphs(
     identity_only=False,
     calibration_file="",
     oks_sigma=0.1,
+    margin=0,
+    symmetric_kpts=None,
     split_inds=None,
 ):
     metadata = data.pop("metadata")
@@ -246,9 +248,23 @@ def _benchmark_paf_graphs(
             oks = []
             for inds in split_inds:
                 assemblies = {k: v for k, v in ass.assemblies.items() if k in inds}
-                oks.append(evaluate_assembly(assemblies, ass_true_dict, oks_sigma))
+                oks.append(
+                    evaluate_assembly(
+                        assemblies,
+                        ass_true_dict,
+                        oks_sigma,
+                        margin=margin,
+                        symmetric_kpts=symmetric_kpts,
+                    )
+                )
         else:
-            oks = evaluate_assembly(ass.assemblies, ass_true_dict, oks_sigma)
+            oks = evaluate_assembly(
+                ass.assemblies,
+                ass_true_dict,
+                oks_sigma,
+                margin=margin,
+                symmetric_kpts=symmetric_kpts,
+            )
         all_metrics.append(oks)
         scores = np.full((len(image_paths), 2), np.nan)
         for i, imname in enumerate(tqdm(image_paths)):
@@ -359,12 +375,15 @@ def cross_validate_paf_graphs(
     metadata_file,
     output_name="",
     pcutoff=0.1,
+    oks_sigma=0.1,
+    margin=0,
     greedy=False,
     add_discarded=True,
     calibrate=False,
     overwrite_config=True,
     n_graphs=10,
     paf_inds=None,
+    symmetric_kpts=None,
 ):
     cfg = auxiliaryfunctions.read_config(config)
     inf_cfg = auxiliaryfunctions.read_plainconfig(inference_config)
@@ -406,6 +425,9 @@ def cross_validate_paf_graphs(
         paf_inds,
         greedy,
         add_discarded,
+        oks_sigma=oks_sigma,
+        margin=margin,
+        symmetric_kpts=symmetric_kpts,
         calibration_file=calibration_file,
         split_inds=[
             metadata["data"]["trainIndices"],

--- a/tests/test_inferenceutils.py
+++ b/tests/test_inferenceutils.py
@@ -37,6 +37,15 @@ def test_calc_object_keypoint_similarity(real_assemblies):
     assert inferenceutils.calc_object_keypoint_similarity(xy3, xy1, sigma) == 0
     assert np.isnan(inferenceutils.calc_object_keypoint_similarity(xy1, xy3, sigma))
 
+    # Test flipped keypoints
+    xy4 = xy1.copy()
+    symmetric_pair = [0, 11]
+    xy4[symmetric_pair] = xy4[symmetric_pair[::-1]]
+    assert inferenceutils.calc_object_keypoint_similarity(xy1, xy4, sigma) != 1
+    assert inferenceutils.calc_object_keypoint_similarity(
+        xy1, xy4, sigma, symmetric_kpts=[symmetric_pair]
+    ) == 1
+
 
 def test_match_assemblies(real_assemblies):
     assemblies = real_assemblies[0]
@@ -59,6 +68,17 @@ def test_evaluate_assemblies(real_assemblies):
     thresholds = np.linspace(0.5, 0.95, n_thresholds)
     dict_ = inferenceutils.evaluate_assembly(
         assemblies, assemblies, oks_thresholds=thresholds
+    )
+    assert dict_["mAP"] == dict_["mAR"] == 1
+    assert len(dict_["precisions"]) == len(dict_["recalls"]) == n_thresholds
+    assert dict_["precisions"].shape[1] == 101
+    np.testing.assert_allclose(dict_["precisions"], 1)
+
+    dict_ = inferenceutils.evaluate_assembly(
+        assemblies,
+        assemblies,
+        oks_thresholds=thresholds,
+        symmetric_kpts=[(0, 5), (1, 4)]
     )
     assert dict_["mAP"] == dict_["mAR"] == 1
     assert len(dict_["precisions"]) == len(dict_["recalls"]) == n_thresholds


### PR DESCRIPTION
This PR addresses the need for a simple way to define symmetric keypoints prior to the calculation of OKS (which is e.g. needed for the pups).
These can now be specified in the test/pose_cfg.yaml as a list of pairs of indices; all possible configurations will be evaluated, and max OKS is returned.
Bounding box margin (for the calculation of the animal scale) and sigma can also be defined in the same file.