### PR TITLE
adds frame extraction to add_new_videos

### DIFF
--- a/deeplabcut/create_project/add.py
+++ b/deeplabcut/create_project/add.py
@@ -112,5 +112,5 @@ def add_new_videos(config, videos, copy_videos=False, coords=None, extract_frame
             "New videos were added to the project and frames have been extracted for labeling!"
         )
     else:
-        print("New video was added to the project!")
+        print("New videos were added to the project! use Use the function 'extract_frames' to select frames for labeling.")
     auxiliaryfunctions.write_config(config, cfg)

--- a/deeplabcut/create_project/add.py
+++ b/deeplabcut/create_project/add.py
@@ -9,7 +9,7 @@ Licensed under GNU Lesser General Public License v3.0
 """
 
 
-def add_new_videos(config, videos, copy_videos=False, coords=None):
+def add_new_videos(config, videos, copy_videos=False, coords=None, extract_frames=True):
     """
     Add new videos to the config file at any stage of the project.
 
@@ -24,8 +24,13 @@ def add_new_videos(config, videos, copy_videos=False, coords=None):
     copy_videos : bool, optional
         If this is set to True, the symlink of the videos are copied to the project/videos directory. The default is
         ``False``; if provided it must be either ``True`` or ``False``.
+
     coords: list, optional
-      A list containing the list of cropping coordinates of the video. The default is set to None.
+        A list containing the list of cropping coordinates of the video. The default is set to None.
+
+    extract_frames: bool, optional
+        if this is set to True extract_frames will be run on the new videos
+
     Examples
     --------
     Video will be added, with cropping dimenions according to the frame dimensinos of mouse5.avi
@@ -44,7 +49,7 @@ def add_new_videos(config, videos, copy_videos=False, coords=None):
 
     from deeplabcut.utils import auxiliaryfunctions
     from deeplabcut.utils.auxfun_videos import VideoReader
-    from deeplabcut.generate_training_dataset.frame_extraction import extract_frames
+    from deeplabcut.generate_training_dataset import frame_extraction
 
     # Read the config file
     cfg = auxiliaryfunctions.read_config(config)
@@ -101,7 +106,11 @@ def add_new_videos(config, videos, copy_videos=False, coords=None):
         else:
             cfg["video_sets_original"].update(params)
     videos_str = [str(video) for video in videos]
-    extract_frames(config, userfeedback=False, videos=videos_str)
+    if extract_frames:
+        frame_extraction.extract_frames(config, userfeedback=False, videos=videos_str)
+
     auxiliaryfunctions.write_config(config, cfg)
 
-    print("New videos were added to the project and frames have been extracted for labeling!")
+    print(
+        "New videos were added to the project and frames have been extracted for labeling!"
+    )

