### PR TITLE
simplified 1-click maDLC analyze video, track, create video within the GUI

### DIFF
--- a/deeplabcut/gui/analyze_videos.py
+++ b/deeplabcut/gui/analyze_videos.py
@@ -37,7 +37,7 @@ class Analyze_videos(wx.Panel):
         self.cfg = auxiliaryfunctions.read_config(self.config)
         self.draw = False
         # design the panel
-        self.sizer = wx.GridBagSizer(5, 15)
+        self.sizer = wx.GridBagSizer(5, 10)
 
 
         text = wx.StaticText(self, label="DeepLabCut - Step 7. Analyze Videos")
@@ -257,7 +257,7 @@ class Analyze_videos(wx.Panel):
         self.trail_points_text.Hide()
         self.trail_points.Hide()
 
-        self.hbox4.Add(self.trajectory_to_plot, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
+        self.hbox3.Add(self.trajectory_to_plot, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
         boxsizer.Add(self.hbox3, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
 
         self.hbox4.Add(self.draw_skeleton, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
@@ -419,7 +419,7 @@ class Analyze_videos(wx.Panel):
                 cropping=crop,
                 robust_nframes=robust,
                 auto_track=True,
-                n_tracks=self.ntracks,
+                n_tracks=self.ntracks.GetValue(),
             )
             if self.create_video_with_all_detections.GetStringSelection() == "Yes":
                 deeplabcut.create_video_with_all_detections(

--- a/deeplabcut/gui/analyze_videos.py
+++ b/deeplabcut/gui/analyze_videos.py
@@ -251,9 +251,8 @@ class Analyze_videos(wx.Panel):
                 style=wx.RA_SPECIFY_COLS,
             )
             self.trajectory.Bind(wx.EVT_RADIOBOX, self.chooseOption)
-            self.trajectory.SetSelection(1)
+            self.trajectory.SetSelection(0)
 
-            #boxsizer.Add(self.hbox2, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
             self.hbox1.Add(self.csv, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
             self.hbox1.Add(self.filter, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
             self.hbox3.Add(self.showfigs, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
@@ -475,6 +474,9 @@ class Analyze_videos(wx.Panel):
                 )
             if self.filter.GetStringSelection() == "Yes":
                 deeplabcut.filterpredictions(self.config, self.filelist)
+
+            if self.csv.GetStringSelection() == "Yes":
+                deeplabcut.analyze_videos_converth5_to_csv(self.filelist,listofvideos=True)
         else:
             scorername = deeplabcut.analyze_videos(
                 self.config,
@@ -518,7 +520,7 @@ class Analyze_videos(wx.Panel):
         else:
             self.csv.SetSelection(1)
             self.filter.SetSelection(1)
-            self.trajectory.SetSelection(1)
+            self.trajectory.SetSelection(0)
             self.dynamic.SetSelection(1)
             # self.select_destfolder.SetPath("None")
         #self.config = []

--- a/deeplabcut/gui/analyze_videos.py
+++ b/deeplabcut/gui/analyze_videos.py
@@ -42,7 +42,7 @@ class Analyze_videos(wx.Panel):
 
         text = wx.StaticText(self, label="DeepLabCut - Step 7. Analyze Videos")
 
-        self.sizer.Add(text, pos=(0, 0), flag=wx.TOP | wx.LEFT | wx.BOTTOM, border=15)
+        self.sizer.Add(text, pos=(0, 0), flag=wx.TOP | wx.LEFT | wx.BOTTOM, border=10)
         # Add logo of DLC
         icon = wx.StaticBitmap(self, bitmap=wx.Bitmap(LOGO_PATH))
         self.sizer.Add(
@@ -51,7 +51,7 @@ class Analyze_videos(wx.Panel):
 
         line1 = wx.StaticLine(self)
         self.sizer.Add(
-            line1, pos=(1, 0), span=(1, 8), flag=wx.EXPAND | wx.BOTTOM, border=15
+            line1, pos=(1, 0), span=(1, 8), flag=wx.EXPAND | wx.BOTTOM, border=10
         )
 
         self.cfg_text = wx.StaticText(self, label="Select the config file")
@@ -96,13 +96,23 @@ class Analyze_videos(wx.Panel):
         self.hbox4 = wx.BoxSizer(wx.HORIZONTAL)
         self.hbox5 = wx.BoxSizer(wx.HORIZONTAL)
 
-#### BOX 2 ####
+#### BOX 1 ####
+
         shuffle_text = wx.StaticBox(self, label="Specify the shuffle")
         shuffle_boxsizer = wx.StaticBoxSizer(shuffle_text, wx.VERTICAL)
         self.shuffle = wx.SpinCtrl(self, value="1", min=0, max=100)
         shuffle_boxsizer.Add(self.shuffle, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
-        boxsizer.Add(self.hbox2, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
-        self.hbox2.Add(shuffle_boxsizer, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
+
+        ntracks_text = wx.StaticBox(self, label="Number of animals")
+        ntracks_boxsizer = wx.StaticBoxSizer(ntracks_text, wx.VERTICAL)
+        self.ntracks = wx.SpinCtrl(self, value=str(len(self.cfg["individuals"])), min=1, max=1000)
+        ntracks_boxsizer.Add(self.ntracks, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
+
+        boxsizer.Add(self.hbox1, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
+        self.hbox1.Add(shuffle_boxsizer, 0, 0)
+        self.hbox1.Add(ntracks_boxsizer, 1, 1)
+
+#### BOX 2 ####
 
         if self.cfg.get("multianimalproject", False):
 
@@ -114,7 +124,7 @@ class Analyze_videos(wx.Panel):
                 style=wx.RA_SPECIFY_COLS,
             )
             self.robust.SetSelection(1)
-            self.hbox2.Add(self.robust, 1, 1)
+
 
             self.create_video_with_all_detections = wx.RadioBox(
                 self,
@@ -123,7 +133,13 @@ class Analyze_videos(wx.Panel):
                 majorDimension=1,
                 style=wx.RA_SPECIFY_COLS,)
             self.create_video_with_all_detections.SetSelection(0)
-            self.hbox2.Add(self.create_video_with_all_detections,1,wx.EXPAND | wx.TOP | wx.BOTTOM,1,)
+
+
+            boxsizer.Add(self.hbox2, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
+            self.hbox2.Add(self.robust, 0,  wx.EXPAND | wx.TOP | wx.BOTTOM,0)
+            self.hbox2.Add(self.create_video_with_all_detections,0, wx.EXPAND | wx.TOP | wx.BOTTOM,0)
+
+
 
 #### BOX 3 ####
             self.calibrate = wx.RadioBox(
@@ -131,30 +147,23 @@ class Analyze_videos(wx.Panel):
                 label="Calibrate animal assembly?",
                 choices=["Yes", "No"],
                 majorDimension=1,
-                style=wx.RA_SPECIFY_COLS,
-            )
+                style=wx.RA_SPECIFY_COLS,)
             self.calibrate.SetSelection(1)
-            self.hbox3.Add(self.calibrate, 1, 1)
+
 
             self.identity_toggle = wx.RadioBox(
                 self,
                 label="Assemble using animal identity?",
                 choices=["Yes", "No"],
                 majorDimension=1,
-                style=wx.RA_SPECIFY_COLS,
-            )
+                style=wx.RA_SPECIFY_COLS,)
             self.identity_toggle.SetSelection(1)
-            self.hbox3.Add(self.identity_toggle, 1, 1)
 
-            winsize_text = wx.StaticBox(
-                self, label="Prioritize past connections over a window of size:"
-            )
-            winsize_sizer = wx.StaticBoxSizer(winsize_text, wx.VERTICAL)
-            self.winsize = wx.SpinCtrl(self, value="0")
-            winsize_sizer.Add(self.winsize, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
-            self.hbox3.Add(winsize_sizer, 1, 1)
+            self.hbox2.Add(self.calibrate, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
+            self.hbox2.Add(self.identity_toggle, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
 
-#### BOX 4 ####
+
+#### BOX 3 ####
 
             self.csv = wx.RadioBox(
                 self,
@@ -192,10 +201,10 @@ class Analyze_videos(wx.Panel):
             self.trajectory.Bind(wx.EVT_RADIOBOX, self.chooseOption)
             self.trajectory.SetSelection(1)
 
-            self.hbox4.Add(self.csv, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
-            self.hbox4.Add(self.filter, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
-            self.hbox4.Add(self.showfigs, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
-            self.hbox4.Add(self.trajectory, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
+            self.hbox3.Add(self.csv, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
+            self.hbox3.Add(self.filter, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
+            self.hbox3.Add(self.showfigs, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
+            self.hbox3.Add(self.trajectory, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
 
         else:
             self.dynamic = wx.RadioBox(
@@ -206,9 +215,10 @@ class Analyze_videos(wx.Panel):
                 style=wx.RA_SPECIFY_COLS,
             )
             self.dynamic.SetSelection(1)
-            self.hbox4.Add(self.dynamic, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
+            self.hbox3.Add(self.dynamic, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
 
 
+        boxsizer.Add(self.hbox3, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
 
 
 
@@ -247,7 +257,7 @@ class Analyze_videos(wx.Panel):
         self.trail_points_text.Hide()
         self.trail_points.Hide()
 
-        self.hbox3.Add(self.trajectory_to_plot, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
+        self.hbox4.Add(self.trajectory_to_plot, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
         boxsizer.Add(self.hbox3, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
 
         self.hbox4.Add(self.draw_skeleton, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
@@ -409,6 +419,7 @@ class Analyze_videos(wx.Panel):
                 cropping=crop,
                 robust_nframes=robust,
                 auto_track=True,
+                n_tracks=self.ntracks,
             )
             if self.create_video_with_all_detections.GetStringSelection() == "Yes":
                 deeplabcut.create_video_with_all_detections(

--- a/deeplabcut/gui/analyze_videos.py
+++ b/deeplabcut/gui/analyze_videos.py
@@ -465,7 +465,10 @@ class Analyze_videos(wx.Panel):
                 robust_nframes=robust,
                 auto_track=True,
                 n_tracks=self.ntracks.GetValue(),
+                calibrate=self.calibrate.GetStringSelection() == "Yes",
+                identity_only=self.identity_toggle.GetStringSelection() == "Yes",
             )
+
             if self.create_video_with_all_detections.GetStringSelection() == "Yes":
                 deeplabcut.create_video_with_all_detections(
                     self.config,

--- a/deeplabcut/gui/analyze_videos.py
+++ b/deeplabcut/gui/analyze_videos.py
@@ -1,5 +1,5 @@
 """
-DeepLabCut2.0 Toolbox (deeplabcut.org)
+DeepLabCut2.2+ Toolbox (deeplabcut.org)
 © A. & M. Mathis Labs
 https://github.com/DeepLabCut/DeepLabCut
 Please see AUTHORS for contributors.
@@ -37,25 +37,21 @@ class Analyze_videos(wx.Panel):
         self.cfg = auxiliaryfunctions.read_config(self.config)
         self.draw = False
         # design the panel
-        self.sizer = wx.GridBagSizer(5, 10)
+        self.sizer = wx.GridBagSizer(5, 15)
 
-        if self.cfg.get("multianimalproject", False):
-            text = wx.StaticText(
-                self, label="DeepLabCut - Step 7. Analyze Videos and Detect Tracklets"
-            )
-        else:
-            text = wx.StaticText(self, label="DeepLabCut - Step 7. Analyze Videos ....")
+
+        text = wx.StaticText(self, label="DeepLabCut - Step 7. Analyze Videos")
 
         self.sizer.Add(text, pos=(0, 0), flag=wx.TOP | wx.LEFT | wx.BOTTOM, border=15)
         # Add logo of DLC
         icon = wx.StaticBitmap(self, bitmap=wx.Bitmap(LOGO_PATH))
         self.sizer.Add(
-            icon, pos=(0, 8), flag=wx.TOP | wx.RIGHT | wx.ALIGN_RIGHT, border=5
+            icon, pos=(0, 10), flag=wx.TOP | wx.RIGHT | wx.ALIGN_RIGHT, border=5
         )
 
         line1 = wx.StaticLine(self)
         self.sizer.Add(
-            line1, pos=(1, 0), span=(1, 8), flag=wx.EXPAND | wx.BOTTOM, border=10
+            line1, pos=(1, 0), span=(1, 8), flag=wx.EXPAND | wx.BOTTOM, border=15
         )
 
         self.cfg_text = wx.StaticText(self, label="Select the config file")
@@ -98,29 +94,15 @@ class Analyze_videos(wx.Panel):
         self.hbox2 = wx.BoxSizer(wx.HORIZONTAL)
         self.hbox3 = wx.BoxSizer(wx.HORIZONTAL)
         self.hbox4 = wx.BoxSizer(wx.HORIZONTAL)
+        self.hbox5 = wx.BoxSizer(wx.HORIZONTAL)
 
-        videotype_text = wx.StaticBox(self, label="Specify the videotype")
-        videotype_text_boxsizer = wx.StaticBoxSizer(videotype_text, wx.VERTICAL)
-        videotypes = [".avi", ".mp4", ".mov"]
-        self.videotype = wx.ComboBox(self, choices=videotypes, style=wx.CB_READONLY)
-        self.videotype.SetValue(".avi")
-        videotype_text_boxsizer.Add(
-            self.videotype, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1
-        )
-
+#### BOX 2 ####
         shuffle_text = wx.StaticBox(self, label="Specify the shuffle")
         shuffle_boxsizer = wx.StaticBoxSizer(shuffle_text, wx.VERTICAL)
         self.shuffle = wx.SpinCtrl(self, value="1", min=0, max=100)
         shuffle_boxsizer.Add(self.shuffle, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
-
-        trainingset = wx.StaticBox(self, label="Specify the trainingset index")
-        trainingset_boxsizer = wx.StaticBoxSizer(trainingset, wx.VERTICAL)
-        self.trainingset = wx.SpinCtrl(self, value="0", min=0, max=100)
-        trainingset_boxsizer.Add(self.trainingset, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
-
-        self.hbox1.Add(videotype_text_boxsizer, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
-        self.hbox1.Add(shuffle_boxsizer, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
-        self.hbox1.Add(trainingset_boxsizer, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
+        boxsizer.Add(self.hbox2, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
+        self.hbox2.Add(shuffle_boxsizer, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
 
         if self.cfg.get("multianimalproject", False):
 
@@ -139,26 +121,11 @@ class Analyze_videos(wx.Panel):
                 label="Create video for checking detections",
                 choices=["Yes", "No"],
                 majorDimension=1,
-                style=wx.RA_SPECIFY_COLS,
-            )
-            self.create_video_with_all_detections.SetSelection(1)
-            self.hbox2.Add(
-                self.create_video_with_all_detections,
-                1,
-                wx.EXPAND | wx.TOP | wx.BOTTOM,
-                1,
-            )
+                style=wx.RA_SPECIFY_COLS,)
+            self.create_video_with_all_detections.SetSelection(0)
+            self.hbox2.Add(self.create_video_with_all_detections,1,wx.EXPAND | wx.TOP | wx.BOTTOM,1,)
 
-            self.overwrite = wx.RadioBox(
-                self,
-                label="Overwrite tracking files (set to yes if you edit inference parameters)",
-                choices=["Yes", "No"],
-                majorDimension=1,
-                style=wx.RA_SPECIFY_COLS,
-            )
-            self.overwrite.SetSelection(1)
-            self.hbox3.Add(self.overwrite, 1, 1)
-
+#### BOX 3 ####
             self.calibrate = wx.RadioBox(
                 self,
                 label="Calibrate animal assembly?",
@@ -167,17 +134,17 @@ class Analyze_videos(wx.Panel):
                 style=wx.RA_SPECIFY_COLS,
             )
             self.calibrate.SetSelection(1)
-            self.hbox4.Add(self.calibrate, 1, 1)
+            self.hbox3.Add(self.calibrate, 1, 1)
 
             self.identity_toggle = wx.RadioBox(
                 self,
-                label="Assemble with identity only?",
+                label="Assemble using animal identity?",
                 choices=["Yes", "No"],
                 majorDimension=1,
                 style=wx.RA_SPECIFY_COLS,
             )
             self.identity_toggle.SetSelection(1)
-            self.hbox4.Add(self.identity_toggle, 1, 1)
+            self.hbox3.Add(self.identity_toggle, 1, 1)
 
             winsize_text = wx.StaticBox(
                 self, label="Prioritize past connections over a window of size:"
@@ -185,9 +152,10 @@ class Analyze_videos(wx.Panel):
             winsize_sizer = wx.StaticBoxSizer(winsize_text, wx.VERTICAL)
             self.winsize = wx.SpinCtrl(self, value="0")
             winsize_sizer.Add(self.winsize, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
-            self.hbox4.Add(winsize_sizer, 1, 1)
+            self.hbox3.Add(winsize_sizer, 1, 1)
 
-        else:
+#### BOX 4 ####
+
             self.csv = wx.RadioBox(
                 self,
                 label="Want to save result(s) as csv?",
@@ -196,15 +164,6 @@ class Analyze_videos(wx.Panel):
                 style=wx.RA_SPECIFY_COLS,
             )
             self.csv.SetSelection(1)
-
-            self.dynamic = wx.RadioBox(
-                self,
-                label="Want to dynamically crop bodyparts?",
-                choices=["Yes", "No"],
-                majorDimension=1,
-                style=wx.RA_SPECIFY_COLS,
-            )
-            self.dynamic.SetSelection(1)
 
             self.filter = wx.RadioBox(
                 self,
@@ -230,19 +189,29 @@ class Analyze_videos(wx.Panel):
                 majorDimension=1,
                 style=wx.RA_SPECIFY_COLS,
             )
-
             self.trajectory.Bind(wx.EVT_RADIOBOX, self.chooseOption)
             self.trajectory.SetSelection(1)
 
-            self.hbox2.Add(self.csv, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
-            self.hbox2.Add(self.filter, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
-            self.hbox2.Add(self.showfigs, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
+            self.hbox4.Add(self.csv, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
+            self.hbox4.Add(self.filter, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
+            self.hbox4.Add(self.showfigs, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
+            self.hbox4.Add(self.trajectory, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
 
-            self.hbox3.Add(self.dynamic, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
-            self.hbox3.Add(self.trajectory, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
+        else:
+            self.dynamic = wx.RadioBox(
+                self,
+                label="Want to dynamically crop bodyparts?",
+                choices=["Yes", "No"],
+                majorDimension=1,
+                style=wx.RA_SPECIFY_COLS,
+            )
+            self.dynamic.SetSelection(1)
+            self.hbox4.Add(self.dynamic, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
 
-        boxsizer.Add(self.hbox1, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
-        boxsizer.Add(self.hbox2, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
+
+
+
+
 
         config_file = auxiliaryfunctions.read_config(self.config)
         if config_file.get("multianimalproject", False):
@@ -296,18 +265,10 @@ class Analyze_videos(wx.Panel):
         self.sizer.Add(self.help_button, pos=(7, 0), flag=wx.LEFT, border=10)
         self.help_button.Bind(wx.EVT_BUTTON, self.help_function)
 
-        self.ok = wx.Button(self, label="Step 1: Analyze Videos")
+        self.ok = wx.Button(self, label="Analyze Videos")
         self.sizer.Add(self.ok, pos=(7, 4), flag=wx.BOTTOM | wx.RIGHT, border=10)
         self.ok.Bind(wx.EVT_BUTTON, self.analyze_videos)
 
-        if config_file.get("multianimalproject", False):
-            self.ok = wx.Button(self, label="Step 2: Convert to Tracklets")
-            self.sizer.Add(self.ok, pos=(7, 5), border=10)
-            self.ok.Bind(wx.EVT_BUTTON, self.convert2_tracklets)
-
-            self.inf_cfg_text = wx.Button(self, label="Edit inference_config.yaml")
-            self.sizer.Add(self.inf_cfg_text, pos=(8, 5), border=10)
-            self.inf_cfg_text.Bind(wx.EVT_BUTTON, self.edit_inf_config)
 
         self.reset = wx.Button(self, label="Reset")
         self.sizer.Add(
@@ -340,8 +301,7 @@ class Analyze_videos(wx.Panel):
     def edit_inf_config(self, event):
         # Read the infer config file
         cfg = auxiliaryfunctions.read_config(self.config)
-        trainingsetindex = self.trainingset.GetValue()
-        trainFraction = cfg["TrainingFraction"][trainingsetindex]
+        #trainFraction = cfg["TrainingFraction"][trainingsetindex]
         self.inf_cfg_path = os.path.join(
             cfg["project_path"],
             auxiliaryfunctions.GetModelFolder(
@@ -390,24 +350,6 @@ class Analyze_videos(wx.Panel):
         """
         self.config = self.sel_config.GetPath()
 
-    def convert2_tracklets(self, event):
-        shuffle = self.shuffle.GetValue()
-        trainingsetindex = self.trainingset.GetValue()
-        if self.overwrite.GetStringSelection() == "Yes":
-            overwrite = True
-        else:
-            overwrite = False
-        deeplabcut.convert_detections2tracklets(
-            self.config,
-            self.filelist,
-            videotype=self.videotype.GetValue(),
-            shuffle=shuffle,
-            trainingsetindex=trainingsetindex,
-            overwrite=overwrite,
-            calibrate=self.calibrate.GetStringSelection() == "Yes",
-            window_size=self.winsize.GetValue(),
-            identity_only=self.identity_toggle.GetStringSelection() == "Yes",
-        )
 
     def select_videos(self, event):
         """
@@ -431,10 +373,10 @@ class Analyze_videos(wx.Panel):
     def analyze_videos(self, event):
 
         shuffle = self.shuffle.GetValue()
-        trainingsetindex = self.trainingset.GetValue()
 
         if self.cfg.get("multianimalproject", False):
             print("DLC network loading and video analysis starting ... ")
+            auto_track=True
         else:
             if self.csv.GetStringSelection() == "Yes":
                 save_as_csv = True
@@ -462,28 +404,23 @@ class Analyze_videos(wx.Panel):
             scorername = deeplabcut.analyze_videos(
                 self.config,
                 self.filelist,
-                videotype=self.videotype.GetValue(),
                 shuffle=shuffle,
-                trainingsetindex=trainingsetindex,
                 gputouse=None,
                 cropping=crop,
                 robust_nframes=robust,
+                auto_track=True,
             )
             if self.create_video_with_all_detections.GetStringSelection() == "Yes":
                 deeplabcut.create_video_with_all_detections(
                     self.config,
                     self.filelist,
-                    videotype=self.videotype.GetValue(),
                     shuffle=shuffle,
-                    trainingsetindex=trainingsetindex,
                 )
         else:
             scorername = deeplabcut.analyze_videos(
                 self.config,
                 self.filelist,
-                videotype=self.videotype.GetValue(),
                 shuffle=shuffle,
-                trainingsetindex=trainingsetindex,
                 gputouse=None,
                 save_as_csv=save_as_csv,
                 cropping=crop,
@@ -493,9 +430,7 @@ class Analyze_videos(wx.Panel):
                 deeplabcut.filterpredictions(
                     self.config,
                     self.filelist,
-                    videotype=self.videotype.GetValue(),
                     shuffle=shuffle,
-                    trainingsetindex=trainingsetindex,
                     filtertype="median",
                     windowlength=5,
                     save_as_csv=save_as_csv,
@@ -510,9 +445,7 @@ class Analyze_videos(wx.Panel):
                     self.config,
                     self.filelist,
                     displayedbodyparts=self.bodyparts,
-                    videotype=self.videotype.GetValue(),
                     shuffle=shuffle,
-                    trainingsetindex=trainingsetindex,
                     filtered=_filter,
                     showfigures=showfig,
                 )
@@ -529,13 +462,12 @@ class Analyze_videos(wx.Panel):
             self.trajectory.SetSelection(1)
             self.dynamic.SetSelection(1)
             # self.select_destfolder.SetPath("None")
-        self.config = []
-        self.sel_config.SetPath("")
-        self.videotype.SetStringSelection(".avi")
+        #self.config = []
+        #self.sel_config.SetPath("")
+        #self.videotype.SetStringSelection(".avi")
         self.sel_vids.SetLabel("Select videos to analyze")
         self.filelist = []
         self.shuffle.SetValue(1)
-        self.trainingset.SetValue(0)
         if self.draw_skeleton.IsShown():
             self.draw_skeleton.SetSelection(1)
             self.draw_skeleton.Hide()

--- a/deeplabcut/gui/analyze_videos.py
+++ b/deeplabcut/gui/analyze_videos.py
@@ -176,7 +176,7 @@ class Analyze_videos(wx.Panel):
 
             self.filter = wx.RadioBox(
                 self,
-                label="Want to filter the predictions?",
+                label="Want to filter the predictions? (+ csv file)",
                 choices=["Yes", "No"],
                 majorDimension=1,
                 style=wx.RA_SPECIFY_COLS,
@@ -473,6 +473,8 @@ class Analyze_videos(wx.Panel):
                     self.filelist,
                     shuffle=shuffle,
                 )
+            if self.filter.GetStringSelection() == "Yes":
+                deeplabcut.filterpredictions(self.config, self.filelist)
         else:
             scorername = deeplabcut.analyze_videos(
                 self.config,

--- a/deeplabcut/gui/analyze_videos.py
+++ b/deeplabcut/gui/analyze_videos.py
@@ -103,14 +103,17 @@ class Analyze_videos(wx.Panel):
         self.shuffle = wx.SpinCtrl(self, value="1", min=0, max=100)
         shuffle_boxsizer.Add(self.shuffle, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
 
-        ntracks_text = wx.StaticBox(self, label="Number of animals")
-        ntracks_boxsizer = wx.StaticBoxSizer(ntracks_text, wx.VERTICAL)
-        self.ntracks = wx.SpinCtrl(self, value=str(len(self.cfg["individuals"])), min=1, max=1000)
-        ntracks_boxsizer.Add(self.ntracks, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
-
         boxsizer.Add(self.hbox1, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
         self.hbox1.Add(shuffle_boxsizer, 0, 0)
-        self.hbox1.Add(ntracks_boxsizer, 1, 1)
+
+        if self.cfg.get("multianimalproject", False):
+            ntracks_text = wx.StaticBox(self, label="Number of animals")
+            ntracks_boxsizer = wx.StaticBoxSizer(ntracks_text, wx.VERTICAL)
+            self.ntracks = wx.SpinCtrl(self, value=str(len(self.cfg["individuals"])), min=1, max=1000)
+            ntracks_boxsizer.Add(self.ntracks, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
+            self.hbox1.Add(ntracks_boxsizer, 1, 1)
+
+
 
 #### BOX 2 ####
 
@@ -139,9 +142,6 @@ class Analyze_videos(wx.Panel):
             self.hbox2.Add(self.robust, 0,  wx.EXPAND | wx.TOP | wx.BOTTOM,0)
             self.hbox2.Add(self.create_video_with_all_detections,0, wx.EXPAND | wx.TOP | wx.BOTTOM,0)
 
-
-
-#### BOX 3 ####
             self.calibrate = wx.RadioBox(
                 self,
                 label="Calibrate animal assembly?",
@@ -215,7 +215,53 @@ class Analyze_videos(wx.Panel):
                 style=wx.RA_SPECIFY_COLS,
             )
             self.dynamic.SetSelection(1)
-            self.hbox3.Add(self.dynamic, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
+            self.hbox3.Add(self.dynamic, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
+
+            self.csv = wx.RadioBox(
+                self,
+                label="Want to save result(s) as csv?",
+                choices=["Yes", "No"],
+                majorDimension=1,
+                style=wx.RA_SPECIFY_COLS,
+            )
+            self.csv.SetSelection(1)
+
+            self.filter = wx.RadioBox(
+                self,
+                label="Want to filter the predictions?",
+                choices=["Yes", "No"],
+                majorDimension=1,
+                style=wx.RA_SPECIFY_COLS,
+            )
+            self.filter.SetSelection(1)
+
+            self.trajectory = wx.RadioBox(
+                self,
+                label="Want to plot the trajectories?",
+                choices=["Yes", "No"],
+                majorDimension=1,
+                style=wx.RA_SPECIFY_COLS,
+            )
+
+            self.showfigs = wx.RadioBox(
+                self,
+                label="Want plots to pop up?",
+                choices=["Yes", "No"],
+                majorDimension=1,
+                style=wx.RA_SPECIFY_COLS,
+            )
+            self.trajectory.Bind(wx.EVT_RADIOBOX, self.chooseOption)
+            self.trajectory.SetSelection(1)
+
+            #boxsizer.Add(self.hbox2, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
+            self.hbox1.Add(self.csv, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
+            self.hbox1.Add(self.filter, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
+            self.hbox3.Add(self.showfigs, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
+            self.hbox3.Add(self.trajectory, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)
+
+
+
+
 
 
         boxsizer.Add(self.hbox3, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 0)

--- a/deeplabcut/gui/analyze_videos.py
+++ b/deeplabcut/gui/analyze_videos.py
@@ -477,6 +477,13 @@ class Analyze_videos(wx.Panel):
 
             if self.csv.GetStringSelection() == "Yes":
                 deeplabcut.analyze_videos_converth5_to_csv(self.filelist,listofvideos=True)
+
+            if self.trajectory.GetStringSelection() == "Yes":
+                if self.showfigs.GetStringSelection() == "No":
+                    showfig = False
+                else:
+                    showfig = True
+                deeplabcut.plot_trajectories(self.config,self.filelist,showfigures=showfig)
         else:
             scorername = deeplabcut.analyze_videos(
                 self.config,

--- a/deeplabcut/gui/create_new_project.py
+++ b/deeplabcut/gui/create_new_project.py
@@ -390,36 +390,42 @@ class Create_new_project(wx.Panel):
             cfg = auxiliaryfunctions.read_config(self.cfg)
             if self.parent.GetPageCount() < 3:
                 page3 = Extract_frames(self.parent, self.gui_size, self.cfg)
-                self.parent.AddPage(page3, "Extract frames")
+                self.parent.AddPage(page3, "Extract Frames")
 
                 page4 = Label_frames(self.parent, self.gui_size, self.cfg)
-                self.parent.AddPage(page4, "Label frames")
+                self.parent.AddPage(page4, "Label Data")
 
                 page5 = Create_training_dataset(self.parent, self.gui_size, self.cfg)
-                self.parent.AddPage(page5, "Create training dataset")
+                self.parent.AddPage(page5, "Create Training Dataset")
 
                 page6 = Train_network(self.parent, self.gui_size, self.cfg)
-                self.parent.AddPage(page6, "Train network")
+                self.parent.AddPage(page6, "Train")
 
                 page7 = Evaluate_network(self.parent, self.gui_size, self.cfg)
-                self.parent.AddPage(page7, "Evaluate network")
-
-                page12 = Video_Editing(self.parent, self.gui_size, self.cfg)
-                self.parent.AddPage(page12, "Video editor")
+                self.parent.AddPage(page7, "Evaluate")
 
                 page8 = Analyze_videos(self.parent, self.gui_size, self.cfg)
                 self.parent.AddPage(page8, "Analyze videos")
 
+                page9 = Create_Labeled_Videos(self.parent, self.gui_size, self.cfg)
+                self.parent.AddPage(page9, "Create videos")
+
+                page11 = Video_Editing(self.parent, self.gui_size, self.cfg)
+                self.parent.AddPage(page11, "OPT: Video editor")
+
+                page12 = Extract_outlier_frames(self.parent, self.gui_size, self.cfg)
+                self.parent.AddPage(page12, "OPT: Extract/Refine Outliers")
+
+                #page10 = Refine_labels(self.parent, self.gui_size, self.cfg, page5)
+                #self.parent.AddPage(page10, "OPT: Refine Labels")
+
+                self.edit_config_file.Enable(True)
+
+
+
                 if cfg.get("multianimalproject", False):
                     page = Refine_tracklets(self.parent, self.gui_size, self.cfg)
-                    self.parent.AddPage(page, "Refine tracklets")
-                page11 = Create_Labeled_Videos(self.parent, self.gui_size, self.cfg)
-                self.parent.AddPage(page11, "Create videos")
-                page9 = Extract_outlier_frames(self.parent, self.gui_size, self.cfg)
-                self.parent.AddPage(page9, "Extract outlier frames")
-                page10 = Refine_labels(self.parent, self.gui_size, self.cfg, page5)
-                self.parent.AddPage(page10, "Refine labels")
-                self.edit_config_file.Enable(True)
+                    self.parent.AddPage(page, "OPT: Refine tracklets")
 
     def add_videos(self, event):
         print("adding new videos to be able to label ...")

--- a/deeplabcut/gui/create_training_dataset.py
+++ b/deeplabcut/gui/create_training_dataset.py
@@ -94,10 +94,11 @@ class Create_training_dataset(wx.Panel):
             "efficientnet-b0",
         ]
         self.net_choice.Set(options)
+        
         if self.cfg.get("multianimalproject", False):
             self.net_choice.SetValue("dlcrnet_ms5")
-
-        self.net_choice.SetValue("resnet_50")
+        else:
+            self.net_choice.SetValue("resnet_50")
 
         netboxsizer.Add(self.net_choice, 20, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
 

--- a/deeplabcut/gui/create_training_dataset.py
+++ b/deeplabcut/gui/create_training_dataset.py
@@ -31,6 +31,7 @@ class Create_training_dataset(wx.Panel):
         # variable initilization
         self.method = "automatic"
         self.config = cfg
+        self.cfg = auxiliaryfunctions.read_config(self.config)
         # design the panel
         self.sizer = wx.GridBagSizer(5, 5)
 
@@ -89,17 +90,15 @@ class Create_training_dataset(wx.Panel):
             "dlcrnet_ms5",
             "resnet_50",
             "resnet_101",
-            "resnet_152",
             "mobilenet_v2_1.0",
-            "mobilenet_v2_0.75",
-            "mobilenet_v2_0.5",
-            "mobilenet_v2_0.35",
             "efficientnet-b0",
-            "efficientnet-b3",
-            "efficientnet-b6",
         ]
         self.net_choice.Set(options)
-        self.net_choice.SetValue("dlcrnet_ms5")
+        if self.cfg.get("multianimalproject", False):
+            self.net_choice.SetValue("dlcrnet_ms5")
+
+        self.net_choice.SetValue("resnet_50")
+
         netboxsizer.Add(self.net_choice, 20, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
 
         aug_text = wx.StaticBox(self, label="Select the augmentation method")
@@ -120,12 +119,12 @@ class Create_training_dataset(wx.Panel):
         self.shuffle = wx.SpinCtrl(self, value="1", min=1, max=100)
         shuffle_text_boxsizer.Add(self.shuffle, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
 
-        trainingindex_box = wx.StaticBox(self, label="Specify the trainingset index")
-        trainingindex_boxsizer = wx.StaticBoxSizer(trainingindex_box, wx.VERTICAL)
-        self.trainingindex = wx.SpinCtrl(self, value="0", min=0, max=100)
-        trainingindex_boxsizer.Add(
-            self.trainingindex, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 10
-        )
+        #trainingindex_box = wx.StaticBox(self, label="Specify the trainingset index")
+        #trainingindex_boxsizer = wx.StaticBoxSizer(trainingindex_box, wx.VERTICAL)
+        #self.trainingindex = wx.SpinCtrl(self, value="0", min=0, max=100)
+        #trainingindex_boxsizer.Add(
+        #    self.trainingindex, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 10
+        #)
 
         self.userfeedback = wx.RadioBox(
             self,
@@ -137,9 +136,9 @@ class Create_training_dataset(wx.Panel):
         self.userfeedback.SetSelection(1)
 
         self.hbox2.Add(shuffle_text_boxsizer, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
-        self.hbox2.Add(trainingindex_boxsizer, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
+        #self.hbox2.Add(trainingindex_boxsizer, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
 
-        self.hbox3.Add(self.userfeedback, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
+        self.hbox2.Add(self.userfeedback, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
 
         if config_file.get("multianimalproject", False):
 
@@ -320,7 +319,7 @@ class Create_training_dataset(wx.Panel):
         """
         num_shuffles = self.shuffle.GetValue()
         config_file = auxiliaryfunctions.read_config(self.config)
-        trainindex = self.trainingindex.GetValue()
+        #trainindex = self.trainingindex.GetValue()
 
         if self.userfeedback.GetStringSelection() == "Yes":
             userfeedback = True
@@ -362,7 +361,7 @@ class Create_training_dataset(wx.Panel):
         self.sel_config.SetPath("")
         # self.shuffles.SetValue("1")
         self.net_choice.SetValue("resnet_50")
-        self.aug_choice.SetValue("default")
+        self.aug_choice.SetValue("imgaug")
         self.model_comparison_choice.SetSelection(1)
         self.network_box.Hide()
         self.networks_to_compare.Hide()

--- a/deeplabcut/gui/create_videos.py
+++ b/deeplabcut/gui/create_videos.py
@@ -1,5 +1,5 @@
 """
-DeepLabCut2.0 Toolbox (deeplabcut.org)
+DeepLabCut2.2+ Toolbox (deeplabcut.org)
 © A. & M. Mathis Labs
 https://github.com/DeepLabCut/DeepLabCut
 Please see AUTHORS for contributors.

--- a/deeplabcut/gui/evaluate_network.py
+++ b/deeplabcut/gui/evaluate_network.py
@@ -89,12 +89,12 @@ class Evaluate_network(wx.Panel):
         self.shuffles = wx.SpinCtrl(self, value="1", min=0, max=100)
         shuffles_text_boxsizer.Add(self.shuffles, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
 
-        trainingset = wx.StaticBox(self, label="Specify the trainingset index")
-        trainingset_boxsizer = wx.StaticBoxSizer(trainingset, wx.VERTICAL)
-        self.trainingset = wx.SpinCtrl(self, value="0", min=0, max=100)
-        trainingset_boxsizer.Add(
-            self.trainingset, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 10
-        )
+        #trainingset = wx.StaticBox(self, label="Specify the trainingset index")
+        #trainingset_boxsizer = wx.StaticBoxSizer(trainingset, wx.VERTICAL)
+        #self.trainingset = wx.SpinCtrl(self, value="0", min=0, max=100)
+        #trainingset_boxsizer.Add(
+        #    self.trainingset, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 10
+        #)
 
         self.plot_choice = wx.RadioBox(
             self,
@@ -134,7 +134,7 @@ class Evaluate_network(wx.Panel):
         self.bodyparts_to_compare.Hide()
 
         self.hbox1.Add(shuffles_text_boxsizer, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
-        self.hbox1.Add(trainingset_boxsizer, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
+        #self.hbox1.Add(trainingset_boxsizer, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
         self.hbox1.Add(self.plot_scoremaps, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
 
         self.hbox2.Add(self.plot_choice, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
@@ -229,12 +229,12 @@ class Evaluate_network(wx.Panel):
     def edit_inf_config(self, event):
         # Read the infer config file
         cfg = auxiliaryfunctions.read_config(self.config)
-        trainingsetindex = self.trainingset.GetValue()
-        trainFraction = cfg["TrainingFraction"][trainingsetindex]
+        #trainingsetindex = self.trainingset.GetValue()
+        trainFraction = cfg["TrainingFraction"]
         self.inf_cfg_path = os.path.join(
             cfg["project_path"],
             auxiliaryfunctions.GetModelFolder(
-                trainFraction, self.shuffles.GetValue(), cfg
+                trainFraction[-1], self.shuffles.GetValue(), cfg
             ),
             "test",
             "inference_cfg.yaml",
@@ -253,7 +253,7 @@ class Evaluate_network(wx.Panel):
     def evaluate_network(self, event):
 
         # shuffle = self.shuffle.GetValue()
-        trainingsetindex = self.trainingset.GetValue()
+        #trainingsetindex = self.trainingset.GetValue()
 
         Shuffles = [self.shuffles.GetValue()]
         if self.plot_choice.GetStringSelection() == "Yes":
@@ -270,7 +270,7 @@ class Evaluate_network(wx.Panel):
         deeplabcut.evaluate_network(
             self.config,
             Shuffles=Shuffles,
-            trainingsetindex=trainingsetindex,
+            #trainingsetindex=trainingsetindex,
             plotting=plotting,
             show_errors=True,
             comparisonbodyparts=self.bodyparts,

--- a/deeplabcut/gui/extract_outlier_frames.py
+++ b/deeplabcut/gui/extract_outlier_frames.py
@@ -36,7 +36,7 @@ class Extract_outlier_frames(wx.Panel):
         # design the panel
         self.sizer = wx.GridBagSizer(5, 5)
 
-        text = wx.StaticText(self, label="DeepLabCut - Step 8. Extract outlier frames")
+        text = wx.StaticText(self, label="DeepLabCut - OPTIONAL: Extract & Refine labels on Outlier Frames")
         self.sizer.Add(text, pos=(0, 0), flag=wx.TOP | wx.LEFT | wx.BOTTOM, border=15)
         # Add logo of DLC
         icon = wx.StaticBitmap(self, bitmap=wx.Bitmap(LOGO_PATH))
@@ -86,7 +86,6 @@ class Extract_outlier_frames(wx.Panel):
         boxsizer = wx.StaticBoxSizer(sb, wx.VERTICAL)
 
         hbox1 = wx.BoxSizer(wx.HORIZONTAL)
-        hbox2 = wx.BoxSizer(wx.HORIZONTAL)
 
         videotype_text = wx.StaticBox(self, label="Specify the videotype")
         videotype_text_boxsizer = wx.StaticBoxSizer(videotype_text, wx.VERTICAL)
@@ -94,36 +93,25 @@ class Extract_outlier_frames(wx.Panel):
         self.videotype = wx.ComboBox(self, choices=videotypes, style=wx.CB_READONLY)
         self.videotype.SetValue(".avi")
         videotype_text_boxsizer.Add(
-            self.videotype, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 10
+            self.videotype, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1
         )
 
         shuffles_text = wx.StaticBox(self, label="Specify the shuffle")
         shuffles_text_boxsizer = wx.StaticBoxSizer(shuffles_text, wx.VERTICAL)
         self.shuffles = wx.SpinCtrl(self, value="1", min=0, max=100)
-        shuffles_text_boxsizer.Add(self.shuffles, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
-
-        trainingindex = wx.StaticBox(self, label="Specify the trainingset index")
-        trainingindex_boxsizer = wx.StaticBoxSizer(trainingindex, wx.VERTICAL)
-        self.trainingindex = wx.SpinCtrl(self, value="0", min=0, max=100)
-        trainingindex_boxsizer.Add(
-            self.trainingindex, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 10
-        )
+        shuffles_text_boxsizer.Add(self.shuffles, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
 
         outlier_algo_text = wx.StaticBox(self, label="Specify the algorithm")
         outlier_algo_text_boxsizer = wx.StaticBoxSizer(outlier_algo_text, wx.VERTICAL)
         algotypes = ["jump", "fitting", "uncertain", "manual"]
         self.algotype = wx.ComboBox(self, choices=algotypes, style=wx.CB_READONLY)
         self.algotype.SetValue("jump")
-        outlier_algo_text_boxsizer.Add(
-            self.algotype, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 10
-        )
+        outlier_algo_text_boxsizer.Add(self.algotype, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
 
         hbox1.Add(videotype_text_boxsizer, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
         hbox1.Add(shuffles_text_boxsizer, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
-        hbox1.Add(trainingindex_boxsizer, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
-        hbox2.Add(outlier_algo_text_boxsizer, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
+        hbox1.Add(outlier_algo_text_boxsizer, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
         boxsizer.Add(hbox1, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
-        boxsizer.Add(hbox2, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
 
         self.sizer.Add(
             boxsizer,
@@ -133,11 +121,24 @@ class Extract_outlier_frames(wx.Panel):
             border=10,
         )
 
+### LABELING ###
+
+
+
+        self.ok = wx.Button(self, label="LAUNCH GUI")
+        self.sizer.Add(self.ok, pos=(7, 4))
+        self.ok.Bind(wx.EVT_BUTTON, self.refine_labels)
+
+        self.merge = wx.Button(self, label="Merge dataset")
+        self.sizer.Add(self.merge, pos=(7, 3), flag=wx.BOTTOM | wx.RIGHT, border=10)
+        self.merge.Bind(wx.EVT_BUTTON, self.merge_dataset)
+        self.merge.Enable(False)
+
         self.help_button = wx.Button(self, label="Help")
         self.sizer.Add(self.help_button, pos=(6, 0), flag=wx.LEFT, border=10)
         self.help_button.Bind(wx.EVT_BUTTON, self.help_function)
 
-        self.ok = wx.Button(self, label="Ok")
+        self.ok = wx.Button(self, label="EXTRACT FRAMES")
         self.sizer.Add(self.ok, pos=(6, 4))
         self.ok.Bind(wx.EVT_BUTTON, self.extract_outlier_frames)
 
@@ -191,7 +192,6 @@ class Extract_outlier_frames(wx.Panel):
             videos=self.filelist,
             videotype=self.videotype.GetValue(),
             shuffle=self.shuffles.GetValue(),
-            trainingsetindex=self.trainingindex.GetValue(),
             outlieralgorithm=self.algotype.GetValue(),
         )
 
@@ -206,3 +206,28 @@ class Extract_outlier_frames(wx.Panel):
         self.sel_vids.SetLabel("Select videos to analyze")
         self.SetSizer(self.sizer)
         self.sizer.Fit(self)
+
+    def refine_labels(self, event):
+        self.merge.Enable(True)
+        deeplabcut.refine_labels(self.config)
+
+    def merge_dataset(self, event):
+        dlg = wx.MessageDialog(
+            None,
+            "1. Make sure that you have refined all the labels before merging the dataset.\n\n2. If you merge the dataset, you need to re-create the training dataset before you start the training.\n\n3. Are you ready to merge the dataset?",
+            "Warning",
+            wx.YES_NO | wx.ICON_WARNING,
+        )
+        result = dlg.ShowModal()
+        if result == wx.ID_YES:
+            notebook = self.GetParent()
+            notebook.SetSelection(4)
+            deeplabcut.merge_datasets(self.config, forceiterate=None)
+
+    def reset_refine_labels(self, event):
+        """
+        Reset to default
+        """
+        self.config = []
+        #self.sel_config.SetPath("")
+        self.merge.Enable(False)

--- a/deeplabcut/gui/extract_outlier_frames.py
+++ b/deeplabcut/gui/extract_outlier_frames.py
@@ -36,7 +36,7 @@ class Extract_outlier_frames(wx.Panel):
         # design the panel
         self.sizer = wx.GridBagSizer(5, 5)
 
-        text = wx.StaticText(self, label="DeepLabCut - OPTIONAL: Extract & Refine labels on Outlier Frames")
+        text = wx.StaticText(self, label="DeepLabCut - OPTIONAL: Extract and Refine labels on Outlier Frames")
         self.sizer.Add(text, pos=(0, 0), flag=wx.TOP | wx.LEFT | wx.BOTTOM, border=15)
         # Add logo of DLC
         icon = wx.StaticBitmap(self, bitmap=wx.Bitmap(LOGO_PATH))

--- a/deeplabcut/gui/refine_tracklets.py
+++ b/deeplabcut/gui/refine_tracklets.py
@@ -38,7 +38,7 @@ class Refine_tracklets(wx.Panel):
         # design the panel
         sizer = wx.GridBagSizer(5, 5)
 
-        text = wx.StaticText(self, label="DeepLabCut - Tracklets: Extract/Refine")
+        text = wx.StaticText(self, label="DeepLabCut - OPTIONAL Refine Tracklets n\ If you want to modfy any aspects of")
         sizer.Add(text, pos=(0, 0), flag=wx.TOP | wx.LEFT | wx.BOTTOM, border=15)
         # Add logo of DLC
         icon = wx.StaticBitmap(self, bitmap=wx.Bitmap(LOGO_PATH))

--- a/deeplabcut/gui/refine_tracklets.py
+++ b/deeplabcut/gui/refine_tracklets.py
@@ -108,20 +108,20 @@ class Refine_tracklets(wx.Panel):
         self.shuffle = wx.SpinCtrl(self, value="1", min=0, max=100)
         shuffle_boxsizer.Add(self.shuffle, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
 
-        trainingset = wx.StaticBox(self, label="Specify the trainingset index")
-        trainingset_boxsizer = wx.StaticBoxSizer(trainingset, wx.VERTICAL)
-        self.trainingset = wx.SpinCtrl(self, value="0", min=0, max=100)
-        trainingset_boxsizer.Add(
-            self.trainingset, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 10
-        )
+        #trainingset = wx.StaticBox(self, label="Specify the trainingset index")
+        #trainingset_boxsizer = wx.StaticBoxSizer(trainingset, wx.VERTICAL)
+        #self.trainingset = wx.SpinCtrl(self, value="0", min=0, max=100)
+        #trainingset_boxsizer.Add(
+        #    self.trainingset, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 10
+        #)
 
         hbox_.Add(videotype_text_boxsizer, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
         hbox_.Add(shuffle_boxsizer, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
-        hbox_.Add(trainingset_boxsizer, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
+        #hbox_.Add(trainingset_boxsizer, 5, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
         vbox_.Add(hbox_)
         sizer.Add(vbox_, pos=(5, 0))
 
-        self.create_tracks_btn = wx.Button(self, label="Step1: Create tracks")
+        self.create_tracks_btn = wx.Button(self, label="Run(or re-run) tracking")
         sizer.Add(self.create_tracks_btn, pos=(6, 1))
         self.create_tracks_btn.Bind(wx.EVT_BUTTON, self.create_tracks)
 
@@ -193,7 +193,7 @@ class Refine_tracklets(wx.Panel):
         sizer.Add(self.inf_cfg_text, pos=(12, 2), flag=wx.BOTTOM | wx.RIGHT, border=10)
         self.inf_cfg_text.Bind(wx.EVT_BUTTON, self.edit_inf_config)
 
-        self.ok = wx.Button(self, label="Optional: Refine tracks")
+        self.ok = wx.Button(self, label="Refine tracks GUI Launch")
         sizer.Add(self.ok, pos=(9, 1))
         self.ok.Bind(wx.EVT_BUTTON, self.refine_tracklets)
 
@@ -211,7 +211,7 @@ class Refine_tracklets(wx.Panel):
         sizer.Add(self.filter, pos=(11, 1), flag=wx.BOTTOM | wx.RIGHT, border=10)
         self.filter.Bind(wx.EVT_BUTTON, self.filter_after_refinement)
 
-        self.export = wx.Button(self, label="Optional: Merge refined data")
+        self.export = wx.Button(self, label="Optional: Merge refined data into training set")
         sizer.Add(self.export, pos=(13, 1), flag=wx.BOTTOM | wx.RIGHT, border=10)
         self.export.Bind(wx.EVT_BUTTON, self.export_data)
         self.export.Disable()
@@ -223,12 +223,12 @@ class Refine_tracklets(wx.Panel):
 
     def edit_inf_config(self, event):
         # Read the infer config file
-        trainingsetindex = self.trainingset.GetValue()
-        trainFraction = self.cfg["TrainingFraction"][trainingsetindex]
+        #trainingsetindex = self.trainingset.GetValue()
+        trainFraction = self.cfg["TrainingFraction"]
         self.inf_cfg_path = os.path.join(
             self.cfg["project_path"],
             auxiliaryfunctions.GetModelFolder(
-                trainFraction, self.shuffle.GetValue(), self.cfg
+                trainFraction[-1], self.shuffle.GetValue(), self.cfg
             ),
             "test",
             "inference_cfg.yaml",
@@ -248,7 +248,7 @@ class Refine_tracklets(wx.Panel):
 
     def filter_after_refinement(self, event):  # why is video type needed?
         shuffle = self.shuffle.GetValue()
-        trainingsetindex = self.trainingset.GetValue()
+        #trainingsetindex = self.trainingset.GetValue()
         window_length = self.filterlength_track.GetValue()
         if window_length % 2 != 1:
             raise ValueError("Window length should be odd.")
@@ -258,7 +258,7 @@ class Refine_tracklets(wx.Panel):
             [self.video],
             videotype=self.videotype.GetValue(),
             shuffle=shuffle,
-            trainingsetindex=trainingsetindex,
+            #trainingsetindex=trainingsetindex,
             filtertype=self.filter_track.GetValue(),
             windowlength=self.filterlength_track.GetValue(),
             save_as_csv=True,
@@ -297,7 +297,7 @@ class Refine_tracklets(wx.Panel):
             [self.video],
             videotype=self.videotype.GetValue(),
             shuffle=self.shuffle.GetValue(),
-            trainingsetindex=self.trainingset.GetValue(),
+            #trainingsetindex=self.trainingset.GetValue(),
             n_tracks=self.ntracks.GetValue(),
         )
 
@@ -305,7 +305,7 @@ class Refine_tracklets(wx.Panel):
         DLCscorer, _ = auxiliaryfunctions.GetScorerName(
             self.cfg,
             self.shuffle.GetValue(),
-            self.cfg["TrainingFraction"][self.trainingset.GetValue()],
+            self.cfg["TrainingFraction"][-1],
         )
         track_method = self.cfg.get("default_track_method", "ellipse")
         if track_method == "ellipse":

--- a/deeplabcut/gui/refine_tracklets.py
+++ b/deeplabcut/gui/refine_tracklets.py
@@ -38,7 +38,7 @@ class Refine_tracklets(wx.Panel):
         # design the panel
         sizer = wx.GridBagSizer(5, 5)
 
-        text = wx.StaticText(self, label="DeepLabCut - OPTIONAL Refine Tracklets n\ If you want to modfy any aspects of")
+        text = wx.StaticText(self, label="DeepLabCut - OPTIONAL Refine Tracklets")
         sizer.Add(text, pos=(0, 0), flag=wx.TOP | wx.LEFT | wx.BOTTOM, border=15)
         # Add logo of DLC
         icon = wx.StaticBitmap(self, bitmap=wx.Bitmap(LOGO_PATH))

--- a/deeplabcut/gui/train_network.py
+++ b/deeplabcut/gui/train_network.py
@@ -99,12 +99,11 @@ class Train_network(wx.Panel):
         self.shuffles = wx.SpinCtrl(self, value="1", min=0, max=100)
         shuffles_text_boxsizer.Add(self.shuffles, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
 
-        trainingindex = wx.StaticBox(self, label="Specify the trainingset index")
-        trainingindex_boxsizer = wx.StaticBoxSizer(trainingindex, wx.VERTICAL)
-        self.trainingindex = wx.SpinCtrl(self, value="0", min=0, max=100)
-        trainingindex_boxsizer.Add(
-            self.trainingindex, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 10
-        )
+        #trainingindex = wx.StaticBox(self, label="Specify the trainingset index")
+        #trainingindex_boxsizer = wx.StaticBoxSizer(trainingindex, wx.VERTICAL)
+        #self.trainingindex = wx.SpinCtrl(self, value="0", min=0, max=100)
+        #trainingindex_boxsizer.Add(
+        #    self.trainingindex, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
 
         self.pose_cfg_choice = wx.RadioBox(
             self,
@@ -135,9 +134,9 @@ class Train_network(wx.Panel):
         )
         # self.display_iters.Enable(False)
 
-        save_iters_text = wx.StaticBox(self, label="Save iterations")
+        save_iters_text = wx.StaticBox(self, label="Save X number of iterations")
         save_iters_text_boxsizer = wx.StaticBoxSizer(save_iters_text, wx.VERTICAL)
-        self.save_iters = wx.SpinCtrl(self, value=save_iters, min=1, max=int(max_iters))
+        self.save_iters = wx.SpinCtrl(self, value="10000", min=1, max=int(max_iters))
         save_iters_text_boxsizer.Add(
             self.save_iters, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 10
         )
@@ -145,20 +144,20 @@ class Train_network(wx.Panel):
 
         max_iters_text = wx.StaticBox(self, label="Maximum iterations")
         max_iters_text_boxsizer = wx.StaticBoxSizer(max_iters_text, wx.VERTICAL)
-        self.max_iters = wx.SpinCtrl(self, value=max_iters, min=1, max=int(max_iters))
+        self.max_iters = wx.SpinCtrl(self, value="500000", min=1, max=int(max_iters))
         max_iters_text_boxsizer.Add(
             self.max_iters, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 10
         )
         # self.max_iters.Enable(False)
 
-        snapshots = wx.StaticBox(self, label="Number of snapshots to keep")
+        snapshots = wx.StaticBox(self, label="Number of network snapshots to keep")
         snapshots_boxsizer = wx.StaticBoxSizer(snapshots, wx.VERTICAL)
-        self.snapshots = wx.SpinCtrl(self, value="5", min=1, max=100)
+        self.snapshots = wx.SpinCtrl(self, value="10", min=1, max=100)
         snapshots_boxsizer.Add(self.snapshots, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
         # self.snapshots.Enable(False)
 
         hbox1.Add(shuffles_text_boxsizer, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
-        hbox1.Add(trainingindex_boxsizer, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
+        #hbox1.Add(trainingindex_boxsizer, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
         hbox1.Add(self.pose_cfg_choice, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
         hbox1.Add(vbox1, 10, wx.EXPAND | wx.TOP | wx.BOTTOM, 10)
 
@@ -216,14 +215,14 @@ class Train_network(wx.Panel):
     def chooseOption(self, event):
         if self.pose_cfg_choice.GetStringSelection() == "Yes":
             self.shuffles.Enable(False)
-            self.trainingindex.Enable(False)
+            #self.trainingindex.Enable(False)
             self.pose_cfg_text.Show()
             self.update_params_text.Show()
             self.SetSizer(self.sizer)
             self.sizer.Fit(self)
         else:
             self.shuffles.Enable(True)
-            self.trainingindex.Enable(True)
+            #self.trainingindex.Enable(True)
             self.pose_cfg_text.Hide()
             self.update_params_text.Hide()
             self.SetSizer(self.sizer)
@@ -238,19 +237,21 @@ class Train_network(wx.Panel):
         """
         """
         self.shuffles.Enable(True)
-        self.trainingindex.Enable(True)
+        #self.trainingindex.Enable(True)
         self.display_iters.Enable(True)
         self.save_iters.Enable(True)
         self.max_iters.Enable(True)
         self.snapshots.Enable(True)
         # Read the pose config file
+
         cfg = auxiliaryfunctions.read_config(self.config)
-        trainFraction = cfg["TrainingFraction"][self.trainingindex.GetValue()]
+        trainFraction = cfg["TrainingFraction"]
+        #print(trainFraction[-1])
         #        print(os.path.join(cfg['project_path'],auxiliaryfunctions.GetModelFolder(trainFraction, self.shuffles.GetValue(),cfg),'train','pose_cfg.yaml'))
         self.pose_cfg_path = os.path.join(
             cfg["project_path"],
             auxiliaryfunctions.GetModelFolder(
-                trainFraction, self.shuffles.GetValue(), cfg
+                trainFraction[-1], self.shuffles.GetValue(), cfg
             ),
             "train",
             "pose_cfg.yaml",
@@ -277,7 +278,7 @@ class Train_network(wx.Panel):
             self.save_iters.SetValue(save_iters)
             self.max_iters.SetValue(max_iters)
             self.shuffles.Enable(True)
-            self.trainingindex.Enable(True)
+            #self.trainingindex.Enable(True)
             self.display_iters.Enable(True)
             self.save_iters.Enable(True)
             self.max_iters.Enable(True)
@@ -290,11 +291,6 @@ class Train_network(wx.Panel):
             shuffle = int(self.shuffles.Children[0].GetValue())
         else:
             shuffle = int(self.shuffles.GetValue())
-
-        if self.trainingindex.Children:
-            trainingsetindex = int(self.trainingindex.Children[0].GetValue())
-        else:
-            trainingsetindex = int(self.trainingindex.GetValue())
 
         if self.snapshots.Children:
             max_snapshots_to_keep = int(self.snapshots.Children[0].GetValue())
@@ -319,7 +315,6 @@ class Train_network(wx.Panel):
         deeplabcut.train_network(
             self.config,
             shuffle,
-            trainingsetindex,
             gputouse=None,
             max_snapshots_to_keep=max_snapshots_to_keep,
             autotune=None,
@@ -337,7 +332,7 @@ class Train_network(wx.Panel):
         self.pose_cfg_text.Hide()
         self.update_params_text.Hide()
         self.pose_cfg_choice.SetSelection(1)
-        self.display_iters.SetValue(100)
+        self.display_iters.SetValue(1000)
         self.save_iters.SetValue(10000)
         self.max_iters.SetValue(50000)
         self.snapshots.SetValue(5)

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -195,6 +195,7 @@ def analyze_videos(
 
     cfg = auxiliaryfunctions.read_config(config)
     trainFraction = cfg["TrainingFraction"][trainingsetindex]
+    iteration = cfg["iteration"]
 
     if cropping is not None:
         cfg["cropping"] = True
@@ -215,8 +216,8 @@ def analyze_videos(
         dlc_cfg = load_config(str(path_test_config))
     except FileNotFoundError:
         raise FileNotFoundError(
-            "It seems the model for shuffle %s and trainFraction %s does not exist."
-            % (shuffle, trainFraction)
+            "It seems the model for iteration %s and shuffle %s and trainFraction %s does not exist."
+            % (iteration, shuffle, trainFraction)
         )
 
     # Check which snapshots are available and sort them by # iterations
@@ -230,7 +231,7 @@ def analyze_videos(
         )
     except FileNotFoundError:
         raise FileNotFoundError(
-            "Snapshots not found! It seems the dataset for shuffle %s has not been trained/does not exist.\n Please train it before using it to analyze videos.\n Use the function 'train_network' to train the network for shuffle %s."
+            "Snapshots not found! It seems the dataset for shuffle %s has not been trained/does not exist.\n Be sure you also have the intented iteration number set.\n Please train it before using it to analyze videos.\n Use the function 'train_network' to train the network for shuffle %s."
             % (shuffle, shuffle)
         )
 

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -58,6 +58,7 @@ def analyze_videos(
     robust_nframes=False,
     allow_growth=False,
     auto_track=True,
+    n_tracks=None,
     use_shelve=False,
 ):
     """
@@ -127,8 +128,8 @@ def analyze_videos(
     auto_track: bool, optional (default=True)
         By default, tracking and stitching are automatically performed, producing the final h5 data file.
         This is equivalent to the behavior of single-animal projects.
-        
-        If False, one must run `convert_detections2tracklets` and `stitch_tracklets` afterwards, in order to obtain the h5 file. 
+
+        If False, one must run `convert_detections2tracklets` and `stitch_tracklets` afterwards, in order to obtain the h5 file.
 
     use_shelve: bool, optional (default=False)
         By default, data are dumped in a pickle file at the end of the video analysis.
@@ -336,6 +337,7 @@ def analyze_videos(
                         shuffle,
                         trainingsetindex,
                         destfolder=destfolder,
+                        n_tracks=n_tracks,
                         modelprefix=modelprefix,
                     )
         else:

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -59,6 +59,8 @@ def analyze_videos(
     allow_growth=False,
     auto_track=True,
     n_tracks=None,
+    calibrate=False,
+    identity_only=False,
     use_shelve=False,
 ):
     """
@@ -130,6 +132,24 @@ def analyze_videos(
         This is equivalent to the behavior of single-animal projects.
 
         If False, one must run `convert_detections2tracklets` and `stitch_tracklets` afterwards, in order to obtain the h5 file.
+
+        This function has 3 related sub-calls:
+
+    identity_only: bool, optional (default=False)
+        If True and animal identity was learned by the model,
+        assembly and tracking rely exclusively on identity prediction.
+
+    calibrate: bool, optional (default=False)
+        If True, use training data to calibrate the animal assembly procedure.
+        This improves its robustness to wrong body part links,
+        but requires very little missing data.
+
+    n_tracks : int, optional
+        Number of tracks to reconstruct. By default, taken as the number
+        of individuals defined in the config.yaml. Another number can be
+        passed if the number of animals in the video is different from
+        the number of animals the model was trained on.
+
 
     use_shelve: bool, optional (default=False)
         By default, data are dumped in a pickle file at the end of the video analysis.
@@ -329,6 +349,8 @@ def analyze_videos(
                         trainingsetindex,
                         destfolder=destfolder,
                         modelprefix=modelprefix,
+                        calibrate=calibrate,
+                        identity_only=identity_only,
                     )
                     stitch_tracklets(
                         config,

--- a/deeplabcut/utils/conversioncode.py
+++ b/deeplabcut/utils/conversioncode.py
@@ -130,7 +130,7 @@ def analyze_videos_converth5_to_csv(video_folder, videotype=".mp4",listofvideos=
                     df = pd.read_hdf(file)
                     df.to_csv(file.replace(".h5", ".csv"))
 
-    print("All pose files were converted.")
+    print("All H5 files were converted to CSV.")
 
 
 def merge_windowsannotationdataONlinuxsystem(cfg):

--- a/deeplabcut/utils/conversioncode.py
+++ b/deeplabcut/utils/conversioncode.py
@@ -74,7 +74,7 @@ def convertcsv2h5(config, userfeedback=True, scorer=None):
             print("Attention:", folder, "does not appear to have labeled data!")
 
 
-def analyze_videos_converth5_to_csv(video_folder, videotype=".mp4"):
+def analyze_videos_converth5_to_csv(video_folder, videotype=".mp4",singlevideo=False):
     """
     By default the output poses (when running analyze_videos) are stored as MultiIndex Pandas Array, which contains the name of the network, body part name, (x, y) label position \n
     in pixels, and the likelihood for each frame per body part. These arrays are stored in an efficient Hierarchical Data Format (HDF) \n
@@ -99,12 +99,21 @@ def analyze_videos_converth5_to_csv(video_folder, videotype=".mp4"):
     deeplabcut.analyze_videos_converth5_to_csv('/media/alex/experimentaldata/cheetahvideos','.mp4')
 
     """
-    h5_files = list(
-        auxiliaryfunctions.grab_files_in_folder(video_folder, "h5", relative=False)
-    )
-    videos = auxiliaryfunctions.grab_files_in_folder(
-        video_folder, videotype, relative=False
-    )
+
+    if singlevideo: # can also be called with a single video (from GUI)
+        videos = [video_folder]
+        h5_files = list(
+            auxiliaryfunctions.grab_files_in_folder(Path(video_folder).parent, "h5", relative=False)
+        )
+    else:
+
+        h5_files = list(
+            auxiliaryfunctions.grab_files_in_folder(video_folder, "h5", relative=False)
+        )
+        videos = auxiliaryfunctions.grab_files_in_folder(
+            video_folder, videotype, relative=False
+        )
+
     for video in videos:
         if "_labeled" in video:
             continue
@@ -117,6 +126,7 @@ def analyze_videos_converth5_to_csv(video_folder, videotype=".mp4"):
                     print(f"Converting {file}...")
                     df = pd.read_hdf(file)
                     df.to_csv(file.replace(".h5", ".csv"))
+
     print("All pose files were converted.")
 
 

--- a/deeplabcut/utils/conversioncode.py
+++ b/deeplabcut/utils/conversioncode.py
@@ -74,7 +74,7 @@ def convertcsv2h5(config, userfeedback=True, scorer=None):
             print("Attention:", folder, "does not appear to have labeled data!")
 
 
-def analyze_videos_converth5_to_csv(video_folder, videotype=".mp4",singlevideo=False):
+def analyze_videos_converth5_to_csv(video_folder, videotype=".mp4",listofvideos=False):
     """
     By default the output poses (when running analyze_videos) are stored as MultiIndex Pandas Array, which contains the name of the network, body part name, (x, y) label position \n
     in pixels, and the likelihood for each frame per body part. These arrays are stored in an efficient Hierarchical Data Format (HDF) \n
@@ -100,11 +100,14 @@ def analyze_videos_converth5_to_csv(video_folder, videotype=".mp4",singlevideo=F
 
     """
 
-    if singlevideo: # can also be called with a single video (from GUI)
-        videos = [video_folder]
-        h5_files = list(
-            auxiliaryfunctions.grab_files_in_folder(Path(video_folder).parent, "h5", relative=False)
-        )
+    if listofvideos: # can also be called with a list of videos (from GUI)
+        videos = video_folder # GUI gives a list of videos
+        if len(videos)>0:
+            h5_files = list(
+                auxiliaryfunctions.grab_files_in_folder(Path(videos[0]).parent, "h5", relative=False)
+            )
+        else:
+            h5_files =[]
     else:
 
         h5_files = list(


### PR DESCRIPTION
# Goal:

To simplify GUI default maDLC into a single step: more advanced users should use the colab or terminal commands, but this makes it simple and straightforward for beginners. This PR directly addresses the GUI; as the one-step function was updated in #1567 , which now allows for dlc.analyze_videos(... `auto_track=True`) to complete analysis, stitching and tracking.

- Example of the new GUI layout for single-click maDLC: 
<img width="1254" alt="Screen Shot 2021-12-20 at 5 37 39 PM" src="https://user-images.githubusercontent.com/28102185/146851326-23ecc001-a8b4-45e0-ad80-b42d591c1b61.png">


## Done:

- [x] Analyze video tab now includes a "one-click" video analysis, create_full_detections_video, track+stitch (assuming same # of animals used in training).
Some dropped terms for simplification .. should decide if this is OKAY, or should make a depreciation warning as not fully backwards compatible (BC)? 
- [x] dropped: `video_type` as a selection menu (as the functions now work without passing this anyhow, so this is BC)
- [x] dropped: `trainingindex`: I suspect this is never changed from default 0... but, dropping could break someone's BC. 
- [x] dropped trainingindex in other tabs too
- [x] combined tab for extract outliers and label, simplifies workflow. 
- [x] filtering works + get CSV file for user
- [x] add in n_tracks, so people can pass in # of animals
- [x] more than 1 video selected working (thanks @backyardbiomech ! )
- [x] update how analyze_videos h5 to csv handles videos (thanks @AlexEMG)
- [x] plot_traj and plots pop up for saDLC and maDLC
- [x] able to use ID = true
- [x] able to use calibration = true
- [x] tested: all combinations of the tabs in the GUI for maDLC
- [x] enhancement: better print statement for `filenotfound` during video analysis to remind use to check iteration # in config.yaml too 
- [x] better network defaults for saDLC and maDLC; also dropped all the model options in the drop down in order to guide novice users to best options; left them all for model comparison though!

Here is the (minimal) expected output from the current WIP PR: 

```python
pythonw -m deeplabcut
Starting GUI...
DLC network loading and video analysis starting ...
Using snapshot-5 for model /Users/mwmathis/Documents/DeepLabCut/examples/multi_mouse-dlc_team-2021-09-03/dlc-models/iteration-0/multi_mouseSep3-trainset80shuffle1
/Users/mwmathis/opt/anaconda3/envs/DEEPLABCUT/lib/python3.8/site-packages/tensorflow/python/keras/engine/base_layer_v1.py:1692: UserWarning: `layer.apply` is deprecated and will be removed in a future version. Please use `layer.__call__` method instead.
  warnings.warn('`layer.apply` is deprecated and '
Activating extracting of PAFs
2021-12-20 15:26:18.987605: I tensorflow/core/platform/cpu_feature_guard.cc:142] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
Starting to analyze %  /Users/mwmathis/Documents/DeepLabCut/examples/multi_mouse-dlc_team-2021-09-03/videos/m3v1mp4short.mp4
Video already analyzed! /Users/mwmathis/Documents/DeepLabCut/examples/multi_mouse-dlc_team-2021-09-03/videos/m3v1mp4shortDLC_dlcrnetms5_multi_mouseSep3shuffle1_5.h5
Using snapshot-5 for model /Users/mwmathis/Documents/DeepLabCut/examples/multi_mouse-dlc_team-2021-09-03/dlc-models/iteration-0/multi_mouseSep3-trainset80shuffle1
Processing...  /Users/mwmathis/Documents/DeepLabCut/examples/multi_mouse-dlc_team-2021-09-03/videos/m3v1mp4short.mp4
Tracklets already computed /Users/mwmathis/Documents/DeepLabCut/examples/multi_mouse-dlc_team-2021-09-03/videos/m3v1mp4shortDLC_dlcrnetms5_multi_mouseSep3shuffle1_5_el.pickle
Set overwrite = True to overwrite.
The tracklets were created (i.e., under the hood deeplabcut.convert_detections2tracklets was run). Now you can 'refine_tracklets' in the GUI, or run 'deeplabcut.stitch_tracklets'.
Processing...  /Users/mwmathis/Documents/DeepLabCut/examples/multi_mouse-dlc_team-2021-09-03/videos/m3v1mp4short.mp4
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 15807.68it/s]
The videos are analyzed. Time to assemble animals and track 'em...
 Call 'create_video_with_all_detections' to check multi-animal detection quality before tracking.
If the tracking is not satisfactory for some videos, consider expanding the training set. You can use the function 'extract_outlier_frames' to extract a few representative outlier frames.
Detections already plotted,  /Users/mwmathis/Documents/DeepLabCut/examples/multi_mouse-dlc_team-2021-09-03/videos/m3v1mp4shortDLC_dlcrnetms5_multi_mouseSep3shuffle1_5_full.mp4
DLC network loading and video analysis starting ...
Using snapshot-5 for model /Users/mwmathis/Documents/DeepLabCut/examples/multi_mouse-dlc_team-2021-09-03/dlc-models/iteration-0/multi_mouseSep3-trainset80shuffle1
Activating extracting of PAFs
Starting to analyze %  /Users/mwmathis/Documents/DeepLabCut/examples/multi_mouse-dlc_team-2021-09-03/videos/m3v1mp4short.mp4
Loading  /Users/mwmathis/Documents/DeepLabCut/examples/multi_mouse-dlc_team-2021-09-03/videos/m3v1mp4short.mp4
Duration of video [s]:  1.03 , recorded with  30.0 fps!
Overall # of frames:  31  found with (before cropping) frame dimensions:  640 480
Starting to extract posture from the video(s) with batchsize: 8
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 31/31 [00:16<00:00,  1.89it/s]
Video Analyzed. Saving results in /Users/mwmathis/Documents/DeepLabCut/examples/multi_mouse-dlc_team-2021-09-03/videos...
Using snapshot-5 for model /Users/mwmathis/Documents/DeepLabCut/examples/multi_mouse-dlc_team-2021-09-03/dlc-models/iteration-0/multi_mouseSep3-trainset80shuffle1
Processing...  /Users/mwmathis/Documents/DeepLabCut/examples/multi_mouse-dlc_team-2021-09-03/videos/m3v1mp4short.mp4
Analyzing /Users/mwmathis/Documents/DeepLabCut/examples/multi_mouse-dlc_team-2021-09-03/videos/m3v1mp4shortDLC_dlcrnetms5_multi_mouseSep3shuffle1_5.h5
31it [00:00, 623.82it/s]
31it [00:03,  8.74it/s]
The tracklets were created (i.e., under the hood deeplabcut.convert_detections2tracklets was run). Now you can 'refine_tracklets' in the GUI, or run 'deeplabcut.stitch_tracklets'.
Processing...  /Users/mwmathis/Documents/DeepLabCut/examples/multi_mouse-dlc_team-2021-09-03/videos/m3v1mp4short.mp4
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 53773.13it/s]
The videos are analyzed. Time to assemble animals and track 'em...
 Call 'create_video_with_all_detections' to check multi-animal detection quality before tracking.
If the tracking is not satisfactory for some videos, consider expanding the training set. You can use the function 'extract_outlier_frames' to extract a few representative outlier frames.
Creating labeled video for  m3v1mp4short
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 31/31 [00:00<00:00, 268.20it/s]
```

## TODO:

