### PR TITLE
Make the outer loop go over GT assemblies in evaluate_assembly

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -480,19 +480,21 @@ def evaluate_multianimal_full(
 
                             print("##########################################")
                             print(
-                                "Average Euclidean distance to GT per individual (in pixels)"
+                                "Average Euclidean distance to GT per individual (in pixels; test-only)"
                             )
                             print(
-                                error_masked.groupby("individuals", axis=1)
+                                error_masked.iloc[testIndices]
+                                .groupby("individuals", axis=1)
                                 .mean()
                                 .mean()
                                 .to_string()
                             )
                             print(
-                                "Average Euclidean distance to GT per bodypart (in pixels)"
+                                "Average Euclidean distance to GT per bodypart (in pixels; test-only)"
                             )
                             print(
-                                error_masked.groupby("bodyparts", axis=1)
+                                error_masked.iloc[testIndices]
+                                .groupby("bodyparts", axis=1)
                                 .mean()
                                 .mean()
                                 .to_string()

--- a/deeplabcut/pose_estimation_tensorflow/lib/crossvalutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/crossvalutils.py
@@ -249,11 +249,11 @@ def _benchmark_paf_graphs(
         if split_inds is not None:
             oks = []
             for inds in split_inds:
-                assemblies = {k: v for k, v in ass.assemblies.items() if k in inds}
+                ass_gt = {k: v for k, v in ass_true_dict.items() if k in inds}
                 oks.append(
                     evaluate_assembly(
-                        assemblies,
-                        ass_true_dict,
+                        ass.assemblies,
+                        ass_gt,
                         oks_sigma,
                         margin=margin,
                         symmetric_kpts=symmetric_kpts,

--- a/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
@@ -990,10 +990,8 @@ def evaluate_assembly(
     # sigma is taken as the median of all COCO keypoint standard deviations
     all_matched = []
     all_unmatched = []
-    for ind, ass_pred in tqdm(ass_pred_dict.items()):
-        ass_true = ass_true_dict.get(ind)
-        if ass_true is None:
-            continue
+    for ind, ass_true in tqdm(ass_true_dict.items()):
+        ass_pred = ass_pred_dict.get(ind, [])
         matched, unmatched = match_assemblies(
             ass_pred,
             ass_true,


### PR DESCRIPTION
If no assemblies are predicted for a given frame, an empty list is passed to `match_assemblies` rather than continuing, extending the `unmatched` list. This guarantees that `ntot` is always correct, even in the extreme case where no animals are predicted at all.
https://github.com/DeepLabCut/DeepLabCut/blob/56e4a0662f8c07646f0ac5391333dfce9bc889ce/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py#L1016 