### PR TITLE
Fix covariance matrix indexing

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
@@ -326,7 +326,7 @@ class Assembler:
         j = link.j2.label
         ind = _conv_square_to_condensed_indices(i, j, self.n_multibodyparts)
         mu = self._kde.mean[ind]
-        sigma = self._kde.covariance[i, j]
+        sigma = self._kde.covariance[ind, ind]
         z = (link.length ** 2 - mu) / sigma
         return 2 * (1 - 0.5 * (1 + erf(abs(z) / sqrt(2))))
 

--- a/tests/test_inferenceutils.py
+++ b/tests/test_inferenceutils.py
@@ -276,7 +276,7 @@ def test_assembler_calibration(real_assemblies):
     j2 = inferenceutils.Joint(tuple(assembly.xy[1]), label=1)
     link = inferenceutils.Link(j1, j2)
     p = ass.calc_link_probability(link)
-    assert np.isclose(p, 0.990, atol=1e-3)
+    assert np.isclose(p, 0.993, atol=1e-3)
 
 
 def test_find_outlier_assemblies(real_assemblies):


### PR DESCRIPTION
Fixes the issue described here https://forum.image.sc/t/indexerror-index-1-is-out-of-bounds-for-axis-1-with-size-1/59472. The probability of a link being observed may have been slightly underestimated (when using `calibrate`=True).