### PR TITLE
Fix merge of old and new (path agnostic) DataFrames

### DIFF
--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -423,6 +423,7 @@ def merge_annotateddatasets(cfg, trainingsetfolder_full):
         )
         try:
             data = pd.read_hdf(file_path)
+            conversioncode.guarantee_multiindex_rows(data)
             AnnotationData.append(data)
         except FileNotFoundError:
             print(file_path, " not found (perhaps not annotated).")
@@ -452,7 +453,6 @@ def merge_annotateddatasets(cfg, trainingsetfolder_full):
     AnnotationData = AnnotationData.reindex(
         bodyparts, axis=1, level=AnnotationData.columns.names.index("bodyparts")
     )
-    conversioncode.guarantee_multiindex_rows(AnnotationData)
     filename = os.path.join(trainingsetfolder_full, f'CollectedData_{cfg["scorer"]}')
     AnnotationData.to_hdf(filename + ".h5", key="df_with_missing", mode="w")
     AnnotationData.to_csv(filename + ".csv")  # human readable.

--- a/deeplabcut/utils/conversioncode.py
+++ b/deeplabcut/utils/conversioncode.py
@@ -149,6 +149,7 @@ def merge_windowsannotationdataONlinuxsystem(cfg):
         filename = os.path.join(folder, "CollectedData_" + cfg["scorer"] + ".h5")
         try:
             data = pd.read_hdf(filename)
+            guarantee_multiindex_rows(data)
             AnnotationData.append(data)
         except FileNotFoundError:
             print(filename, " not found (perhaps not annotated)")


### PR DESCRIPTION
For projects created prior to #1584 with extra data labeled later on, `merge_annotateddatasets` will attempt to concatenate DataFrames with absolute image paths and others with the new hierarchical index (also making sorting problematic as seen in #1636). Data are now converted to the new format right upon reading files, so mixed-format datasets are properly merged.

Fixes #1636