### PR TITLE
fix typo in compute_deviations()

### DIFF
--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -488,7 +488,7 @@ def compute_deviations(
         meany, CIy = FitSARIMAXModel(y, p, p_bound, alpha, ARdegree, MAdegree)
         distance = np.sqrt((x - meanx) ** 2 + (y - meany) ** 2)
         significant = (
-            (x < CIx[:, 0]) + (x > CIx[:, 1]) + (x < CIy[:, 0]) + (y > CIy[:, 1])
+            (x < CIx[:, 0]) + (x > CIx[:, 1]) + (y < CIy[:, 0]) + (y > CIy[:, 1])
         )
         preds.append(np.c_[distance, significant, meanx, meany, CIx, CIy])
 


### PR DESCRIPTION
Fix a typo in `deeplabcut.refine_training_dataset.outlier_frames.compute_deviations()`
fixes #1574 