### PR TITLE
Default to headless when wx backend cannot be set (Importing headless even with GUI installation)

### DIFF
--- a/deeplabcut/__init__.py
+++ b/deeplabcut/__init__.py
@@ -34,7 +34,7 @@ try:
     from deeplabcut.gui.tracklet_toolbox import refine_tracklets
 
     from deeplabcut.utils.skeleton import SkeletonBuilder
-except ModuleNotFoundError:
+except (ModuleNotFoundError, ImportError):
     print(
         "DLC loaded in light mode; you cannot use any GUI (labeling, relabeling and standalone GUI)"
     )


### PR DESCRIPTION
Importing DLC installed with GUI support on a headless machine fails, asking users to have 2 separate envs (or uninstalling/reinstalling wxpython...). A less error-prone, but equally easy, solution is to catch errors upon importing matplotlib, and automatically defaults to headless if wxagg couldn't be set. What would you say @MMathisLab?

Fixes #1583 