--- a/deeplabcut/create_project/add.py
+++ b/deeplabcut/create_project/add.py
@@ -19,7 +19,7 @@ def add_new_videos(config, videos, copy_videos=False, coords=None, extract_frame
         String containing the full path of the config file in the project.
 
     videos : list
-        A list of string containing the full paths of the videos to include in the project.
+        A list of strings containing the full paths of the videos to include in the project.
 
     copy_videos : bool, optional
         If this is set to True, the symlink of the videos are copied to the project/videos directory. The default is
@@ -108,9 +108,9 @@ def add_new_videos(config, videos, copy_videos=False, coords=None, extract_frame
     videos_str = [str(video) for video in videos]
     if extract_frames:
         frame_extraction.extract_frames(config, userfeedback=False, videos=videos_str)
-
+        print(
+            "New videos were added to the project and frames have been extracted for labeling!"
+        )
+    else:
+        print("New video was added to the project!")
     auxiliaryfunctions.write_config(config, cfg)
-
-    print(
-        "New videos were added to the project and frames have been extracted for labeling!"
-    )

--- a/deeplabcut/create_project/add.py
+++ b/deeplabcut/create_project/add.py
@@ -44,6 +44,7 @@ def add_new_videos(config, videos, copy_videos=False, coords=None):
 
     from deeplabcut.utils import auxiliaryfunctions
     from deeplabcut.utils.auxfun_videos import VideoReader
+    from deeplabcut.generate_training_dataset.frame_extraction import extract_frames
 
     # Read the config file
     cfg = auxiliaryfunctions.read_config(config)
@@ -99,8 +100,8 @@ def add_new_videos(config, videos, copy_videos=False, coords=None):
             cfg["video_sets"].update(params)
         else:
             cfg["video_sets_original"].update(params)
-
+    videos_str = [str(video) for video in videos]
+    extract_frames(config, userfeedback=False, videos=videos_str)
     auxiliaryfunctions.write_config(config, cfg)
-    print(
-        "New video was added to the project! Use the function 'extract_frames' to select frames for labeling."
-    )
+
+    print("New videos were added to the project and frames have been extracted for labeling!")

--- a/deeplabcut/create_project/add.py
+++ b/deeplabcut/create_project/add.py
@@ -112,5 +112,7 @@ def add_new_videos(config, videos, copy_videos=False, coords=None, extract_frame
             "New videos were added to the project and frames have been extracted for labeling!"
         )
     else:
-        print("New videos were added to the project! use Use the function 'extract_frames' to select frames for labeling.")
+        print(
+            "New videos were added to the project! use Use the function 'extract_frames' to select frames for labeling."
+        )
     auxiliaryfunctions.write_config(config, cfg)

--- a/deeplabcut/create_project/add.py
+++ b/deeplabcut/create_project/add.py
@@ -113,6 +113,6 @@ def add_new_videos(config, videos, copy_videos=False, coords=None, extract_frame
         )
     else:
         print(
-            "New videos were added to the project! use Use the function 'extract_frames' to select frames for labeling."
+            "New videos were added to the project! Use the function 'extract_frames' to select frames for labeling."
         )
     auxiliaryfunctions.write_config(config, cfg)

--- a/deeplabcut/create_project/add.py
+++ b/deeplabcut/create_project/add.py
@@ -9,7 +9,7 @@ Licensed under GNU Lesser General Public License v3.0
 """
 
 
-def add_new_videos(config, videos, copy_videos=False, coords=None, extract_frames=True):
+def add_new_videos(config, videos, copy_videos=False, coords=None, extract_frames=False):
     """
     Add new videos to the config file at any stage of the project.
 

--- a/deeplabcut/generate_training_dataset/frame_extraction.py
+++ b/deeplabcut/generate_training_dataset/frame_extraction.py
@@ -74,6 +74,7 @@ def extract_frames(
     slider_width=25,
     config3d=None,
     extracted_cam=0,
+    videos=None,
 ):
     """
     Extracts frames from the videos in the config.yaml file. Only the videos in the config.yaml will be used to select the frames.\n
@@ -142,6 +143,9 @@ def extract_frames(
         The index of the camera that already has extracted frames. This will match frame numbers to extract for all other cameras.
         This parameter is necessary if you wish to use epipolar lines in the labeling toolbox. Only use if mode = 'match' and config3d is provided.
 
+    videos: list, default: None
+            A list of the string containing full paths to videos to extract frames for. If this is left as None all videos in the config file will have frames extracted.
+
     Examples
     --------
     for selecting frames automatically with 'kmeans' and want to crop the frames.
@@ -206,8 +210,8 @@ def extract_frames(
             raise Exception(
                 "Perhaps consider extracting more, or a natural number of frames."
             )
-
-        videos = cfg.get("video_sets_original") or cfg["video_sets"]
+        if videos is None:
+            videos = cfg.get("video_sets_original") or cfg["video_sets"]
         if opencv:
             from deeplabcut.utils.auxfun_videos import VideoReader
         else:

--- a/deeplabcut/generate_training_dataset/frame_extraction.py
+++ b/deeplabcut/generate_training_dataset/frame_extraction.py
@@ -74,7 +74,7 @@ def extract_frames(
     slider_width=25,
     config3d=None,
     extracted_cam=0,
-    videos=None,
+    videos_list=None,
 ):
     """
     Extracts frames from the videos in the config.yaml file. Only the videos in the config.yaml will be used to select the frames.\n
@@ -143,8 +143,9 @@ def extract_frames(
         The index of the camera that already has extracted frames. This will match frame numbers to extract for all other cameras.
         This parameter is necessary if you wish to use epipolar lines in the labeling toolbox. Only use if mode = 'match' and config3d is provided.
 
-    videos: list, default: None
-            A list of the string containing full paths to videos to extract frames for. If this is left as None all videos in the config file will have frames extracted.
+    videos_list: list, default: None
+            A list of the string containing full paths to videos to extract frames for. If this is left as None all videos specified in the config file will have frames extracted. 
+            Otherwise one can select a subset by passing those paths. 
 
     Examples
     --------
@@ -210,8 +211,11 @@ def extract_frames(
             raise Exception(
                 "Perhaps consider extracting more, or a natural number of frames."
             )
-        if videos is None:
+        if videos_list is None:
             videos = cfg.get("video_sets_original") or cfg["video_sets"]
+        else: #filter video_list by the ones in the config file
+            videos = [v for v in cfg["video_sets"] if v in videos_list]
+            
         if opencv:
             from deeplabcut.utils.auxfun_videos import VideoReader
         else:


### PR DESCRIPTION
Adds frame extraction to add_new_videos for **only** the newly added videos. Modifies extract_frames to accept an optional list of strings containing paths, when that list is not empty extract_frames only extracts frames for the videos at those paths.

Currently there is no way to extract frames for only videos added after initial model creation with user input in the command line.