### PR TITLE
Pin pytables to fix h5 writing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ scipy>=1.4
 six
 statsmodels>=0.11
 tensorflow>=2.0
-tables
+tables<=3.6.1
 tensorpack
 tf_slim
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
         "scikit-learn",
         "scipy>=1.4",
         "statsmodels>=0.11",
-        "tables",
+        "tables<=3.6.1",
         "tensorflow>=2.0",
         "tensorpack",
         "tf_slim",


### PR DESCRIPTION
Ensure pytables is at most 3.6.1, since 3.7.0 seems to have been very problematic lately.