### PR TITLE
Better format for cross-platform labelling and training (storing triples) 

### DIFF
--- a/deeplabcut/__init__.py
+++ b/deeplabcut/__init__.py
@@ -75,7 +75,6 @@ from deeplabcut.utils import (
     auxiliaryfunctions,
     convert2_maDLC,
     convertcsv2h5,
-    convertannotationdata_fromwindows2unixstyle,
     analyze_videos_converth5_to_csv,
     auxfun_videos,
 )

--- a/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
@@ -62,7 +62,7 @@ def format_multianimal_training_data(
     array = np.round(array, decimals=n_decimals)
     for i in tqdm(train_inds):
         filename = filenames[i]
-        img_shape = read_image_shape_fast(os.path.join(project_path, filename))
+        img_shape = read_image_shape_fast(os.path.join(project_path, *filename))
         joints = dict()
         has_data = False
         for n, xy in enumerate(array[i]):
@@ -97,7 +97,6 @@ def create_multianimaltraining_dataset(
     config,
     num_shuffles=1,
     Shuffles=None,
-    windows2linux=False,
     net_type=None,
     numdigits=2,
     crop_size=(400, 400),
@@ -124,10 +123,6 @@ def create_multianimaltraining_dataset(
 
     Shuffles: list of shuffles.
         Alternatively the user can also give a list of shuffles (integers!).
-
-    windows2linux: bool.
-        The annotation files contain path formated according to your operating system. If you label on windows
-        but train & evaluate on a unix system (e.g. ubunt, colab, Mac) set this variable to True to convert the paths.
 
     net_type: string
         Type of networks. Currently resnet_50, resnet_101, and resnet_152, efficientnet-b0, efficientnet-b1, efficientnet-b2, efficientnet-b3,
@@ -186,7 +181,7 @@ def create_multianimaltraining_dataset(
     full_training_path = Path(project_path, trainingsetfolder)
     auxiliaryfunctions.attempttomakefolder(full_training_path, recursive=True)
 
-    Data = merge_annotateddatasets(cfg, full_training_path, windows2linux)
+    Data = merge_annotateddatasets(cfg, full_training_path)
     if Data is None:
         return
     Data = Data[scorer]
@@ -516,7 +511,7 @@ def convert_cropped_to_standard_dataset(
     img_names_old = np.asarray(
         [strip_cropped_image_name(img) for img in df_old.index.to_list()]
     )
-    df = merge_annotateddatasets(cfg, datasets_folder, False)
+    df = merge_annotateddatasets(cfg, datasets_folder)
     img_names = df.index.to_numpy()
     train_idx = []
     test_idx = []

--- a/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
@@ -11,6 +11,7 @@ Licensed under GNU Lesser General Public License v3.0
 import os
 import os.path
 import re
+import warnings
 from itertools import combinations
 from pathlib import Path
 
@@ -97,6 +98,7 @@ def create_multianimaltraining_dataset(
     config,
     num_shuffles=1,
     Shuffles=None,
+    windows2linux=False,
     net_type=None,
     numdigits=2,
     crop_size=(400, 400),
@@ -165,6 +167,12 @@ def create_multianimaltraining_dataset(
     >>> deeplabcut.create_multianimaltraining_dataset(r'C:\\Users\\Ulf\\looming-task\\config.yaml',Shuffles=[3,17,5])
     --------
     """
+    if windows2linux:
+        warnings.warn(
+            "`windows2linux` has no effect since 2.2.0.4 and will be removed in 2.2.1.",
+            FutureWarning,
+        )
+
     if len(crop_size) != 2 or not all(isinstance(v, int) for v in crop_size):
         raise ValueError("Crop size must be a tuple of two integers (width, height).")
 

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -11,6 +11,7 @@ import math
 import logging
 import os
 import os.path
+import warnings
 
 from functools import lru_cache
 from pathlib import Path
@@ -658,6 +659,7 @@ def create_training_dataset(
     config,
     num_shuffles=1,
     Shuffles=None,
+    windows2linux=False,
     userfeedback=False,
     trainIndices=None,
     testIndices=None,
@@ -709,6 +711,13 @@ def create_training_dataset(
     """
     import scipy.io as sio
 
+    if windows2linux:
+        # DeprecationWarnings are silenced since Python 3.2 unless triggered in __main__
+        warnings.warn(
+            "`windows2linux` has no effect since 2.2.0.4 and will be removed in 2.2.1.",
+            FutureWarning,
+        )
+
     # Loading metadata from config file:
     cfg = auxiliaryfunctions.read_config(config)
     if cfg.get("multianimalproject", False):
@@ -717,7 +726,7 @@ def create_training_dataset(
         )
 
         create_multianimaltraining_dataset(
-            config, num_shuffles, Shuffles, net_type
+            config, num_shuffles, Shuffles, net_type=net_type
         )
     else:
         scorer = cfg["scorer"]
@@ -967,6 +976,7 @@ def create_training_model_comparison(
     net_types=["resnet_50"],
     augmenter_types=["default"],
     userfeedback=False,
+    windows2linux=False,
 ):
     """
     Creates a training dataset with different networks and augmentation types (dataset_loader) so that the shuffles
@@ -1009,6 +1019,12 @@ def create_training_model_comparison(
     """
     # read cfg file
     cfg = auxiliaryfunctions.read_config(config)
+
+    if windows2linux:
+        warnings.warn(
+            "`windows2linux` has no effect since 2.2.0.4 and will be removed in 2.2.1.",
+            FutureWarning,
+        )
 
     # create log file
     log_file_name = os.path.join(cfg["project_path"], "training_model_comparison.log")

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -178,7 +178,7 @@ def dropannotationfileentriesduetodeletedimages(config):
         DC = pd.read_hdf(fn)
         dropped = False
         for imagename in DC.index:
-            if os.path.isfile(os.path.join(cfg["project_path"], imagename)):
+            if os.path.isfile(os.path.join(cfg["project_path"], *imagename)):
                 pass
             else:
                 print("Dropping...", imagename)
@@ -292,6 +292,7 @@ def check_labels(
             DataCombined = pd.read_hdf(
                 os.path.join(str(folder), "CollectedData_" + cfg["scorer"] + ".h5")
             )
+            conversioncode.guarantee_multiindex_rows(DataCombined)
             if cfg.get("multianimalproject", False):
                 color_by = "individual" if visualizeindividuals else "bodypart"
             else:  # for single animal projects
@@ -403,7 +404,7 @@ def _robust_path_split(path):
     return parent, filename, ext
 
 
-def merge_annotateddatasets(cfg, trainingsetfolder_full, windows2linux):
+def merge_annotateddatasets(cfg, trainingsetfolder_full):
     """
     Merges all the h5 files for all labeled-datasets (from individual videos).
 
@@ -453,30 +454,10 @@ def merge_annotateddatasets(cfg, trainingsetfolder_full, windows2linux):
     AnnotationData = AnnotationData.reindex(
         bodyparts, axis=1, level=AnnotationData.columns.names.index("bodyparts")
     )
-
-    # Let's check if the code is *not* run on windows (Source: #https://stackoverflow.com/questions/1325581/how-do-i-check-if-im-running-on-windows-in-python)
-    # but the paths are in windows format...
-    windowspath = "\\" in AnnotationData.index[0]
-    if os.name != "nt" and windowspath and not windows2linux:
-        print(
-            "It appears that the images were labeled on a Windows system, but you are currently trying to create a training set on a Unix system. \n In this case the paths should be converted. Do you want to proceed with the conversion?"
-        )
-        askuser = input("yes/no")
-    else:
-        askuser = "no"
-
+    conversioncode.guarantee_multiindex_rows(AnnotationData)
     filename = os.path.join(trainingsetfolder_full, f'CollectedData_{cfg["scorer"]}')
-    if (
-        windows2linux or askuser == "yes" or askuser == "y" or askuser == "Ja"
-    ):  # convert windows path in pandas array \\ to unix / !
-        AnnotationData = conversioncode.convertpaths_to_unixstyle(
-            AnnotationData, filename
-        )
-        print("Annotation data converted to unix format...")
-    else:  # store as is
-        AnnotationData.to_hdf(filename + ".h5", key="df_with_missing", mode="w")
-        AnnotationData.to_csv(filename + ".csv")  # human readable.
-
+    AnnotationData.to_hdf(filename + ".h5", key="df_with_missing", mode="w")
+    AnnotationData.to_csv(filename + ".csv")  # human readable.
     return AnnotationData
 
 
@@ -539,7 +520,7 @@ def pad_train_test_indices(train_inds, test_inds, train_fraction):
     return train_inds, test_inds
 
 
-def mergeandsplit(config, trainindex=0, uniform=True, windows2linux=False):
+def mergeandsplit(config, trainindex=0, uniform=True):
     """
     This function allows additional control over "create_training_dataset".
 
@@ -560,10 +541,6 @@ def mergeandsplit(config, trainindex=0, uniform=True, windows2linux=False):
 
     uniform: bool, optional
         Perform uniform split (disregarding folder structure in labeled data), or (if False) leave one folder out.
-
-    windows2linux: bool.
-        The annotation files contain path formated according to your operating system. If you label on windows
-        but train & evaluate on a unix system (e.g. ubunt, colab, Mac) set this variable to True to convert the paths.
 
     Examples
     --------
@@ -600,11 +577,11 @@ def mergeandsplit(config, trainindex=0, uniform=True, windows2linux=False):
         Data = merge_annotateddatasets(
             cfg,
             Path(os.path.join(project_path, trainingsetfolder)),
-            windows2linux=windows2linux,
         )
         if Data is None:
             return [], []
 
+    conversioncode.guarantee_multiindex_rows(Data)
     Data = Data[scorer]  # extract labeled data
 
     if uniform == True:
@@ -619,8 +596,7 @@ def mergeandsplit(config, trainindex=0, uniform=True, windows2linux=False):
         print("Excluding the following folder (from training):", test_video_name)
         trainIndices, testIndices = [], []
         for index, name in enumerate(Data.index):
-            # print(index,name.split(os.sep)[1])
-            if test_video_name == name.split(os.sep)[1]:  # this is the video name
+            if test_video_name == name[1]:  # this is the video name
                 # print(name,test_video_name)
                 testIndices.append(index)
             else:
@@ -650,7 +626,7 @@ def format_training_data(df, train_inds, nbodyparts, project_path):
         data = dict()
         filename = df.index[i]
         data["image"] = filename
-        img_shape = read_image_shape_fast(os.path.join(project_path, filename))
+        img_shape = read_image_shape_fast(os.path.join(project_path, *filename))
         data["size"] = img_shape
         temp = df.iloc[i].values.reshape(-1, 2)
         joints = np.c_[range(nbodyparts), temp]
@@ -682,7 +658,6 @@ def create_training_dataset(
     config,
     num_shuffles=1,
     Shuffles=None,
-    windows2linux=False,
     userfeedback=False,
     trainIndices=None,
     testIndices=None,
@@ -705,10 +680,6 @@ def create_training_dataset(
 
     Shuffles: list of shuffles.
         Alternatively the user can also give a list of shuffles (integers!).
-
-    windows2linux: bool.
-        The annotation files contain path formated according to your operating system. If you label on windows
-        but train & evaluate on a unix system (e.g. ubunt, colab, Mac) set this variable to True to convert the paths.
 
     userfeedback: bool, optional
         If this is set to false, then all requested train/test splits are created (no matter if they already exist). If you
@@ -746,7 +717,7 @@ def create_training_dataset(
         )
 
         create_multianimaltraining_dataset(
-            config, num_shuffles, Shuffles, windows2linux, net_type
+            config, num_shuffles, Shuffles, net_type
         )
     else:
         scorer = cfg["scorer"]
@@ -760,7 +731,7 @@ def create_training_dataset(
         )
 
         Data = merge_annotateddatasets(
-            cfg, Path(os.path.join(project_path, trainingsetfolder)), windows2linux
+            cfg, Path(os.path.join(project_path, trainingsetfolder)),
         )
         if Data is None:
             return
@@ -996,7 +967,6 @@ def create_training_model_comparison(
     net_types=["resnet_50"],
     augmenter_types=["default"],
     userfeedback=False,
-    windows2linux=False,
 ):
     """
     Creates a training dataset with different networks and augmentation types (dataset_loader) so that the shuffles
@@ -1027,10 +997,6 @@ def create_training_model_comparison(
     userfeedback: bool, optional
         If this is set to false, then all requested train/test splits are created (no matter if they already exist). If you
         want to assure that previous splits etc. are not overwritten, then set this to True and you will be asked for each split.
-
-    windows2linux: bool.
-        The annotation files contain path formated according to your operating system. If you label on windows
-        but train & evaluate on a unix system (e.g. ubunt, colab, Mac) set this variable to True to convert the paths.
 
     Example
     --------
@@ -1089,6 +1055,5 @@ def create_training_model_comparison(
                     testIndices=[testIndices],
                     augmenter_type=aug,
                     userfeedback=userfeedback,
-                    windows2linux=windows2linux,
                 )
                 logger.info(log_info)

--- a/deeplabcut/gui/labeling_toolbox.py
+++ b/deeplabcut/gui/labeling_toolbox.py
@@ -943,8 +943,6 @@ class MainFrame(BaseFrame):
         self.dataFrame.to_hdf(
             os.path.join(self.dir, "CollectedData_" + self.scorer + ".h5"),
             "df_with_missing",
-            format="table",
-            mode="w",
         )
 
     def onChecked(self, event):

--- a/deeplabcut/gui/labeling_toolbox.py
+++ b/deeplabcut/gui/labeling_toolbox.py
@@ -653,8 +653,8 @@ class MainFrame(BaseFrame):
             self.iter = 0
 
         # Reading the image name
-        self.img = Path(*self.dataFrame.index[self.iter])
-        img_name = self.img.name
+        self.img = os.path.join(*self.dataFrame.index[self.iter])
+        img_name = Path(self.img).name
         self.norm, self.colorIndex = self.image_panel.getColorIndices(
             self.img, self.bodyparts
         )

--- a/deeplabcut/gui/multiple_individuals_labeling_toolbox.py
+++ b/deeplabcut/gui/multiple_individuals_labeling_toolbox.py
@@ -1317,8 +1317,6 @@ class MainFrame(BaseFrame):
         self.dataFrame.to_hdf(
             os.path.join(self.dir, "CollectedData_" + self.scorer + ".h5"),
             "df_with_missing",
-            format="table",
-            mode="w",
         )
 
     def onChecked(self, event):

--- a/deeplabcut/gui/multiple_individuals_labeling_toolbox.py
+++ b/deeplabcut/gui/multiple_individuals_labeling_toolbox.py
@@ -34,6 +34,7 @@ from deeplabcut.utils import (
     auxiliaryfunctions,
     auxfun_multianimal,
     auxiliaryfunctions_3d,
+    conversioncode,
 )
 
 # ###########################################################################
@@ -780,21 +781,17 @@ class MainFrame(BaseFrame):
         self.statusbar.SetStatusText(
             "Working on folder: {}".format(os.path.split(str(self.dir))[-1])
         )
-        self.relativeimagenames = [
+        relativeimagenames = [
             "labeled" + n.split("labeled")[1] for n in self.index
         ]  # [n.split(self.project_path+'/')[1] for n in self.index]
-
+        self.relativeimagenames = [tuple(name.split(os.path.sep))
+                                   for name in relativeimagenames]
         # Reading the existing dataset,if already present
         try:
             self.dataFrame = pd.read_hdf(
                 os.path.join(self.dir, "CollectedData_" + self.scorer + ".h5")
             )
-            # Handle data previously labeled on a different platform
-            sep = "/" if "/" in self.dataFrame.index[0] else "\\"
-            if sep != os.path.sep:
-                self.dataFrame.index = self.dataFrame.index.str.replace(
-                    sep, os.path.sep
-                )
+            conversioncode.guarantee_multiindex_rows(self.dataFrame)
             self.dataFrame.sort_index(inplace=True)
             self.prev.Enable(True)
             # Finds the first empty row in the dataframe and sets the iteration to that index
@@ -832,7 +829,7 @@ class MainFrame(BaseFrame):
         img_name = Path(self.index[self.iter]).name
 
         # Checking for new frames and adding them to the existing dataframe
-        old_imgs = np.sort(list(self.dataFrame.index))
+        old_imgs = sorted(self.dataFrame.index)
         self.newimages = list(set(self.relativeimagenames) - set(old_imgs))
         if self.newimages:
             print("Found new frames..")
@@ -1001,27 +998,30 @@ class MainFrame(BaseFrame):
             if uniquebodyparts is not None:
                 if prefix == "single":
                     for c, bp in enumerate(uniquebodyparts):
-                        index = pd.MultiIndex.from_product(
+                        cols = pd.MultiIndex.from_product(
                             [[self.scorer], [prefix], [bp], ["x", "y"]],
                             names=["scorer", "individuals", "bodyparts", "coords"],
                         )
-                        frame = pd.DataFrame(a, columns=index, index=relativeimagenames)
+                        index = pd.MultiIndex.from_tuples(relativeimagenames)
+                        frame = pd.DataFrame(a, columns=cols, index=index)
                         dataFrame = pd.concat([dataFrame, frame], axis=1)
                 else:
                     for c, bp in enumerate(multibodyparts):
-                        index = pd.MultiIndex.from_product(
+                        cols = pd.MultiIndex.from_product(
                             [[self.scorer], [prefix], [bp], ["x", "y"]],
                             names=["scorer", "individuals", "bodyparts", "coords"],
                         )
-                        frame = pd.DataFrame(a, columns=index, index=relativeimagenames)
+                        index = pd.MultiIndex.from_tuples(relativeimagenames)
+                        frame = pd.DataFrame(a, columns=cols, index=index)
                         dataFrame = pd.concat([dataFrame, frame], axis=1)
             else:
                 for c, bp in enumerate(multibodyparts):
-                    index = pd.MultiIndex.from_product(
+                    cols = pd.MultiIndex.from_product(
                         [[self.scorer], [prefix], [bp], ["x", "y"]],
                         names=["scorer", "individuals", "bodyparts", "coords"],
                     )
-                    frame = pd.DataFrame(a, columns=index, index=relativeimagenames)
+                    index = pd.MultiIndex.from_tuples(relativeimagenames)
+                    frame = pd.DataFrame(a, columns=cols, index=index)
                     dataFrame = pd.concat([dataFrame, frame], axis=1)
         dataFrame.sort_index(inplace=True)
         return dataFrame

--- a/deeplabcut/gui/multiple_individuals_refinement_toolbox.py
+++ b/deeplabcut/gui/multiple_individuals_refinement_toolbox.py
@@ -31,7 +31,11 @@ from skimage import io
 
 from deeplabcut.gui import auxfun_drag
 from deeplabcut.gui.widgets import BasePanel, WidgetPanel, BaseFrame
-from deeplabcut.utils import auxiliaryfunctions, visualization
+from deeplabcut.utils import (
+    auxiliaryfunctions,
+    visualization,
+    conversioncode,
+)
 
 
 # ###########################################################################
@@ -55,7 +59,7 @@ class ImagePanel(BasePanel):
                     + "/"
                     + str(len(index) - 1)
                     + " "
-                    + str(Path(index[itr]).stem)
+                    + str(Path(*index[itr]).stem)
                     + " "
                     + " Threshold chosen is: "
                     + str("{0:.2f}".format(threshold))
@@ -68,7 +72,7 @@ class ImagePanel(BasePanel):
                     + "/"
                     + str(len(index) - 1)
                     + " "
-                    + str(Path(index[itr]).stem)
+                    + str(Path(*index[itr]).stem)
                 )
             )
         if keep_view:
@@ -313,7 +317,7 @@ class MainFrame(BaseFrame):
         MainFrame.updateZoomPan(self)
         self.updatedCoords = []
 
-        img_name = Path(self.index[self.iter]).name
+        img_name = Path(*self.index[self.iter]).name
         #        self.axes.clear()
         self.figure.delaxes(self.figure.axes[1])
         (
@@ -406,6 +410,7 @@ class MainFrame(BaseFrame):
                     .unique()
                     .to_list()
             )
+            conversioncode.guarantee_multiindex_rows(self.Dataframe)
             self.Dataframe.sort_index(inplace=True)
             self.scorer = self.Dataframe.columns.get_level_values(0)[0]
 
@@ -416,7 +421,7 @@ class MainFrame(BaseFrame):
             self.index = list(self.Dataframe.iloc[:, 0].index)
             # Reading images
 
-            self.img = os.path.join(self.project_path, self.index[self.iter])
+            self.img = os.path.join(self.project_path, *self.index[self.iter])
             img_name = Path(self.img).name
             self.norm, self.colorIndex = self.image_panel.getColorIndices(
                 self.img, self.bodyparts
@@ -483,7 +488,7 @@ class MainFrame(BaseFrame):
                 textBox.ShowModal()
                 self.threshold = float(textBox.GetValue())
                 textBox.Destroy()
-                self.img = os.path.join(self.project_path, self.index[self.iter])
+                self.img = os.path.join(self.project_path, *self.index[self.iter])
                 img_name = Path(self.img).name
                 self.axes.clear()
                 self.preview = False
@@ -569,7 +574,7 @@ class MainFrame(BaseFrame):
 
         if len(self.index) > self.iter:
             self.updatedCoords = []
-            self.img = os.path.join(self.project_path, self.index[self.iter])
+            self.img = os.path.join(self.project_path, *self.index[self.iter])
             img_name = Path(self.img).name
 
             # Plotting
@@ -624,7 +629,7 @@ class MainFrame(BaseFrame):
                     self.index = list(self.Dataframe.iloc[:, 0].index)
                 self.iter = self.iter - 1
 
-                self.img = os.path.join(self.project_path, self.index[self.iter])
+                self.img = os.path.join(self.project_path, *self.index[self.iter])
                 img_name = Path(self.img).name
 
                 (
@@ -673,7 +678,7 @@ class MainFrame(BaseFrame):
         if self.iter >= 0:
             self.updatedCoords = []
             # Reading Image
-            self.img = os.path.join(self.project_path, self.index[self.iter])
+            self.img = os.path.join(self.project_path, *self.index[self.iter])
             img_name = Path(self.img).name
 
             # Plotting
@@ -779,7 +784,7 @@ class MainFrame(BaseFrame):
     def check_labels(self):
         print("Checking labels if they are outside the image")
         for i in self.Dataframe.index:
-            image_name = os.path.join(self.project_path, i)
+            image_name = os.path.join(self.project_path, *i)
             im = PIL.Image.open(image_name)
             self.width, self.height = im.size
             for ind in self.individual_names:

--- a/deeplabcut/gui/outlier_frame_extraction_toolbox.py
+++ b/deeplabcut/gui/outlier_frame_extraction_toolbox.py
@@ -26,7 +26,11 @@ from skimage.util import img_as_ubyte
 
 from deeplabcut.create_project import add
 from deeplabcut.gui.widgets import BasePanel, WidgetPanel, BaseFrame
-from deeplabcut.utils import auxiliaryfunctions, visualization
+from deeplabcut.utils import (
+    auxiliaryfunctions,
+    visualization,
+    conversioncode,
+)
 from deeplabcut.utils.auxfun_videos import VideoWriter
 
 
@@ -226,6 +230,7 @@ class MainFrame(BaseFrame):
         self.video_source = Path(video).resolve()
         self.shuffle = shuffle
         self.Dataframe = Dataframe
+        conversioncode.guarantee_multiindex_rows(self.Dataframe)
         self.savelabeled = savelabeled
         self.multianimal = multianimal
         if self.multianimal:
@@ -384,6 +389,7 @@ class MainFrame(BaseFrame):
             if self.savelabeled:
                 self.figure.savefig(labeled_img_name, bbox_inches="tight")
             Data = pd.read_hdf(self.machinefile)
+            conversioncode.guarantee_multiindex_rows(Data)
             DataCombined = pd.concat([Data, DF])
             DataCombined = DataCombined[~DataCombined.index.duplicated(keep="first")]
             DataCombined.to_hdf(self.machinefile, key="df_with_missing", mode="w")

--- a/deeplabcut/gui/refinement.py
+++ b/deeplabcut/gui/refinement.py
@@ -31,7 +31,7 @@ from skimage import io
 
 from deeplabcut.gui import auxfun_drag
 from deeplabcut.gui.widgets import BasePanel, WidgetPanel, BaseFrame
-from deeplabcut.utils import auxiliaryfunctions
+from deeplabcut.utils import auxiliaryfunctions, conversioncode
 
 
 # ###########################################################################
@@ -72,7 +72,7 @@ class ImagePanel(BasePanel):
                     + "/"
                     + str(len(index) - 1)
                     + " "
-                    + str(Path(index[itr]).stem)
+                    + str(Path(*index[itr]).stem)
                     + " "
                     + " Threshold chosen is: "
                     + str("{0:.2f}".format(threshold))
@@ -85,7 +85,7 @@ class ImagePanel(BasePanel):
                     + "/"
                     + str(len(index) - 1)
                     + " "
-                    + str(Path(index[itr]).stem)
+                    + str(Path(*index[itr]).stem)
                 )
             )
 
@@ -311,7 +311,7 @@ class MainFrame(BaseFrame):
         MainFrame.updateZoomPan(self)
         self.updatedCoords = []
 
-        img_name = Path(self.index[self.iter]).name
+        img_name = Path(*self.index[self.iter]).name
         #        self.axes.clear()
         self.figure.delaxes(self.figure.axes[1])
         self.figure, self.axes, self.canvas, self.toolbar = self.image_panel.drawplot(
@@ -391,6 +391,7 @@ class MainFrame(BaseFrame):
 
         if os.path.isfile(self.dataname):
             self.Dataframe = pd.read_hdf(self.dataname)
+            conversioncode.guarantee_multiindex_rows(self.Dataframe)
             self.Dataframe.sort_index(inplace=True)
             self.scorer = self.Dataframe.columns.get_level_values(0)[0]
 
@@ -401,7 +402,7 @@ class MainFrame(BaseFrame):
             self.index = list(self.Dataframe.iloc[:, 0].index)
             # Reading images
 
-            self.img = os.path.join(self.project_path, self.index[self.iter])
+            self.img = os.path.join(self.project_path, *self.index[self.iter])
             img_name = Path(self.img).name
             self.norm, self.colorIndex = self.image_panel.getColorIndices(
                 self.img, self.bodyparts
@@ -457,7 +458,7 @@ class MainFrame(BaseFrame):
                 textBox.ShowModal()
                 self.threshold = float(textBox.GetValue())
                 textBox.Destroy()
-                self.img = os.path.join(self.project_path, self.index[self.iter])
+                self.img = os.path.join(self.project_path, *self.index[self.iter])
                 img_name = Path(self.img).name
                 self.axes.clear()
                 self.preview = False
@@ -540,7 +541,7 @@ class MainFrame(BaseFrame):
 
         if len(self.index) > self.iter:
             self.updatedCoords = []
-            self.img = os.path.join(self.project_path, self.index[self.iter])
+            self.img = os.path.join(self.project_path, *self.index[self.iter])
             img_name = Path(self.img).name
 
             # Plotting
@@ -577,7 +578,7 @@ class MainFrame(BaseFrame):
                     self.index = list(self.Dataframe.iloc[:, 0].index)
                 self.iter = self.iter - 1
 
-                self.img = os.path.join(self.project_path, self.index[self.iter])
+                self.img = os.path.join(self.project_path, *self.index[self.iter])
                 img_name = Path(self.img).name
 
                 (
@@ -626,7 +627,7 @@ class MainFrame(BaseFrame):
         if self.iter >= 0:
             self.updatedCoords = []
             # Reading Image
-            self.img = os.path.join(self.project_path, self.index[self.iter])
+            self.img = os.path.join(self.project_path, *self.index[self.iter])
             img_name = Path(self.img).name
 
             # Plotting
@@ -697,7 +698,7 @@ class MainFrame(BaseFrame):
     def check_labels(self):
         print("Checking labels if they are outside the image")
         for i in self.Dataframe.index:
-            image_name = os.path.join(self.project_path, i)
+            image_name = os.path.join(self.project_path, *i)
             im = PIL.Image.open(image_name)
             width, height = im.size
             for bpindex, bp in enumerate(self.bodyparts):

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -585,7 +585,7 @@ def evaluate_network(
         from deeplabcut.pose_estimation_tensorflow.datasets.utils import (
             data_to_input,
         )
-        from deeplabcut.utils import auxiliaryfunctions
+        from deeplabcut.utils import auxiliaryfunctions, conversioncode
         import tensorflow as tf
 
         # If a string was passed in, auto-convert to True for backward compatibility
@@ -741,6 +741,7 @@ def evaluate_network(
                 else:
                     scale = 1
 
+                conversioncode.guarantee_multiindex_rows(Data)
                 ##################################################
                 # Compute predictions over images
                 ##################################################
@@ -788,7 +789,7 @@ def evaluate_network(
                         print("Running evaluation ...")
                         for imageindex, imagename in tqdm(enumerate(Data.index)):
                             image = imread(
-                                os.path.join(cfg["project_path"], imagename), mode="RGB"
+                                os.path.join(cfg["project_path"], *imagename), mode="RGB"
                             )
                             if scale != 1:
                                 image = imresize(image, scale)
@@ -825,11 +826,9 @@ def evaluate_network(
 
                         # Saving results
                         DataMachine = pd.DataFrame(
-                            PredicteData, columns=index, index=Data.index.values
+                            PredicteData, columns=index, index=Data.index
                         )
-                        DataMachine.to_hdf(
-                            resultsfilename, "df_with_missing", format="table", mode="w"
-                        )
+                        DataMachine.to_hdf(resultsfilename, "df_with_missing")
 
                         print(
                             "Analysis is done and the results are stored (see evaluation-results) for snapshot: ",
@@ -922,6 +921,7 @@ def evaluate_network(
                         # print(final_result)
                     else:
                         DataMachine = pd.read_hdf(resultsfilename)
+                        conversioncode.guarantee_multiindex_rows(DataMachine)
                         if plotting:
                             DataCombined = pd.concat(
                                 [Data.T, DataMachine.T], axis=0, sort=False

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -114,7 +114,11 @@ def evaluate_multianimal_full(
         predict,
         predict_multianimal as predictma,
     )
-    from deeplabcut.utils import auxiliaryfunctions, auxfun_multianimal
+    from deeplabcut.utils import (
+        auxiliaryfunctions,
+        auxfun_multianimal,
+        conversioncode,
+    )
 
     import tensorflow as tf
 
@@ -149,10 +153,8 @@ def evaluate_multianimal_full(
             "CollectedData_" + cfg["scorer"] + ".h5",
         )
     )
-    # Handle data previously annotated on a different platform
-    sep = "/" if "/" in Data.index[0] else "\\"
-    if sep != os.path.sep:
-        Data.index = Data.index.str.replace(sep, os.path.sep)
+    conversioncode.guarantee_multiindex_rows(Data)
+
     # Get list of body parts to evaluate network for
     comparisonbodyparts = auxiliaryfunctions.IntersectionofBodyPartsandOnesGivenbyUser(
         cfg, comparisonbodyparts
@@ -310,7 +312,7 @@ def evaluate_multianimal_full(
                         conf = np.full_like(dist, np.nan)
                         print("Network Evaluation underway...")
                         for imageindex, imagename in tqdm(enumerate(Data.index)):
-                            image_path = os.path.join(cfg["project_path"], imagename)
+                            image_path = os.path.join(cfg["project_path"], *imagename)
                             image = io.imread(image_path)
                             if image.ndim == 2 or image.shape[-1] == 1:
                                 image = skimage.color.gray2rgb(image)
@@ -577,7 +579,7 @@ def evaluate_multianimal_full(
                         colors = visualization.get_cmap(n_animals, name=cfg["colormap"])
                         for k, v in tqdm(assemblies.items()):
                             imname = image_paths[k]
-                            image_path = os.path.join(cfg["project_path"], imname)
+                            image_path = os.path.join(cfg["project_path"], *imname)
                             image = io.imread(image_path)
                             if image.ndim == 2 or image.shape[-1] == 1:
                                 image = skimage.color.gray2rgb(image)

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_deterministic.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_deterministic.py
@@ -61,7 +61,7 @@ class DeterministicPoseDataset(BasePoseDataset):
 
             item = DataItem()
             item.image_id = i
-            item.im_path = sample[0][0]
+            item.im_path = os.path.join(*[s.strip() for s in sample[0][0]])
             item.im_size = sample[1][0]
             if len(sample) >= 3:
                 joints = sample[2][0][0]

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
@@ -93,7 +93,7 @@ class ImgaugPoseDataset(BasePoseDataset):
 
                 item = DataItem()
                 item.image_id = i
-                item.im_path = sample[0][0]
+                item.im_path = os.path.join(*[s.strip() for s in sample[0][0]])
                 item.im_size = sample[1][0]
                 if len(sample) >= 3:
                     joints = sample[2][0][0]
@@ -123,7 +123,7 @@ class ImgaugPoseDataset(BasePoseDataset):
                 sample = pickledata[i]  # mlab[0, i]
                 item = DataItem()
                 item.image_id = i
-                item.im_path = sample["image"]  # [0][0]
+                item.im_path = os.path.join(*sample["image"])  # [0][0]
                 item.im_size = sample["size"]  # sample[1][0]
                 if len(sample) >= 3:
                     item.num_animals = len(sample["joints"])

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_multianimal_imgaug.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_multianimal_imgaug.py
@@ -57,7 +57,7 @@ class MAImgaugPoseDataset(BasePoseDataset):
             sample = pickledata[i]  # mlab[0, i]
             item = DataItem()
             item.image_id = i
-            item.im_path = sample["image"]  # [0][0]
+            item.im_path = os.path.join(*sample["image"])  # [0][0]
             item.im_size = sample["size"]  # sample[1][0]
             if "joints" in sample.keys():
                 Joints = sample["joints"]

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_tensorpack.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_tensorpack.py
@@ -113,7 +113,7 @@ class Pose(RNGDataFlow):
             item = DataItem()
             item.image_id = i
             base = str(self.cfg["project_path"])
-            im_path = os.path.join(base, sample[0][0])
+            im_path = os.path.join(base, *[s.strip() for s in sample[0][0]])
             item.im_path = im_path
             item.im_size = sample[1][0]
             if len(sample) >= 3:

--- a/deeplabcut/pose_estimation_tensorflow/visualizemaps.py
+++ b/deeplabcut/pose_estimation_tensorflow/visualizemaps.py
@@ -224,7 +224,7 @@ def extract_maps(
 
             DATA = {}
             for imageindex, imagename in tqdm(Indices):
-                image = imread(os.path.join(cfg["project_path"], imagename), mode="RGB")
+                image = imread(os.path.join(cfg["project_path"], *imagename), mode="RGB")
                 if scale != 1:
                     image = imresize(image, scale)
 
@@ -455,7 +455,7 @@ def extract_save_all_maps(
                 if not extract_paf:
                     paf = None
                 label = "train" if trainingframe else "test"
-                imname = os.path.split(os.path.splitext(impath)[0])[1]
+                imname = impath[-1]
                 scmap, (locref_x, locref_y), paf = resize_all_maps(
                     image, scmap, locref, paf
                 )

--- a/deeplabcut/utils/auxfun_multianimal.py
+++ b/deeplabcut/utils/auxfun_multianimal.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-from deeplabcut.utils import auxiliaryfunctions
+from deeplabcut.utils import auxiliaryfunctions, conversioncode
 from deeplabcut.generate_training_dataset import trainingsetmanipulation
 
 def extractindividualsandbodyparts(cfg):
@@ -206,6 +206,7 @@ def convert2_maDLC(config, userfeedback=True, forceindividual=None):
 
             fn = os.path.join(str(folder), "CollectedData_" + cfg["scorer"])
             Data = pd.read_hdf(fn + ".h5")
+            conversioncode.guarantee_multiindex_rows(Data)
             imindex = Data.index
 
             print("This is a single animal data set, converting to multi...", folder)
@@ -269,11 +270,11 @@ def convert2_maDLC(config, userfeedback=True, forceindividual=None):
                     dataFrame = pd.concat([dataFrame, frame], axis=1)
 
             Data.to_hdf(
-                fn + "singleanimal.h5", "df_with_missing", format="table", mode="w"
+                fn + "singleanimal.h5", "df_with_missing",
             )
             Data.to_csv(fn + "singleanimal.csv")
 
-            dataFrame.to_hdf(fn + ".h5", "df_with_missing", format="table", mode="w")
+            dataFrame.to_hdf(fn + ".h5", "df_with_missing")
             dataFrame.to_csv(fn + ".csv")
 
 
@@ -299,6 +300,7 @@ def convert_single2multiplelegacyAM(config, userfeedback=True, target=None):
         ):  # multilanguage support :)
             fn = os.path.join(str(folder), "CollectedData_" + cfg["scorer"])
             Data = pd.read_hdf(fn + ".h5")
+            conversioncode.guarantee_multiindex_rows(Data)
             imindex = Data.index
 
             if "individuals" in Data.columns.names and (
@@ -342,12 +344,12 @@ def convert_single2multiplelegacyAM(config, userfeedback=True, target=None):
                         DataFrame = pd.concat([DataFrame, dataFrame], axis=1)
 
                 Data.to_hdf(
-                    fn + "multianimal.h5", "df_with_missing", format="table", mode="w"
+                    fn + "multianimal.h5", "df_with_missing",
                 )
                 Data.to_csv(fn + "multianimal.csv")
 
                 DataFrame.to_hdf(
-                    fn + ".h5", "df_with_missing", format="table", mode="w"
+                    fn + ".h5", "df_with_missing",
                 )
                 DataFrame.to_csv(fn + ".csv")
             elif target == None or target == "multi":
@@ -429,12 +431,12 @@ def convert_single2multiplelegacyAM(config, userfeedback=True, target=None):
                         DataFrame = pd.concat([DataFrame, dataFrame], axis=1)
 
                 Data.to_hdf(
-                    fn + "singleanimal.h5", "df_with_missing", format="table", mode="w"
+                    fn + "singleanimal.h5", "df_with_missing",
                 )
                 Data.to_csv(fn + "singleanimal.csv")
 
                 DataFrame.to_hdf(
-                    fn + ".h5", "df_with_missing", format="table", mode="w"
+                    fn + ".h5", "df_with_missing",
                 )
                 DataFrame.to_csv(fn + ".csv")
 

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -16,6 +16,7 @@ import pandas as pd
 import ruamel.yaml.representer
 import yaml
 from ruamel.yaml import YAML
+from deeplabcut.utils import conversioncode
 
 
 def create_config_template(multianimal=False):

--- a/deeplabcut/utils/conversioncode.py
+++ b/deeplabcut/utils/conversioncode.py
@@ -9,81 +9,9 @@ Licensed under GNU Lesser General Public License v3.0
 """
 
 import os
-from pathlib import Path
-
 import pandas as pd
-
-from deeplabcut.generate_training_dataset import trainingsetmanipulation
 from deeplabcut.utils import auxiliaryfunctions
-import warnings
-
-
-def convertannotationdata_fromwindows2unixstyle(
-    config, userfeedback=True, win2linux=True
-):
-    """
-    Converts paths in annotation file (CollectedData_*user*.h5) in labeled-data/videofolder1, etc.
-
-    from windows to linux format. This is important when one e.g. labeling on Windows, but
-    wants to re-label/check_labels/ on a Linux computer (and vice versa).
-
-    Note for training data annotated on Windows in Linux this is not necessary, as the data
-    gets converted during training set creation.
-
-    config : string
-        Full path of the config.yaml file as a string.
-
-    userfeedback: bool, optional
-        If true the user will be asked specifically for each folder in labeled-data if the containing csv shall be converted to hdf format.
-
-    win2linux: bool, optional.
-        By default converts from windows to linux. If false, converts from unix to windows.
-    """
-    cfg = auxiliaryfunctions.read_config(config)
-    folders = [
-        Path(config).parent / "labeled-data" / trainingsetmanipulation._robust_path_split(vid)[1]
-        for vid in cfg["video_sets"]
-    ]
-
-    for folder in folders:
-        if userfeedback:
-            print("Do you want to convert the annotationdata in folder:", folder, "?")
-            askuser = input("yes/no")
-        else:
-            askuser = "yes"
-
-        if askuser == "y" or askuser == "yes" or askuser == "Ja" or askuser == "ha":
-            fn = os.path.join(str(folder), "CollectedData_" + cfg["scorer"])
-            if os.path.exists(fn + ".h5"):
-                Data = pd.read_hdf(fn + ".h5")
-                if win2linux:
-                    convertpaths_to_unixstyle(Data, fn)
-                else:
-                    convertpaths_to_windowsstyle(Data, fn)
-            else:
-                warnings.warn(f"Could not find '{fn+'.h5'}'. skipping")
-
-
-def convertpaths_to_unixstyle(Data, fn):
-    """ auxiliary function that converts paths in annotation files:
-        labeled-data\\video\\imgXXX.png to labeled-data/video/imgXXX.png """
-    Data.to_csv(fn + "windows" + ".csv")
-    Data.to_hdf(fn + "windows" + ".h5", "df_with_missing", format="table", mode="w")
-    Data.index = Data.index.str.replace("\\", "/")
-    Data.to_csv(fn + ".csv")
-    Data.to_hdf(fn + ".h5", "df_with_missing", format="table", mode="w")
-    return Data
-
-
-def convertpaths_to_windowsstyle(Data, fn):
-    """ auxiliary function that converts paths in annotation files:
-        labeled-data/video/imgXXX.png to labeled-data\\video\\imgXXX.png """
-    Data.to_csv(fn + "unix" + ".csv")
-    Data.to_hdf(fn + "unix" + ".h5", "df_with_missing", format="table", mode="w")
-    Data.index = Data.index.str.replace("/", "\\")
-    Data.to_csv(fn + ".csv")
-    Data.to_hdf(fn + ".h5", "df_with_missing", format="table", mode="w")
-    return Data
+from pathlib import Path
 
 
 def convertcsv2h5(config, userfeedback=True, scorer=None):
@@ -213,3 +141,12 @@ def merge_windowsannotationdataONlinuxsystem(cfg):
             print(filename, " not found (perhaps not annotated)")
 
     return AnnotationData
+
+
+def guarantee_multiindex_rows(df):
+    # Make paths platform-agnostic if they are not already
+    if not isinstance(df.index, pd.MultiIndex):  # Backwards compatibility
+        path = df.index[0]
+        sep = "/" if "/" in path else "\\"
+        splits = tuple(df.index.str.split(sep))
+        df.index = pd.MultiIndex.from_tuples(splits)

--- a/deeplabcut/utils/visualization.py
+++ b/deeplabcut/utils/visualization.py
@@ -149,7 +149,7 @@ def plot_and_save_labeled_frame(
     ax,
     scaling=1,
 ):
-    image_path = os.path.join(cfg["project_path"], DataCombined.index[ind])
+    image_path = os.path.join(cfg["project_path"], *DataCombined.index[ind])
     frame = io.imread(image_path)
     if np.ndim(frame) > 2:  # color image!
         h, w, numcolors = np.shape(frame)
@@ -295,15 +295,12 @@ def make_labeled_images_from_dataframe(
             bones.extend(zip(match1, match2))
     ind_bones = tuple(zip(*bones))
 
-    sep = "/" if "/" in df.index[0] else "\\"
-    images = cfg["project_path"] + sep + df.index
-    if sep != os.path.sep:
-        images = images.str.replace(sep, os.path.sep)
+    images_list = [os.path.join(cfg["project_path"], *tuple_)
+                   for tuple_ in df.index.tolist()]
     if not destfolder:
-        destfolder = os.path.dirname(images[0])
+        destfolder = os.path.dirname(images_list[0])
     tmpfolder = destfolder + "_labeled"
     attempttomakefolder(tmpfolder)
-    images_list = images.to_list()
     ic = io.imread_collection(images_list)
 
     h, w = ic[0].shape[:2]

--- a/docs/recipes/BatchProcessing.md
+++ b/docs/recipes/BatchProcessing.md
@@ -114,7 +114,7 @@ for project in Projects[model]:
     print("Shuffle: ", shuffle)
     print("config: ", config)
 
-    deeplabcut.create_training_dataset(config, Shuffles=[shuffle],windows2linux=True)
+    deeplabcut.create_training_dataset(config, Shuffles=[shuffle])
 
     deeplabcut.train_network(config, shuffle=shuffle, max_snapshots_to_keep=5, maxiters=Maxiter)
     print("Evaluating...")

--- a/examples/testscript_multianimal.py
+++ b/examples/testscript_multianimal.py
@@ -2,7 +2,7 @@ import os
 import deeplabcut
 import numpy as np
 import pandas as pd
-import shutil
+import pickle
 from deeplabcut.utils import auxfun_multianimal, auxiliaryfunctions
 
 
@@ -93,6 +93,17 @@ if __name__ == "__main__":
     print("Creating train dataset...")
     deeplabcut.create_multianimaltraining_dataset(config_path, net_type=NET, crop_size=(200, 200))
     print("Train dataset created.")
+
+    # Check the training image paths are correctly stored as arrays of strings
+    trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(cfg)
+    datafile, _ = auxiliaryfunctions.GetDataandMetaDataFilenames(
+        trainingsetfolder, 0.8, 1, cfg,
+    )
+    datafile = datafile.split(".mat")[0] + ".pickle"
+    with open(os.path.join(cfg["project_path"], datafile), "rb") as f:
+        pickledata = pickle.load(f)
+    num_images = len(pickledata)
+    assert all(len(pickledata[i]["image"]) == 3 for i in range(num_images))
 
     print("Editing pose config...")
     model_folder = auxiliaryfunctions.GetModelFolder(

--- a/tests/test_conversioncode.py
+++ b/tests/test_conversioncode.py
@@ -1,0 +1,20 @@
+import os
+import pandas as pd
+from conftest import TEST_DATA_DIR
+from deeplabcut.utils import conversioncode
+
+
+def test_guarantee_multiindex_rows():
+    df_unix = pd.read_hdf(os.path.join(TEST_DATA_DIR, "trimouse_calib.h5"))
+    paths = list(df_unix.index)
+    df_posix = df_unix.copy()
+    df_posix.index = df_posix.index.str.replace("/", "\\")
+    nrows = len(df_unix)
+    for df in (df_unix, df_posix):
+        conversioncode.guarantee_multiindex_rows(df)
+        assert isinstance(df.index, pd.MultiIndex)
+        assert len(df) == nrows
+        assert df.index.nlevels == 3
+        assert all(df.index.get_level_values(0) == "labeled-data")
+        assert all(img.endswith('.png') for img in df.index.get_level_values(2))
+        assert [os.path.join(*tup) for tup in df.index] == paths

--- a/tests/test_conversioncode.py
+++ b/tests/test_conversioncode.py
@@ -6,7 +6,6 @@ from deeplabcut.utils import conversioncode
 
 def test_guarantee_multiindex_rows():
     df_unix = pd.read_hdf(os.path.join(TEST_DATA_DIR, "trimouse_calib.h5"))
-    paths = list(df_unix.index)
     df_posix = df_unix.copy()
     df_posix.index = df_posix.index.str.replace("/", "\\")
     nrows = len(df_unix)
@@ -17,4 +16,3 @@ def test_guarantee_multiindex_rows():
         assert df.index.nlevels == 3
         assert all(df.index.get_level_values(0) == "labeled-data")
         assert all(img.endswith('.png') for img in df.index.get_level_values(2))
-        assert [os.path.join(*tup) for tup in df.index] == paths

--- a/tests/test_inferenceutils.py
+++ b/tests/test_inferenceutils.py
@@ -2,11 +2,9 @@ import numpy as np
 import os
 import pickle
 import pytest
+from conftest import TEST_DATA_DIR
 from deeplabcut.pose_estimation_tensorflow.lib import inferenceutils
 from scipy.spatial.distance import squareform
-
-
-TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
 
 
 def test_conv_square_to_condensed_indices():

--- a/tests/test_pose_multianimal_imgaug.py
+++ b/tests/test_pose_multianimal_imgaug.py
@@ -1,6 +1,7 @@
 import numpy as np
 import os
 import pytest
+from conftest import TEST_DATA_DIR
 from deeplabcut.pose_estimation_tensorflow.datasets import (
     Batch,
     pose_multianimal_imgaug,
@@ -16,10 +17,6 @@ pose_multianimal_imgaug.imread = mock_imread
 
 @pytest.fixture()
 def ma_dataset():
-    TEST_DATA_DIR = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)),
-        "data"
-    )
     cfg = read_plainconfig(os.path.join(TEST_DATA_DIR, "pose_cfg.yaml"))
     cfg["project_path"] = TEST_DATA_DIR
     cfg["dataset"] = "trimouse_train_data.pickle"

--- a/tests/test_trainingsetmanipulation.py
+++ b/tests/test_trainingsetmanipulation.py
@@ -1,10 +1,16 @@
 import numpy as np
 import os
+import pandas as pd
 from conftest import TEST_DATA_DIR
 from deeplabcut.generate_training_dataset import (
     read_image_shape_fast,
     SplitTrials,
+    format_training_data,
+    format_multianimal_training_data,
+    trainingsetmanipulation,
+    multiple_individuals_trainingsetmanipulation,
 )
+from deeplabcut.utils.conversioncode import guarantee_multiindex_rows
 from skimage import io, color
 
 
@@ -29,3 +35,55 @@ def test_split_trials():
         train_inds = train_inds[train_inds != -1]
         test_inds = test_inds[test_inds != -1]
         assert (len(train_inds) + len(test_inds)) == n_rows
+
+
+def test_format_training_data(monkeypatch):
+    fake_shape = 3, 480, 640
+    monkeypatch.setattr(
+        trainingsetmanipulation,
+        "read_image_shape_fast",
+        lambda _: fake_shape,
+    )
+    df = pd.read_hdf(
+        os.path.join(TEST_DATA_DIR, "trimouse_calib.h5")
+    ).xs("mus1", level="individuals", axis=1)
+    guarantee_multiindex_rows(df)
+    train_inds = list(range(10))
+    _, data = format_training_data(df, train_inds, 12, "")
+    assert len(data) == len(train_inds)
+    # Check data comprise path, shape, and xy coordinates
+    assert all(len(d) == 3 for d in data)
+    assert all(
+        (d[0].size == 3
+         and d[0].dtype.char == "U"
+         and d[0][0, -1].endswith(".png"))
+        for d in data
+    )
+    assert all(np.all(d[1] == np.array(fake_shape)[None]) for d in data)
+    assert all(
+        (d[2][0, 0].shape[1] == 3
+         and d[2][0, 0].dtype == np.int64)
+        for d in data
+    )
+
+
+def test_format_multianimal_training_data(monkeypatch):
+    fake_shape = 3, 480, 640
+    monkeypatch.setattr(
+        multiple_individuals_trainingsetmanipulation,
+        "read_image_shape_fast",
+        lambda _: fake_shape,
+    )
+    df = pd.read_hdf(os.path.join(TEST_DATA_DIR, "trimouse_calib.h5"))
+    guarantee_multiindex_rows(df)
+    train_inds = list(range(10))
+    n_decimals = 1
+    data = format_multianimal_training_data(df, train_inds, "", n_decimals)
+    assert len(data) == len(train_inds)
+    assert all(isinstance(d, dict) for d in data)
+    assert all(len(d['image']) == 3 for d in data)
+    assert all(np.all(d["size"] == np.array(fake_shape)) for d in data)
+    assert all(
+        (xy.shape[1] == 3 and np.isfinite(xy).all())
+        for d in data for xy in d["joints"].values()
+    )

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,16 +1,15 @@
 import os
 import pytest
+from conftest import TEST_DATA_DIR
 from deeplabcut.utils.auxfun_videos import VideoWriter
 
 
-TEST_DATA_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "data")
-video = os.path.join(TEST_DATA_DIR, "vid.avi")
 POS_FRAMES = 1  # Equivalent to cv2.CAP_PROP_POS_FRAMES
 
 
 @pytest.fixture()
 def video_clip():
-    return VideoWriter(video)
+    return VideoWriter(os.path.join(TEST_DATA_DIR, "vid.avi"))
 
 
 def test_reader_wrong_inputs(tmp_path):


### PR DESCRIPTION
Image paths were stored with OS-specific path separators, making labeling/training hard across platforms (e.g., forcing users to create the training data with the machine they train their models on, and occasionally to convert their data). Paths are now stored without separators as MultiIndex (labeled-data, subfolder, imagename), making indexing/merging DataFrames easy and robust; only upon reading an image are the paths reconstructed.
I tested the GUIs as well ☺️