### PR TITLE
Use TF2 documented way to allow growth

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/core/predict.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/predict.py
@@ -25,6 +25,9 @@ https://arxiv.org/abs/1909.11229
 import numpy as np
 import tensorflow as tf
 from deeplabcut.pose_estimation_tensorflow.nnets.factory import PoseNetFactory
+from deeplabcut.pose_estimation_tensorflow.core.train import (
+    allow_memory_growth,
+)
 
 
 def setup_pose_prediction(cfg, allow_growth=False):
@@ -46,11 +49,8 @@ def setup_pose_prediction(cfg, allow_growth=False):
     restorer = tf.compat.v1.train.Saver()
 
     if allow_growth:
-        config = tf.compat.v1.ConfigProto()
-        config.gpu_options.allow_growth = True
-        sess = tf.compat.v1.Session(config=config)
-    else:
-        sess = tf.compat.v1.Session()
+        allow_memory_growth()
+    sess = tf.compat.v1.Session()
     sess.run(tf.compat.v1.global_variables_initializer())
     sess.run(tf.compat.v1.local_variables_initializer())
 
@@ -217,12 +217,8 @@ def setup_GPUpose_prediction(cfg, allow_growth=False):
     restorer = tf.compat.v1.train.Saver()
 
     if allow_growth:
-        config = tf.compat.v1.ConfigProto()
-        config.gpu_options.allow_growth = True
-        sess = tf.compat.v1.Session(config=config)
-    else:
-        sess = tf.compat.v1.Session()
-
+        allow_memory_growth()
+    sess = tf.compat.v1.Session()
     sess.run(tf.compat.v1.global_variables_initializer())
     sess.run(tf.compat.v1.local_variables_initializer())
 

--- a/deeplabcut/pose_estimation_tensorflow/core/train.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train.py
@@ -141,6 +141,11 @@ def get_optimizer_with_freeze(loss_op, cfg):
     return learning_rate, train_unfrozen_op, train_frozen_op
 
 
+def allow_memory_growth():
+    for dev in tf.config.list_physical_devices("GPU"):
+        tf.config.experimental.set_memory_growth(dev, True)
+
+
 def train(
     config_yaml,
     displayiters,
@@ -208,12 +213,8 @@ def train(
     )  # selects how many snapshots are stored, see https://github.com/AlexEMG/DeepLabCut/issues/8#issuecomment-387404835
 
     if allow_growth:
-        config = tf.compat.v1.ConfigProto()
-        config.gpu_options.allow_growth = True
-        sess = tf.compat.v1.Session(config=config)
-    else:
-        sess = tf.compat.v1.Session()
-
+        allow_memory_growth()
+    sess = tf.compat.v1.Session()
     coord, thread = start_preloading(sess, enqueue_op, dataset, placeholders)
     train_writer = tf.compat.v1.summary.FileWriter(cfg["log_dir"], sess.graph)
 

--- a/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
@@ -28,6 +28,7 @@ from deeplabcut.pose_estimation_tensorflow.core.train import (
     start_preloading,
     get_optimizer,
     LearningRate,
+    allow_memory_growth,
 )
 
 
@@ -106,12 +107,8 @@ def train(
     )  # selects how many snapshots are stored, see https://github.com/AlexEMG/DeepLabCut/issues/8#issuecomment-387404835
 
     if allow_growth:
-        config = tf.compat.v1.ConfigProto()
-        config.gpu_options.allow_growth = True
-        sess = tf.compat.v1.Session(config=config)
-    else:
-        sess = tf.compat.v1.Session()
-
+        allow_memory_growth()
+    sess = tf.compat.v1.Session()
     coord, thread = start_preloading(sess, enqueue_op, dataset, placeholders)
     train_writer = tf.compat.v1.summary.FileWriter(cfg["log_dir"], sess.graph)
     learning_rate, train_op, tstep = get_optimizer(total_loss, cfg)


### PR DESCRIPTION
I realized that allowing memory growth the old way had no effect when running the testscript; it now does.