### PR TITLE
Replace underscores for dashes in foldername

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -905,7 +905,7 @@ def evaluate_network(
                                 str(evaluationfolder),
                                 "LabeledImages_"
                                 + DLCscorer
-                                + "_"
+                                + "-"
                                 + Snapshots[snapindex],
                             )
                             auxiliaryfunctions.attempttomakefolder(foldername)
@@ -934,7 +934,7 @@ def evaluate_network(
                                 str(evaluationfolder),
                                 "LabeledImages_"
                                 + DLCscorer
-                                + "_"
+                                + "-"
                                 + Snapshots[snapindex],
                             )
                             auxiliaryfunctions.attempttomakefolder(foldername)

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -293,7 +293,7 @@ def evaluate_multianimal_full(
                     if plotting:
                         foldername = os.path.join(
                             str(evaluationfolder),
-                            "LabeledImages_" + DLCscorer + "_" + Snapshots[snapindex],
+                            "LabeledImages_" + DLCscorer + "-" + Snapshots[snapindex],
                         )
                         auxiliaryfunctions.attempttomakefolder(foldername)
                         if plotting == "bodypart":


### PR DESCRIPTION
The h5 file in the "evaluation-results" folder uses a "-" to append the snapshot information to the name string whereas the folder containing Test and Training Images in the same directory uses an "_".