### PR TITLE
Fix for restarted training not following the lr schedule

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/core/train.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train.py
@@ -264,14 +264,14 @@ def train(
     max_iter += start_iter  # max_iter is relative to start_iter
     for it in range(start_iter, max_iter + 1):
         if "efficientnet" in net_type:
-            dict_ = {tstep: it - start_iter}
-            current_lr = sess.run(learning_rate, feed_dict=dict_)
+            lr_dict = {tstep: it - start_iter}
+            current_lr = sess.run(learning_rate, feed_dict=lr_dict)
         else:
             current_lr = lr_gen.get_lr(it - start_iter)
-            dict_ = {learning_rate: current_lr}
+            lr_dict = {learning_rate: current_lr}
 
         [_, loss_val, summary] = sess.run(
-            [train_op, total_loss, merged_summaries], feed_dict=dict_
+            [train_op, total_loss, merged_summaries], feed_dict=lr_dict
         )
         cum_loss += loss_val
         train_writer.add_summary(summary, it)

--- a/deeplabcut/pose_estimation_tensorflow/core/train.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train.py
@@ -32,9 +32,13 @@ from deeplabcut.pose_estimation_tensorflow.util.logging import setup_logging
 
 
 class LearningRate(object):
-    def __init__(self, cfg):
+    def __init__(self, cfg, start_iteration):
         self.steps = cfg["multi_step"]
         self.current_step = 0
+        # Initializing lr to right value if DLC already trained
+        for step in self.steps:
+            if start_iteration >= step[1]:
+                self.current_step += 1
 
     def get_lr(self, iteration):
         lr = self.steps[self.current_step][0]

--- a/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
@@ -141,7 +141,7 @@ def train(
         print("Save_iters overwritten as", save_iters)
 
     cumloss, partloss, locrefloss, pwloss = 0.0, 0.0, 0.0, 0.0
-    lr_gen = LearningRate(cfg)
+    lr_gen = LearningRate(cfg, start_iter)
     stats_path = Path(config_yaml).with_name("learning_stats.csv")
     lrf = open(str(stats_path), "w")
 

--- a/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
@@ -141,24 +141,25 @@ def train(
         print("Save_iters overwritten as", save_iters)
 
     cumloss, partloss, locrefloss, pwloss = 0.0, 0.0, 0.0, 0.0
-    lr_gen = LearningRate(cfg, start_iter)
+    lr_gen = LearningRate(cfg)
     stats_path = Path(config_yaml).with_name("learning_stats.csv")
     lrf = open(str(stats_path), "w")
 
     print("Training parameters:")
     print(cfg)
     print("Starting multi-animal training....")
+    max_iter += start_iter  # max_iter is relative to start_iter
     for it in range(start_iter, max_iter + 1):
         if "efficientnet" in net_type:
-            dict = {tstep: it}
-            current_lr = sess.run(learning_rate, feed_dict=dict)
+            dict_ = {tstep: it - start_iter}
+            current_lr = sess.run(learning_rate, feed_dict=dict_)
         else:
-            current_lr = lr_gen.get_lr(it)
-            dict = {learning_rate: current_lr}
+            current_lr = lr_gen.get_lr(it - start_iter)
+            dict_ = {learning_rate: current_lr}
 
         # [_, loss_val, summary] = sess.run([train_op, total_loss, merged_summaries],feed_dict={learning_rate: current_lr})
         [_, alllosses, loss_val, summary] = sess.run(
-            [train_op, losses, total_loss, merged_summaries], feed_dict=dict
+            [train_op, losses, total_loss, merged_summaries], feed_dict=dict_
         )
 
         partloss += alllosses["part_loss"]  # scoremap loss

--- a/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
@@ -151,15 +151,15 @@ def train(
     max_iter += start_iter  # max_iter is relative to start_iter
     for it in range(start_iter, max_iter + 1):
         if "efficientnet" in net_type:
-            dict_ = {tstep: it - start_iter}
-            current_lr = sess.run(learning_rate, feed_dict=dict_)
+            lr_dict = {tstep: it - start_iter}
+            current_lr = sess.run(learning_rate, feed_dict=lr_dict)
         else:
             current_lr = lr_gen.get_lr(it - start_iter)
-            dict_ = {learning_rate: current_lr}
+            lr_dict = {learning_rate: current_lr}
 
         # [_, loss_val, summary] = sess.run([train_op, total_loss, merged_summaries],feed_dict={learning_rate: current_lr})
         [_, alllosses, loss_val, summary] = sess.run(
-            [train_op, losses, total_loss, merged_summaries], feed_dict=dict_
+            [train_op, losses, total_loss, merged_summaries], feed_dict=lr_dict
         )
 
         partloss += alllosses["part_loss"]  # scoremap loss


### PR DESCRIPTION
The iteration # passed to the scheduler is now correct.
Note that max_iter is relative to start_iter; i.e., retraining from 50k iterations with max_iter=50k will train the model up to 100k.

Fixes #1646