### PR TITLE
Speed up maDLC workflow when there is only one animal

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
@@ -622,6 +622,13 @@ class Assembler:
         if not any(i in bag for i in range(self.n_multibodyparts)):
             return None, unique
 
+        if self.max_n_individuals == 1:
+            get_attr = operator.attrgetter("confidence")
+            ass = Assembly(self.n_multibodyparts)
+            for joints in bag.values():
+                ass.add_joint(max(joints, key=get_attr))
+            return [ass], unique
+
         if self.identity_only:
             assemblies = []
             get_attr = operator.attrgetter("group")

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1471,31 +1471,39 @@ def convert_detections2tracklets(
                         _single[imindex] = single_detection
                     tracklets["single"].update(_single)
 
-                keep = set(multi_bpts).difference(ignore_bodyparts or [])
-                keep_inds = sorted(multi_bpts.index(bpt) for bpt in keep)
-                for index, imname in tqdm(enumerate(imnames)):
-                    assemblies = ass.assemblies.get(index)
-                    if assemblies is None:
-                        continue
-                    animals = np.stack([ass.data for ass in assemblies])
-                    if not identity_only:
-                        if track_method == "box":
-                            bboxes = trackingutils.calc_bboxes_from_keypoints(
-                                animals[:, keep_inds], inferencecfg["boundingboxslack"], offset=0
-                            )  # TODO: get cropping parameters and utilize!
-                            trackers = mot_tracker.update(bboxes)
+                if inferencecfg["topktoretain"] == 1:
+                    tracklets[0] = {}
+                    for index, imname in tqdm(enumerate(imnames)):
+                        assemblies = ass.assemblies.get(index)
+                        if assemblies is None:
+                            continue
+                        tracklets[0][imname] = assemblies[0].data
+                else:
+                    keep = set(multi_bpts).difference(ignore_bodyparts or [])
+                    keep_inds = sorted(multi_bpts.index(bpt) for bpt in keep)
+                    for index, imname in tqdm(enumerate(imnames)):
+                        assemblies = ass.assemblies.get(index)
+                        if assemblies is None:
+                            continue
+                        animals = np.stack([ass.data for ass in assemblies])
+                        if not identity_only:
+                            if track_method == "box":
+                                bboxes = trackingutils.calc_bboxes_from_keypoints(
+                                    animals[:, keep_inds], inferencecfg["boundingboxslack"], offset=0
+                                )  # TODO: get cropping parameters and utilize!
+                                trackers = mot_tracker.update(bboxes)
+                            else:
+                                xy = animals[:, keep_inds, :2]
+                                trackers = mot_tracker.track(xy)
                         else:
-                            xy = animals[:, keep_inds, :2]
-                            trackers = mot_tracker.track(xy)
-                    else:
-                        # Optimal identity assignment based on soft voting
-                        mat = np.zeros((len(assemblies), inferencecfg["topktoretain"]))
-                        for nrow, assembly in enumerate(assemblies):
-                            for k, v in assembly.soft_identity.items():
-                                mat[nrow, k] = v
-                        inds = linear_sum_assignment(mat, maximize=True)
-                        trackers = np.c_[inds][:, ::-1]
-                    trackingutils.fill_tracklets(tracklets, trackers, animals, imname)
+                            # Optimal identity assignment based on soft voting
+                            mat = np.zeros((len(assemblies), inferencecfg["topktoretain"]))
+                            for nrow, assembly in enumerate(assemblies):
+                                for k, v in assembly.soft_identity.items():
+                                    mat[nrow, k] = v
+                            inds = linear_sum_assignment(mat, maximize=True)
+                            trackers = np.c_[inds][:, ::-1]
+                        trackingutils.fill_tracklets(tracklets, trackers, animals, imname)
 
                 tracklets["header"] = pdindex
                 with open(trackname, "wb") as f:

--- a/docs/maDLC_UserGuide.md
+++ b/docs/maDLC_UserGuide.md
@@ -472,6 +472,9 @@ deeplabcut.convert_detections2tracklets(..., identity_only=True)
 
 **Animal assembly and tracking quality** can be assessed via `deeplabcut.utils.make_labeled_video.create_video_from_pickled_tracks`. This function provides an additional diagnostic tool before moving on to refining tracklets.
 
+
+**Note:** If only one individual is to be assembled and tracked, assembly and tracking are skipped, and detections are treated as in single-animal projects; i.e., it is the keypoints with highest confidence that are kept and accumulated over frames to form a single, long tracklet. No action is required from users, this is done automatically.
+
 **Next, tracklets are stitched to form complete tracks with:
 
 ```python


### PR DESCRIPTION
Bypass assembly and tracking if only one individual is defined. Since there will be only one resulting tracklet, stitching is instantaneous so it doesn't need an update.