### PR TITLE
drop opencv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ numba
 matplotlib
 networkx
 numpy
-opencv-python-headless
 pandas>=1.0.1
 patsy
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setuptools.setup(
         "matplotlib",
         "networkx",
         "numpy",
-        "opencv-python-headless",
         "pandas>=1.0.1",
         "scikit-image>=0.17,<=0.18.1",
         "scikit-learn",


### PR DESCRIPTION
## Goal: 
testing related to #1625 , where it appears multiple installations of opencv occur, causing issues on COLAB (note, within local conda env this is not an issue).

## Likely Issue:
- in testing it seems tensorflow 2.7 included `opencv-python` in dependencies:

<img width="858" alt="Screen Shot 2021-12-29 at 12 22 52 PM" src="https://user-images.githubusercontent.com/28102185/147696730-531758c2-902f-4403-9504-d9a99409828c.png">


## changes:
- drop opencv-python from requirements.txt, setup.py

Note, there apparently are two routes for this, drop in `setup.py`, and or check first: https://github.com/aleju/imgaug/pull/586/files

## testing:
- [x] tested on COLAB

<img width="906" alt="Screen Shot 2021-12-29 at 12 40 07 PM" src="https://user-images.githubusercontent.com/28102185/147697783-d79734c3-beb9-47b0-b305-573e2c3aef60.png">

- [x] passed tests on github 