### PR TITLE
Optionally write data on the fly to a shelf during analyze_videos

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/predict_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_multianimal.py
@@ -8,7 +8,8 @@ https://github.com/AlexEMG/DeepLabCut/blob/master/AUTHORS
 Licensed under GNU Lesser General Public License v3.0
 """
 import os
-import os.path
+import pickle
+import shelve
 import time
 from pathlib import Path
 
@@ -32,6 +33,7 @@ def AnalyzeMultiAnimalVideo(
     outputs,
     destfolder=None,
     robust_nframes=False,
+    use_shelve=False,
 ):
     """ Helper function for analyzing a video with multiple individuals """
 
@@ -75,6 +77,10 @@ def AnalyzeMultiAnimalVideo(
         start = time.time()
 
         print("Starting to extract posture from the video(s) with batchsize:", dlc_cfg["batch_size"])
+        if use_shelve:
+            shelf_path = dataname.split(".h5")[0] + "_full.pickle"
+        else:
+            shelf_path = ""
         if int(dlc_cfg["batch_size"]) > 1:
             PredicteData, nframes = GetPoseandCostsF(
                 cfg,
@@ -85,10 +91,11 @@ def AnalyzeMultiAnimalVideo(
                 vid,
                 nframes,
                 int(dlc_cfg["batch_size"]),
+                shelf_path,
             )
         else:
             PredicteData, nframes = GetPoseandCostsS(
-                cfg, dlc_cfg, sess, inputs, outputs, vid, nframes,
+                cfg, dlc_cfg, sess, inputs, outputs, vid, nframes, shelf_path,
             )
 
         stop = time.time()
@@ -116,11 +123,16 @@ def AnalyzeMultiAnimalVideo(
         metadata = {"data": dictionary}
         print("Video Analyzed. Saving results in %s..." % (destfolder))
 
-        _ = auxfun_multianimal.SaveFullMultiAnimalData(PredicteData, metadata, dataname)
+        if use_shelve:
+            metadata_path = dataname.split(".h5")[0] + "_meta.pickle"
+            with open(metadata_path, "wb") as f:
+                pickle.dump(metadata, f, pickle.HIGHEST_PROTOCOL)
+        else:
+            _ = auxfun_multianimal.SaveFullMultiAnimalData(PredicteData, metadata, dataname)
 
 
 def GetPoseandCostsF(
-    cfg, dlc_cfg, sess, inputs, outputs, cap, nframes, batchsize,
+    cfg, dlc_cfg, sess, inputs, outputs, cap, nframes, batchsize, shelf_path,
 ):
     """ Batchwise prediction of pose """
     strwidth = int(np.ceil(np.log10(nframes)))  # width for strings
@@ -137,7 +149,27 @@ def GetPoseandCostsF(
     counter = 0
     inds = []
 
-    PredicteData = {}
+    if shelf_path:
+        db = shelve.open(
+            shelf_path,
+            protocol=pickle.DEFAULT_PROTOCOL,
+        )
+    else:
+        db = dict()
+    db["metadata"] = {
+        "nms radius": dlc_cfg["nmsradius"],
+        "minimal confidence": dlc_cfg["minconfidence"],
+        "sigma": dlc_cfg.get("sigma", 1),
+        "PAFgraph": dlc_cfg["partaffinityfield_graph"],
+        "PAFinds": dlc_cfg.get(
+            "paf_best", np.arange(len(dlc_cfg["partaffinityfield_graph"]))
+        ),
+        "all_joints": [[i] for i in range(len(dlc_cfg["all_joints"]))],
+        "all_joints_names": [
+            dlc_cfg["all_joints_names"][i] for i in range(len(dlc_cfg["all_joints"]))
+        ],
+        "nframes": nframes,
+    }
     while cap.video.isOpened():
         frame = cap.read_frame(crop=cfg["cropping"])
         if frame is not None:
@@ -148,7 +180,8 @@ def GetPoseandCostsF(
                     dlc_cfg, frames, sess, inputs, outputs,
                 )
                 for ind, data in zip(inds, D):
-                    PredicteData["frame" + str(ind).zfill(strwidth)] = data
+                    db["frame" + str(ind).zfill(strwidth)] = data
+                del D
                 batch_ind = 0
                 inds.clear()
                 batch_num += 1
@@ -160,14 +193,35 @@ def GetPoseandCostsF(
                     dlc_cfg, frames, sess, inputs, outputs,
                 )
                 for ind, data in zip(inds, D):
-                    PredicteData["frame" + str(ind).zfill(strwidth)] = data
+                    db["frame" + str(ind).zfill(strwidth)] = data
+                del D
             break
         counter += 1
         pbar.update(1)
 
     cap.close()
     pbar.close()
-    PredicteData["metadata"] = {
+    try:
+        db.close()
+    except AttributeError:
+        pass
+    return db, nframes
+
+
+def GetPoseandCostsS(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes, shelf_path):
+    """ Non batch wise pose estimation for video cap."""
+    strwidth = int(np.ceil(np.log10(nframes)))  # width for strings
+    if cfg["cropping"]:
+        cap.set_bbox(cfg["x1"], cfg["x2"], cfg["y1"], cfg["y2"])
+
+    if shelf_path:
+        db = shelve.open(
+        shelf_path,
+        protocol=pickle.DEFAULT_PROTOCOL,
+    )
+    else:
+        db = dict()
+    db["metadata"] = {
         "nms radius": dlc_cfg["nmsradius"],
         "minimal confidence": dlc_cfg["minconfidence"],
         "sigma": dlc_cfg.get("sigma", 1),
@@ -181,16 +235,6 @@ def GetPoseandCostsF(
         ],
         "nframes": nframes,
     }
-    return PredicteData, nframes
-
-
-def GetPoseandCostsS(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes):
-    """ Non batch wise pose estimation for video cap."""
-    strwidth = int(np.ceil(np.log10(nframes)))  # width for strings
-    if cfg["cropping"]:
-        cap.set_bbox(cfg["x1"], cfg["x2"], cfg["y1"], cfg["y2"])
-
-    PredicteData = {}  # np.zeros((nframes, 3 * len(dlc_cfg['all_joints_names'])))
     pbar = tqdm(total=nframes)
     counter = 0
     while cap.video.isOpened():
@@ -200,25 +244,16 @@ def GetPoseandCostsS(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes):
             dets = predict.predict_batched_peaks_and_costs(
                 dlc_cfg, np.expand_dims(frame, axis=0), sess, inputs, outputs,
             )
-            PredicteData["frame" + str(counter).zfill(strwidth)] = dets[0]
+            db["frame" + str(counter).zfill(strwidth)] = dets[0]
+            del dets
         elif counter >= nframes:
             break
         counter += 1
         pbar.update(1)
 
     pbar.close()
-    PredicteData["metadata"] = {
-        "nms radius": dlc_cfg["nmsradius"],
-        "minimal confidence": dlc_cfg["minconfidence"],
-        "sigma": dlc_cfg.get("sigma", 1),
-        "PAFgraph": dlc_cfg["partaffinityfield_graph"],
-        "PAFinds": dlc_cfg.get(
-            "paf_best", np.arange(len(dlc_cfg["partaffinityfield_graph"]))
-        ),
-        "all_joints": [[i] for i in range(len(dlc_cfg["all_joints"]))],
-        "all_joints_names": [
-            dlc_cfg["all_joints_names"][i] for i in range(len(dlc_cfg["all_joints"]))
-        ],
-        "nframes": nframes,
-    }
-    return PredicteData, nframes
+    try:
+        db.close()
+    except AttributeError:
+        pass
+    return db, nframes

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1469,6 +1469,10 @@ def convert_detections2tracklets(
                     ass.calibrate(train_data_file)
                 ass.assemble()
                 ass.to_pickle(dataname.split(".h5")[0] + "_assemblies.pickle")
+                try:
+                    data.close()
+                except AttributeError:
+                    pass
 
                 if cfg[
                     "uniquebodyparts"

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -54,7 +54,8 @@ def analyze_videos(
     dynamic=(False, 0.5, 10),
     modelprefix="",
     robust_nframes=False,
-    allow_growth=False
+    allow_growth=False,
+    use_shelve=False,
 ):
     """
     Makes prediction based on a trained network. The index of the trained network is specified by parameters in the config file (in particular the variable 'snapshotindex')
