### PR TITLE
Update python-package.yml -- testing 3.9 (consider dropping 3.7?), and security patch

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-11, windows-latest]
-        python-version: [3.7, 3.8] #3.9 only failing for tables on macos and windows; mwm 6302021
+        python-version: [3.7, 3.8, 3.9, 3.10] #3.9 only failing for tables on macos and windows; mwm 6302021
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -56,6 +56,6 @@ jobs:
 
       - name: Run functional tests
         run: |
-          pip install git+git://github.com/${{ github.repository }}.git@${{ github.sha }}
+          pip install git+https://github.com/${{ github.repository }}.git@${{ github.sha }}
           python examples/testscript.py
           python examples/testscript_multianimal.py

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-11, windows-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10] #3.9 only failing for tables on macos and windows; mwm 6302021
+        python-version: [3.7, 3.8, 3.9] #3.9 only failing for tables on macos and windows; mwm 6302021
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip


### PR DESCRIPTION
based on failing tests due to `git://`, simple swap for `https://` https://github.blog/2021-09-01-improving-git-protocol-security-github/