### PR TITLE
Ignore single-keypoint assemblies during mAP evaluation

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
@@ -871,28 +871,20 @@ def match_assemblies(
     ass_pred = [a for a in ass_pred if len(a) > 1]
     ass_true = [a for a in ass_true if len(a) > 1]
 
-    inds_true = list(range(len(ass_true)))
-    inds_pred = np.argsort(
-        [ins.affinity if ins.n_links else ins.confidence for ins in ass_pred]
-    )[::-1]
-    matched = []
-    for ind_pred in inds_pred:
-        xy_pred = ass_pred[ind_pred].xy
-        oks = []
-        for ind_true in inds_true:
-            xy_true = ass_true[ind_true].xy
-            oks.append(
-                calc_object_keypoint_similarity(
-                    xy_pred, xy_true, sigma, margin, symmetric_kpts,
-                )
+    mat = np.zeros((len(ass_pred), len(ass_true)))
+    for i, a_pred in enumerate(ass_pred):
+        for j, a_true in enumerate(ass_true):
+            oks = calc_object_keypoint_similarity(
+                a_pred.xy, a_true.xy, sigma, margin, symmetric_kpts,
             )
-        if np.all(np.isnan(oks)):
-            continue
-        ind_best = np.nanargmax(oks)
-        ind_true_best = inds_true.pop(ind_best)
-        matched.append((ass_pred[ind_pred], ass_true[ind_true_best], oks[ind_best]))
-        if not inds_true:
-            break
+            if ~np.isnan(oks):
+                mat[i, j] = oks
+    rows, cols = linear_sum_assignment(mat, maximize=True)
+    matched = []
+    inds_true = list(range(len(ass_true)))
+    for row, col in zip(rows, cols):
+        matched.append((ass_pred[row], ass_true[col], mat[row, col]))
+        _ = inds_true.remove(col)
     unmatched = [ass_true[ind] for ind in inds_true]
     return matched, unmatched
 

--- a/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
@@ -867,6 +867,10 @@ def match_assemblies(
     margin=0,
     symmetric_kpts=None,
 ):
+    # Only consider assemblies of at least two keypoints
+    ass_pred = [a for a in ass_pred if len(a) > 1]
+    ass_true = [a for a in ass_true if len(a) > 1]
+
     inds_true = list(range(len(ass_true)))
     inds_pred = np.argsort(
         [ins.affinity if ins.n_links else ins.confidence for ins in ass_pred]

--- a/tests/test_inferenceutils.py
+++ b/tests/test_inferenceutils.py
@@ -112,7 +112,8 @@ def test_assembly():
     assert ass.data[j2.label, -1] == -1
     assert ass.area == 0
     assert ass.intersection_with(ass) == 1.0
-    assert np.all(np.isnan(ass._dict["data"]))
+    # Original (cached) coordinates must have remained empty
+    assert np.all(np.isnan(ass._dict["data"][:, :2]))
 
     ass.remove_joint(j2)
     assert len(ass) == 1


### PR DESCRIPTION
Note that optimal assembly matching is a bit slower (~15%), but that's perhaps more readable (and not that significant in practice)