### PR TITLE
Backward compatibility of training on data stored the old way

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_deterministic.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_deterministic.py
@@ -17,6 +17,7 @@ import numpy as np
 import os
 import scipy.io as sio
 from deeplabcut.utils.auxfun_videos import imread, imresize
+from deeplabcut.utils.conversioncode import robust_split_path
 from .factory import PoseDatasetFactory
 from .pose_base import BasePoseDataset
 from .utils import (
@@ -61,7 +62,12 @@ class DeterministicPoseDataset(BasePoseDataset):
 
             item = DataItem()
             item.image_id = i
-            item.im_path = os.path.join(*[s.strip() for s in sample[0][0]])
+            im_path = sample[0][0]
+            if isinstance(im_path, str):
+                im_path = robust_split_path(im_path)
+            else:
+                im_path = [s.strip() for s in im_path]
+            item.im_path = os.path.join(*im_path)
             item.im_size = sample[1][0]
             if len(sample) >= 3:
                 joints = sample[2][0][0]

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
@@ -24,6 +24,7 @@ import numpy as np
 import scipy.io as sio
 
 from deeplabcut.utils.auxfun_videos import imread
+from deeplabcut.utils.conversioncode import robust_split_path
 from .factory import PoseDatasetFactory
 from .pose_base import BasePoseDataset
 from .utils import DataItem, Batch
@@ -92,7 +93,12 @@ class ImgaugPoseDataset(BasePoseDataset):
 
                 item = DataItem()
                 item.image_id = i
-                item.im_path = os.path.join(*[s.strip() for s in sample[0][0]])
+                im_path = sample[0][0]
+                if isinstance(im_path, str):
+                    im_path = robust_split_path(im_path)
+                else:
+                    im_path = [s.strip() for s in im_path]
+                item.im_path = os.path.join(*im_path)
                 item.im_size = sample[1][0]
                 if len(sample) >= 3:
                     joints = sample[2][0][0]

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_multianimal_imgaug.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_multianimal_imgaug.py
@@ -21,6 +21,7 @@ from deeplabcut.pose_estimation_tensorflow.datasets.factory import PoseDatasetFa
 from deeplabcut.pose_estimation_tensorflow.datasets.pose_base import BasePoseDataset
 from deeplabcut.pose_estimation_tensorflow.datasets.utils import DataItem, Batch
 from deeplabcut.utils.auxfun_videos import imread
+from deeplabcut.utils.conversioncode import robust_split_path
 from math import sqrt
 
 
@@ -56,8 +57,11 @@ class MAImgaugPoseDataset(BasePoseDataset):
             sample = pickledata[i]  # mlab[0, i]
             item = DataItem()
             item.image_id = i
-            item.im_path = os.path.join(*sample["image"])  # [0][0]
-            item.im_size = sample["size"]  # sample[1][0]
+            im_path = sample["image"]
+            if isinstance(im_path, str):
+                im_path = robust_split_path(im_path)
+            item.im_path = os.path.join(*im_path)
+            item.im_size = sample["size"]
             if "joints" in sample.keys():
                 Joints = sample["joints"]
                 if (

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_tensorpack.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_tensorpack.py
@@ -25,6 +25,7 @@ import os
 import cv2
 import numpy as np
 import scipy.io as sio
+from deeplabcut.utils.conversioncode import robust_split_path
 from numpy import array as arr
 from tensorpack.dataflow.base import RNGDataFlow
 from tensorpack.dataflow.common import MapData
@@ -112,7 +113,12 @@ class Pose(RNGDataFlow):
             item = DataItem()
             item.image_id = i
             base = str(self.cfg["project_path"])
-            im_path = os.path.join(base, *[s.strip() for s in sample[0][0]])
+            im_path = sample[0][0]
+            if isinstance(im_path, str):
+                im_path = robust_split_path(im_path)
+            else:
+                im_path = [s.strip() for s in im_path]
+            item.im_path = os.path.join(base, *im_path)
             item.im_path = im_path
             item.im_size = sample[1][0]
             if len(sample) >= 3:

--- a/deeplabcut/utils/conversioncode.py
+++ b/deeplabcut/utils/conversioncode.py
@@ -150,3 +150,8 @@ def guarantee_multiindex_rows(df):
         sep = "/" if "/" in path else "\\"
         splits = tuple(df.index.str.split(sep))
         df.index = pd.MultiIndex.from_tuples(splits)
+
+
+def robust_split_path(s):
+    sep = "/" if "/" in s else "\\"
+    return tuple(s.split(sep))


### PR DESCRIPTION
#1584 assumed that training data would be newly formed (i.e., with path separators already stripped) when training a network. This is not always the case though (e.g., when retraining previous networks with deeplabcut-master...). This is now fixed with this PR.