### PR TITLE
Freshening up `Getlistofvideos`

### DIFF
--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -8,6 +8,7 @@ https://github.com/AlexEMG/DeepLabCut/blob/master/AUTHORS
 Licensed under GNU Lesser General Public License v3.0
 """
 import os
+import typing
 import pickle
 import warnings
 from pathlib import Path
@@ -313,7 +314,8 @@ def write_pickle(filename, data):
         pickle.dump(data, handle, protocol=pickle.HIGHEST_PROTOCOL)
 
 
-def Getlistofvideos(videos, videotype):
+def Getlistofvideos(videos: typing.Union[typing.List[str], str], 
+                    videotype: typing.Optional[str] = None) -> typing.List[str]:
     """ Returns list of videos of videotype "videotype" in
     folder videos or for list of videos.
 
@@ -321,48 +323,50 @@ def Getlistofvideos(videos, videotype):
 
     *_labeled.videotype
     *_full.videotype
-
+    
+    Args:
+        videos (list[str], str): List of video paths or a single path string. If string (or len() == 1 list of strings) is a directory, 
+            finds all videos whose extension matches  ``videotype`` in the directory
+        videotype (None, str): File extension used to filter videos. Optional if ``videos`` is a list of video files,
+            but raises a ``ValueError`` if not provided if ``videos`` is a directory.
     """
+    if isinstance(videos, str):
+        videos = [videos]
+    
+    
     if [os.path.isdir(i) for i in videos] == [True]:  # checks if input is a directory
         """
         Returns all the videos in the directory.
         """
-        from random import sample
+        if videotype is None:
+            raise ValueError('When given a directory of videos, must be given a videotype )
+        
+        from random import shuffle
 
         print("Analyzing all the videos in the directory...")
         videofolder = videos[0]
+                             
+        # make list of full paths
+        videos = [os.path.join(videofolder, fn) for fn in os.listdir(videofolder)]
 
-        os.chdir(videofolder)
-        videolist = [
-            os.path.join(videofolder, fn)
-            for fn in os.listdir(os.curdir)
-            if os.path.isfile(fn)
-            and fn.endswith(videotype)
-            and "_labeled." not in fn
-            and "_full." not in fn
-        ]  # exclude labeled (also for multianimal projects) videos!
+        shuffle(videos) # this is useful so multiple nets can be used to analzye simultanously
 
-        Videos = sample(
-            videolist, len(videolist)
-        )  # this is useful so multiple nets can be used to analzye simultanously
-
-    else:
-        if isinstance(videos, str):
-            if (
-                os.path.isfile(videos)
-                and "_labeled." not in videos
-                and "_full." not in videos
-            ):  # #or just one direct path!
-                Videos = [videos]
-            else:
-                Videos = []
-        else:
-            Videos = [
-                v
-                for v in videos
-                if os.path.isfile(v) and "_labeled." not in v and "_full." not in v
-            ]
-    return Videos
+    # if not given a videotype and given a list of files, use empty string
+    # ( 'file.mp4'.endswith('')  == True )
+    if videotype is None:
+        videotype = ''
+                             
+    # filter list of videos
+    videos = [
+        v
+        for v in videos
+        if os.path.isfile(v)
+        and v.endswith(videotype)
+        and "_labeled." not in v
+        and "_full." not in v
+    ]
+        
+    return videos
 
 
 def SaveData(PredicteData, metadata, dataname, pdindex, imagenames, save_as_csv):

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -339,7 +339,7 @@ def Getlistofvideos(videos: typing.Union[typing.List[str], str],
         Returns all the videos in the directory.
         """
         if videotype is None:
-            raise ValueError('When given a directory of videos, must be given a videotype )
+            raise ValueError('When given a directory of videos, must be given a videotype')
         
         from random import shuffle
 


### PR DESCRIPTION
re: https://github.com/DeepLabCut/DeepLabCut/issues/1703

* type hints & docstring update
* make `videotype` optional when given a list of files
* coerce strings to list at start
* use shuffle instead of sampling with list of videos
* don't change directory
* unify filtering into one operation at end of function