### PR TITLE
Fix NameError: name 'config' is not defined in get_track_method

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/lib/trackingutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/trackingutils.py
@@ -24,6 +24,8 @@ from tqdm import tqdm
 
 warnings.simplefilter("ignore", category=NumbaPerformanceWarning)
 
+TRACK_METHODS = "box", "skeleton", "ellipse"
+
 
 def calc_iou(bbox1, bbox2):
     x1 = max(bbox1[0], bbox2[0])
@@ -795,7 +797,7 @@ def reconstruct_all_ellipses(data, sd):
 def _track_individuals(
     individuals, min_hits=1, max_age=5, similarity_threshold=0.6, track_method="ellipse"
 ):
-    if track_method not in ("box", "skeleton", "ellipse"):
+    if track_method not in TRACK_METHODS:
         raise ValueError(f"Unknown {track_method} tracker.")
 
     if track_method == "ellipse":

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1359,9 +1359,8 @@ def convert_detections2tracklets(
     if len(cfg["multianimalbodyparts"]) == 1 and track_method != "box":
         warnings.warn("Switching to `box` tracker for single point tracking...")
         track_method = "box"
-
-    cfg["default_track_method"] = track_method
-    auxiliaryfunctions.write_config(config, cfg)
+        cfg["default_track_method"] = track_method
+        auxiliaryfunctions.write_config(config, cfg)
 
     trainFraction = cfg["TrainingFraction"][trainingsetindex]
     start_path = os.getcwd()  # record cwd to return to this directory in the end

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1183,9 +1183,9 @@ def _convert_detections_to_tracklets(
     calibrate=False,
 ):
     track_method = cfg.get("default_track_method", "ellipse")
-    if track_method not in ("box", "skeleton", "ellipse"):
+    if track_method not in trackingutils.TRACK_METHODS:
         raise ValueError(
-            "Invalid tracking method. Only `box`, `skeleton` and `ellipse` are currently supported."
+            f"Invalid tracking method. Only {', '.join(trackingutils.TRACK_METHODS)} are currently supported."
         )
 
     joints = data["metadata"]["all_joints_names"]
@@ -1356,14 +1356,12 @@ def convert_detections2tracklets(
     cfg = auxiliaryfunctions.read_config(config)
     track_method = auxfun_multianimal.get_track_method(cfg, track_method=track_method)
 
-    if track_method not in ("box", "skeleton", "ellipse"):
-        raise ValueError(
-            "Invalid tracking method. Only `box`, `skeleton` and `ellipse` are currently supported."
-        )
-
     if len(cfg["multianimalbodyparts"]) == 1 and track_method != "box":
         warnings.warn("Switching to `box` tracker for single point tracking...")
         track_method = "box"
+
+    cfg["default_track_method"] = track_method
+    auxiliaryfunctions.write_config(config, cfg)
 
     trainFraction = cfg["TrainingFraction"][trainingsetindex]
     start_path = os.getcwd()  # record cwd to return to this directory in the end

--- a/deeplabcut/utils/auxfun_multianimal.py
+++ b/deeplabcut/utils/auxfun_multianimal.py
@@ -43,12 +43,13 @@ def get_track_method(cfg, track_method=""):
             track_method = cfg.get("default_track_method", "")
             if not track_method:
                 warnings.warn(
-                    f"""
-                    `default_track_method` is undefined in the config.yaml file and will be set to `ellipse`.
-                    Edit it manually to one of {TRACK_METHODS} if you want to overwrite this default choice.
-                    """
+                    "default_track_method` is undefined in the config.yaml file and will be set to `ellipse`."
                 )
                 track_method = "ellipse"
+                cfg["default_track_method"] = track_method
+                auxiliaryfunctions.write_config(
+                    str(Path(cfg["project_path"]) / "config.yaml"), cfg
+                )
             return track_method
 
     else:  # no tracker for single-animal projects


### PR DESCRIPTION
`config` was undefined in the function, causing the error reported here https://forum.image.sc/t/track-method-parameter-is-missing-in-madlcs-analyze-videos-in-colab/62542.
Tracking methods are now also defined in a single location, making it easier to add new ones in the future.
