### PR TITLE
Discard empty assemblies but not those without links

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
@@ -715,7 +715,7 @@ class Assembler:
             if joint.idx not in assembled and np.isfinite(joint.confidence)
         )
         for assembly in assemblies[::-1]:
-            if 0 <= assembly.n_links < self.min_n_links:
+            if 0 < assembly.n_links < self.min_n_links or not len(assembly):
                 for link in assembly._links:
                     discarded.update((link.j1, link.j2))
                 assemblies.remove(assembly)

--- a/tests/test_inferenceutils.py
+++ b/tests/test_inferenceutils.py
@@ -228,7 +228,7 @@ def test_assembler_with_identity(tmpdir_factory, real_assemblies):
             ids = [np.random.rand(c.shape[0], 3) for c in conf]
             v["identity"] = ids
 
-    ass = inferenceutils.Assembler(data, max_n_individuals=3, n_multibodyparts=12,)
+    ass = inferenceutils.Assembler(data, max_n_individuals=3, n_multibodyparts=12)
     assert ass._has_identity
     assert len(ass.metadata["imnames"]) == 50
     assert ass.n_keypoints == 12
@@ -260,6 +260,7 @@ def test_assembler_with_identity(tmpdir_factory, real_assemblies):
     # contain only parts of a single group ID.
     ass.identity_only = True
     ass.assemble()
+    assert len(ass.assemblies) == len(real_assemblies)
     eq = []
     for a in ass.assemblies.values():
         for _ in a:


### PR DESCRIPTION
When using identity only, assemblies are populated from `joints` (i.e., keypoints) only rather than `links`. An assembly may therefore be non-empty while containing no links, incorrectly causing its deletion. This case is now correctly handled.

Fixes #1693