### PR TITLE
Fix KMeans segfault

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,16 +13,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-10.15, windows-latest]
+        os: [ubuntu-latest, macos-11, windows-latest]
         python-version: [3.7, 3.8] #3.9 only failing for tables on macos and windows; mwm 6302021
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip
-          - os: macOS-10.15
+          - os: macos-11
             path: ~/Library/Caches/pip
           - os: windows-latest
             path: ~\AppData\Local\pip\Cache
-            
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pandas>=1.0.1
 patsy
 pyyaml
 setuptools
-scikit-image>=0.17
+scikit-image>=0.17,<=0.18.1
 scikit-learn
 scipy>=1.4
 six

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(
         "numpy",
         "opencv-python-headless",
         "pandas>=1.0.1",
-        "scikit-image>=0.17",
+        "scikit-image>=0.17,<=0.18.1",
         "scikit-learn",
         "scipy>=1.4",
         "statsmodels>=0.11",


### PR DESCRIPTION
scikit-image was the culprit; adding that line alone (`from skimage.util import img_as_ubyte`) was enough to make sklearn MiniBatchKMeans crash with v0.18.2 and v0.18.3...so enforcing <=0.18.1 for now

Fixes #1522