### PR TITLE
WIP: Delay setting the matplotlib backend until the user asks to launch the GUI

### DIFF
--- a/deeplabcut/__init__.py
+++ b/deeplabcut/__init__.py
@@ -17,13 +17,7 @@ tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
 DEBUG = True and "DEBUG" in os.environ and os.environ["DEBUG"]
 from deeplabcut import DEBUG
 
-# DLClight version does not support GUIs. Importing accordingly
-import matplotlib as mpl
-
 try:
-    import wx
-
-    mpl.use("WxAgg")
     from deeplabcut import generate_training_dataset
     from deeplabcut import refine_training_dataset
 
@@ -38,10 +32,6 @@ except (ModuleNotFoundError, ImportError):
     print(
         "DLC loaded in light mode; you cannot use any GUI (labeling, relabeling and standalone GUI)"
     )
-    mpl.use(
-        "AGG"
-    )  # anti-grain geometry engine #https://matplotlib.org/faq/usage_faq.html
-
 
 from deeplabcut.create_project import (
     create_new_project,

--- a/deeplabcut/gui/launch_script.py
+++ b/deeplabcut/gui/launch_script.py
@@ -10,6 +10,7 @@ Licensed under GNU Lesser General Public License v3.0
 """
 import os
 import wx
+import matplotlib as mpl
 
 from deeplabcut.gui.create_new_project import Create_new_project
 from deeplabcut.gui.welcome import Welcome
@@ -41,6 +42,8 @@ class MainFrame(BaseFrame):
 
 
 def launch_dlc():
+    mpl.use("WxAgg")
+
     app = wx.App()
     app.locale = wx.Locale(wx.LANGUAGE_ENGLISH)
     frame = MainFrame().Show()


### PR DESCRIPTION
This is my attempt at addressing users' ability to import their DeepLabCut environment in both a Jupyter noteook and using the provided GUI (which is really useful!) 

I still need to test it on a variety of configurations, but this makes `wx` a truely optional dependency, and doesn't affect the behavior of matplotlib until the user calls the GUI launching script.



Closes https://github.com/DeepLabCut/DeepLabCut/issues/1548