### PR TITLE
Allow windows to resize to be smaller than the default size

### DIFF
--- a/deeplabcut/gui/widgets.py
+++ b/deeplabcut/gui/widgets.py
@@ -51,7 +51,7 @@ class BaseFrame(wx.Frame):
     """Contains the main GUI and button boxes"""
 
     def __init__(self, frame_title="", parent=None, imtypes=None):
-        # Settting the GUI size and panels design
+        # Setting the GUI size and panels design
         displays = (
             wx.Display(i) for i in range(wx.Display.GetCount())
         )  # Gets the number of displays
@@ -77,9 +77,8 @@ class BaseFrame(wx.Frame):
         self.statusbar = self.CreateStatusBar()
         self.statusbar.SetStatusText("")
 
-        self.SetSizeHints(
-            wx.Size(self.gui_size)
-        )  #  This sets the minimum size of the GUI. It can scale now!
+        # This sets the minimum size of the GUI. It can scale now!
+        self.SetSizeHints(wx.Size(800, 600))
 
     @staticmethod
     def calc_distance(x1, y1, x2, y2):


### PR DESCRIPTION
With multimonitors on linux, it seems that wx can sometimes detect a single "big" monitor, instead of multiple ones.

the code in `widgets.py`

```
        displays = (
            wx.Display(i) for i in range(wx.Display.GetCount())
        )  # Gets the number of displays
        screenSizes = [
            display.GetGeometry().GetSize() for display in displays
        ]  # Gets the size of each display
```
Returns a single monitor, with a riddiculously sized screen.

When it is multipled by `0.8` and `0.75` it is still often too big.

While I wish I had time to debug why wx was doing this, seeing as DeepLabCut has intentions on moving to qt, this doesn't seem so worth our time.

However, it seems reasonable to allow the users to resize their screens to something smaller than what is proportional to a window.

I suggest 800 x 600 here but I guess the numbers are adjustable.

This makes this appear:
![image](https://user-images.githubusercontent.com/90008/146086055-566e37d5-ad06-4938-a922-3cbedf838b6f.png)

Not "ideal" but I've seen some people with really small monitors. 
1400 x 600 would yield
![image](https://user-images.githubusercontent.com/90008/146086165-5b3eeb9e-5f42-45d3-8217-765ff458f81a.png)



I hope this helps.