@@ -119,6 +120,11 @@ def analyze_videos(
     allow_growth: bool, default false.
         For some smaller GPUs the memory issues happen. If true, the memory allocator does not pre-allocate the entire specified
         GPU memory region, instead starting small and growing as needed. See issue: https://forum.image.sc/t/how-to-stop-running-out-of-vram/30551/2
+
+    use_shelve: bool, optional (default=False)
+        By default, data are dumped in a pickle file at the end of the video analysis.
+        Otherwise, data are written to disk on the fly using a "shelf"; i.e., a pickle-based,
+        persistent, database-like object by default, resulting in constant memory footprint.
 
     Examples
     --------
@@ -297,6 +303,7 @@ def analyze_videos(
                     outputs,
                     destfolder,
                     robust_nframes=robust_nframes,
+                    use_shelve=use_shelve,
                 )
         else:
             for video in Videos:

--- a/deeplabcut/utils/auxfun_multianimal.py
+++ b/deeplabcut/utils/auxfun_multianimal.py
@@ -10,6 +10,7 @@ Licensed under GNU Lesser General Public License v3.0
 
 import os
 import pickle
+import shelve
 from itertools import combinations
 from pathlib import Path
 
@@ -116,8 +117,14 @@ def SaveFullMultiAnimalData(data, metadata, dataname, suffix="_full"):
 
 def LoadFullMultiAnimalData(dataname):
     """ Save predicted data as h5 file and metadata as pickle file; created by predict_videos.py """
-    with open(dataname.split(".h5")[0] + "_full.pickle", "rb") as handle:
-        data = pickle.load(handle)
+    try:
+        with open(dataname.split(".h5")[0] + "_full.pickle", "rb") as handle:
+            data = pickle.load(handle)
+    except FileNotFoundError:
+        data = shelve.open(
+            dataname.split(".h5")[0] + "_full.pickle",
+            flag="r",
+        )
     with open(dataname.split(".h5")[0] + "_meta.pickle", "rb") as handle:
         metadata = pickle.load(handle)
     return data, metadata


### PR DESCRIPTION
DLC data container may grow larger than memory when analyzing very long videos.
To address this issue, a user is now given the option to pass the flag `use_shelve=True` to `analyze_videos`, in order to write data on the fly to a shelf, a persistent (dictionary) database-like object using the pickle protocol. This results in constant memory usage, with little overhead when writing to disk. Advantageously, if the analysis were to stop, it would start again from the last analyzed frame.

I didn't include casting data to float16 as it resulted in only a ~20% reduction in file size, maybe indicating that file size is mainly dominated by all the nested dicts of np.array we store. 🤔 Can be left for another PR anyway.

Solves #1468