### PR TITLE
Fix learning rate when retraining

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/core/train.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train.py
@@ -264,14 +264,14 @@ def train(
     max_iter += start_iter  # max_iter is relative to start_iter
     for it in range(start_iter, max_iter + 1):
         if "efficientnet" in net_type:
-            dict = {tstep: it - start_iter}
-            current_lr = sess.run(learning_rate, feed_dict=dict)
+            dict_ = {tstep: it - start_iter}
+            current_lr = sess.run(learning_rate, feed_dict=dict_)
         else:
             current_lr = lr_gen.get_lr(it - start_iter)
-            dict = {learning_rate: current_lr}
+            dict_ = {learning_rate: current_lr}
 
         [_, loss_val, summary] = sess.run(
-            [train_op, total_loss, merged_summaries], feed_dict=dict
+            [train_op, total_loss, merged_summaries], feed_dict=dict_
         )
         cum_loss += loss_val
         train_writer.add_summary(summary, it)

--- a/deeplabcut/pose_estimation_tensorflow/core/train.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train.py
@@ -261,12 +261,13 @@ def train(
     print("Training parameter:")
     print(cfg)
     print("Starting training....")
+    max_iter += start_iter  # max_iter is relative to start_iter
     for it in range(start_iter, max_iter + 1):
         if "efficientnet" in net_type:
-            dict = {tstep: it}
+            dict = {tstep: it - start_iter}
             current_lr = sess.run(learning_rate, feed_dict=dict)
         else:
-            current_lr = lr_gen.get_lr(it)
+            current_lr = lr_gen.get_lr(it - start_iter)
             dict = {learning_rate: current_lr}
 
         [_, loss_val, summary] = sess.run(

--- a/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
@@ -148,12 +148,13 @@ def train(
     print("Training parameters:")
     print(cfg)
     print("Starting multi-animal training....")
+    max_iter += start_iter  # max_iter is relative to start_iter
     for it in range(start_iter, max_iter + 1):
         if "efficientnet" in net_type:
-            dict = {tstep: it}
+            dict = {tstep: it - start_iter}
             current_lr = sess.run(learning_rate, feed_dict=dict)
         else:
-            current_lr = lr_gen.get_lr(it)
+            current_lr = lr_gen.get_lr(it - start_iter)
             dict = {learning_rate: current_lr}
 
         # [_, loss_val, summary] = sess.run([train_op, total_loss, merged_summaries],feed_dict={learning_rate: current_lr})

--- a/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
@@ -151,15 +151,15 @@ def train(
     max_iter += start_iter  # max_iter is relative to start_iter
     for it in range(start_iter, max_iter + 1):
         if "efficientnet" in net_type:
-            dict = {tstep: it - start_iter}
-            current_lr = sess.run(learning_rate, feed_dict=dict)
+            dict_ = {tstep: it - start_iter}
+            current_lr = sess.run(learning_rate, feed_dict=dict_)
         else:
             current_lr = lr_gen.get_lr(it - start_iter)
-            dict = {learning_rate: current_lr}
+            dict_ = {learning_rate: current_lr}
 
         # [_, loss_val, summary] = sess.run([train_op, total_loss, merged_summaries],feed_dict={learning_rate: current_lr})
         [_, alllosses, loss_val, summary] = sess.run(
-            [train_op, losses, total_loss, merged_summaries], feed_dict=dict
+            [train_op, losses, total_loss, merged_summaries], feed_dict=dict_
         )
 
         partloss += alllosses["part_loss"]  # scoremap loss


### PR DESCRIPTION
The iteration # passed to the scheduler is now correct.
Note that max_iter is relative to start_iter; i.e., retraining from 50k iterations with max_iter=50k will train the model up to 100k.

Fixes #1646