### PR TITLE
Add option to automatically jump to the next unlabeled data folder

### DIFF
--- a/deeplabcut/gui/label_frames.py
+++ b/deeplabcut/gui/label_frames.py
@@ -27,6 +27,7 @@ def label_frames(
     imtypes=["*.png"],
     config3d=None,
     sourceCam=None,
+    jump_unlabeled=False,
 ):
     """
     Manually label/annotate the extracted frames. Update the list of body parts you want to localize in the config.yaml file first.
@@ -73,11 +74,11 @@ def label_frames(
     if cfg.get("multianimalproject", False) or multiple_individualsGUI:
         from deeplabcut.gui import multiple_individuals_labeling_toolbox
 
-        multiple_individuals_labeling_toolbox.show(config, config3d, sourceCam)
+        multiple_individuals_labeling_toolbox.show(config, config3d, sourceCam, jump_unlabeled)
     else:
         from deeplabcut.gui import labeling_toolbox
 
-        labeling_toolbox.show(config, config3d, sourceCam, imtypes=imtypes)
+        labeling_toolbox.show(config, config3d, sourceCam, imtypes, jump_unlabeled)
 
     os.chdir(startpath)
 

--- a/deeplabcut/gui/labeling_toolbox.py
+++ b/deeplabcut/gui/labeling_toolbox.py
@@ -247,11 +247,11 @@ class ScrollPanel(SP.ScrolledPanel):
 
 
 class MainFrame(BaseFrame):
-    def __init__(self, parent, config, imtypes, config3d, sourceCam):
+    def __init__(self, parent, config, imtypes, config3d, sourceCam, jump_unlabeled):
         super(MainFrame, self).__init__(
             "DeepLabCut2.0 - Labeling ToolBox", parent, imtypes
         )
-
+        self.jump_unlabeled = jump_unlabeled
         self.statusbar.SetStatusText(
             "Looking for a folder to start labeling. Click 'Load frames' to begin."
         )
@@ -574,7 +574,12 @@ class MainFrame(BaseFrame):
             style=wx.DD_DEFAULT_STYLE,
         )
         if dlg.ShowModal() == wx.ID_OK:
-            self.dir = dlg.GetPath()
+            if self.jump_unlabeled:
+                self.dir = str(auxiliaryfunctions.find_next_unlabeled_folder(
+                    self.config_file
+                ))
+            else:
+                self.dir = dlg.GetPath()
             self.load.Enable(False)
             self.next.Enable(True)
             self.save.Enable(True)
@@ -957,9 +962,9 @@ class MainFrame(BaseFrame):
             self.slider.Enable(False)
 
 
-def show(config, config3d, sourceCam, imtypes=["*.png"]):
+def show(config, config3d, sourceCam, imtypes=["*.png"], jump_unlabeled=False):
     app = wx.App()
-    frame = MainFrame(None, config, imtypes, config3d, sourceCam).Show()
+    frame = MainFrame(None, config, imtypes, config3d, sourceCam, jump_unlabeled).Show()
     app.MainLoop()
 
 

--- a/deeplabcut/gui/labeling_toolbox.py
+++ b/deeplabcut/gui/labeling_toolbox.py
@@ -565,29 +565,29 @@ class MainFrame(BaseFrame):
         """
         Show the DirDialog and ask the user to change the directory where machine labels are stored
         """
-        self.statusbar.SetStatusText("Looking for a folder to start labeling...")
-        cwd = os.path.join(os.getcwd(), "labeled-data")
-        dlg = wx.DirDialog(
-            self,
-            "Choose the directory where your extracted frames are saved:",
-            cwd,
-            style=wx.DD_DEFAULT_STYLE,
-        )
-        if dlg.ShowModal() == wx.ID_OK:
-            if self.jump_unlabeled:
-                self.dir = str(auxiliaryfunctions.find_next_unlabeled_folder(
-                    self.config_file
-                ))
-            else:
-                self.dir = dlg.GetPath()
-            self.load.Enable(False)
-            self.next.Enable(True)
-            self.save.Enable(True)
+        if self.jump_unlabeled:
+            self.dir = str(auxiliaryfunctions.find_next_unlabeled_folder(
+                self.config_file
+            ))
         else:
+            self.statusbar.SetStatusText("Looking for a folder to start labeling...")
+            cwd = os.path.join(os.getcwd(), "labeled-data")
+            dlg = wx.DirDialog(
+                self,
+                "Choose the directory where your extracted frames are saved:",
+                cwd,
+                style=wx.DD_DEFAULT_STYLE,
+            )
+            if dlg.ShowModal() != wx.ID_OK:
+                dlg.Destroy()
+                self.Close(True)
+                return
+            self.dir = dlg.GetPath()
             dlg.Destroy()
-            self.Close(True)
-            return
-        dlg.Destroy()
+
+        self.load.Enable(False)
+        self.next.Enable(True)
+        self.save.Enable(True)
 
         # Enabling the zoom, pan and home buttons
         self.zoom.Enable(True)

--- a/deeplabcut/gui/multiple_individuals_labeling_toolbox.py
+++ b/deeplabcut/gui/multiple_individuals_labeling_toolbox.py
@@ -283,11 +283,11 @@ class ScrollPanel(SP.ScrolledPanel):
 
 
 class MainFrame(BaseFrame):
-    def __init__(self, parent, config, config3d, sourceCam):
+    def __init__(self, parent, config, config3d, sourceCam, jump_unlabeled):
         super(MainFrame, self).__init__(
             "DeepLabCut 2.2 - Multiple Individuals Labeling", parent
         )
-
+        self.jump_unlabeled = jump_unlabeled
         self.statusbar.SetStatusText(
             "Looking for a folder to start labeling. Click 'Load frames' to begin."
         )
@@ -723,7 +723,12 @@ class MainFrame(BaseFrame):
             style=wx.DD_DEFAULT_STYLE,
         )
         if dlg.ShowModal() == wx.ID_OK:
-            self.dir = dlg.GetPath()
+            if self.jump_unlabeled:
+                self.dir = str(auxiliaryfunctions.find_next_unlabeled_folder(
+                    self.config_file
+                ))
+            else:
+                self.dir = dlg.GetPath()
             self.load.Enable(False)
             self.next.Enable(True)
             self.save.Enable(True)
@@ -1331,9 +1336,9 @@ class MainFrame(BaseFrame):
             self.change_marker_size.Enable(False)
 
 
-def show(config, config3d, sourceCam):
+def show(config, config3d, sourceCam, jump_unlabeled=False):
     app = wx.App()
-    frame = MainFrame(None, config, config3d, sourceCam).Show()
+    frame = MainFrame(None, config, config3d, sourceCam, jump_unlabeled).Show()
     app.MainLoop()
 
 

--- a/deeplabcut/gui/multiple_individuals_labeling_toolbox.py
+++ b/deeplabcut/gui/multiple_individuals_labeling_toolbox.py
@@ -714,29 +714,29 @@ class MainFrame(BaseFrame):
         """
         Show the DirDialog and ask the user to change the directory where machine labels are stored
         """
-        self.statusbar.SetStatusText("Looking for a folder to start labeling...")
-        cwd = os.path.join(os.getcwd(), "labeled-data")
-        dlg = wx.DirDialog(
-            self,
-            "Choose the directory where your extracted frames are saved:",
-            cwd,
-            style=wx.DD_DEFAULT_STYLE,
-        )
-        if dlg.ShowModal() == wx.ID_OK:
-            if self.jump_unlabeled:
-                self.dir = str(auxiliaryfunctions.find_next_unlabeled_folder(
-                    self.config_file
-                ))
-            else:
-                self.dir = dlg.GetPath()
-            self.load.Enable(False)
-            self.next.Enable(True)
-            self.save.Enable(True)
+        if self.jump_unlabeled:
+            self.dir = str(auxiliaryfunctions.find_next_unlabeled_folder(
+                self.config_file
+            ))
         else:
+            self.statusbar.SetStatusText("Looking for a folder to start labeling...")
+            cwd = os.path.join(os.getcwd(), "labeled-data")
+            dlg = wx.DirDialog(
+                self,
+                "Choose the directory where your extracted frames are saved:",
+                cwd,
+                style=wx.DD_DEFAULT_STYLE,
+            )
+            if dlg.ShowModal() != wx.ID_OK:
+                dlg.Destroy()
+                self.Close(True)
+                return
+            self.dir = dlg.GetPath()
             dlg.Destroy()
-            self.Close(True)
-            return
-        dlg.Destroy()
+
+        self.load.Enable(False)
+        self.next.Enable(True)
+        self.save.Enable(True)
 
         # Enabling the zoom, pan and home buttons
         self.zoom.Enable(True)

--- a/deeplabcut/gui/multiple_individuals_refinement_toolbox.py
+++ b/deeplabcut/gui/multiple_individuals_refinement_toolbox.py
@@ -140,10 +140,10 @@ class ScrollPanel(SP.ScrolledPanel):
 
 
 class MainFrame(BaseFrame):
-    def __init__(self, parent, config):
+    def __init__(self, parent, config, jump_unlabeled):
         super(MainFrame, self).__init__("DeepLabCut - Refinement ToolBox", parent)
         self.Bind(wx.EVT_CHAR_HOOK, self.OnKeyPressed)
-
+        self.jump_unlabeled = jump_unlabeled
         ###################################################################################################################################################
 
         # Spliting the frame into top and bottom panels. Bottom panels contains the widgets. The top panel is for showing images and plotting!
@@ -238,6 +238,7 @@ class MainFrame(BaseFrame):
         self.file = 0
         self.updatedCoords = []
         self.drs = []
+        self.config_file = config
         self.cfg = auxiliaryfunctions.read_config(config)
         self.humanscorer = self.cfg["scorer"]
         self.move2corner = self.cfg["move2corner"]
@@ -348,7 +349,12 @@ class MainFrame(BaseFrame):
 
         fname = str("machinelabels-iter" + str(self.iterationindex) + ".h5")
         self.statusbar.SetStatusText("Looking for a folder to start refining...")
-        cwd = os.path.join(os.getcwd(), "labeled-data")
+        if self.jump_unlabeled:
+            cwd = str(auxiliaryfunctions.find_next_unlabeled_folder(
+                self.config_file
+            ))
+        else:
+            cwd = os.path.join(os.getcwd(), "labeled-data")
         #        dlg = wx.FileDialog(self, "Choose the machinelabels file for current iteration.",cwd, "",wildcard=fname,style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST)
         if platform.system() == "Darwin":
             dlg = wx.FileDialog(
@@ -1167,9 +1173,9 @@ class MainFrame(BaseFrame):
         self.figure.canvas.draw()
 
 
-def show(config):
+def show(config, jump_unlabeled=False):
     app = wx.App()
-    frame = MainFrame(None, config).Show()
+    frame = MainFrame(None, config, jump_unlabeled).Show()
     app.MainLoop()
 
 

--- a/deeplabcut/gui/refine_labels.py
+++ b/deeplabcut/gui/refine_labels.py
@@ -21,7 +21,7 @@ from deeplabcut.utils import auxiliaryfunctions
 from pathlib import Path
 
 
-def refine_labels(config, multianimal=False):
+def refine_labels(config, multianimal=False, jump_unlabeled=False):
     """
     Refines the labels of the outlier frames extracted from the analyzed videos.\n Helps in augmenting the training dataset.
     Use the function ``analyze_video`` to analyze a video and extracts the outlier frames using the function
@@ -52,11 +52,11 @@ def refine_labels(config, multianimal=False):
     if not multianimal and not cfg.get("multianimalproject", False):
         from deeplabcut.gui import refinement
 
-        refinement.show(config)
+        refinement.show(config, jump_unlabeled)
     else:  # loading multianimal labeling GUI
         from deeplabcut.gui import multiple_individuals_refinement_toolbox
 
-        multiple_individuals_refinement_toolbox.show(config)
+        multiple_individuals_refinement_toolbox.show(config, jump_unlabeled)
 
     os.chdir(startpath)
 

--- a/deeplabcut/gui/refinement.py
+++ b/deeplabcut/gui/refinement.py
@@ -144,10 +144,10 @@ class ScrollPanel(SP.ScrolledPanel):
 
 
 class MainFrame(BaseFrame):
-    def __init__(self, parent, config):
+    def __init__(self, parent, config, jump_unlabeled):
         super(MainFrame, self).__init__("DeepLabCut2.0 - Refinement ToolBox", parent)
         self.Bind(wx.EVT_CHAR_HOOK, self.OnKeyPressed)
-
+        self.jump_unlabeled = jump_unlabeled
         ###################################################################################################################################################
 
         # Spliting the frame into top and bottom panels. Bottom panels contains the widgets. The top panel is for showing images and plotting!
@@ -243,6 +243,7 @@ class MainFrame(BaseFrame):
         self.updatedCoords = []
         self.dataFrame = None
         self.drs = []
+        self.config_file = config
         cfg = auxiliaryfunctions.read_config(config)
         self.humanscorer = cfg["scorer"]
         self.move2corner = cfg["move2corner"]
@@ -337,7 +338,12 @@ class MainFrame(BaseFrame):
 
         fname = str("machinelabels-iter" + str(self.iterationindex) + ".h5")
         self.statusbar.SetStatusText("Looking for a folder to start refining...")
-        cwd = os.path.join(os.getcwd(), "labeled-data")
+        if self.jump_unlabeled:
+            cwd = str(auxiliaryfunctions.find_next_unlabeled_folder(
+                self.config_file
+            ))
+        else:
+            cwd = os.path.join(os.getcwd(), "labeled-data")
         #        dlg = wx.FileDialog(self, "Choose the machinelabels file for current iteration.",cwd, "",wildcard=fname,style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST)
         platform.system()
         if platform.system() == "Darwin":
@@ -892,9 +898,9 @@ class MainFrame(BaseFrame):
         self.figure.canvas.draw()
 
 
-def show(config):
+def show(config, jump_unlabeled=False):
     app = wx.App()
-    frame = MainFrame(None, config).Show()
+    frame = MainFrame(None, config, jump_unlabeled).Show()
     app.MainLoop()
 
 

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -7,7 +7,7 @@ Please see AUTHORS for contributors.
 https://github.com/AlexEMG/DeepLabCut/blob/master/AUTHORS
 Licensed under GNU Lesser General Public License v3.0
 """
-from email.mime import base
+
 import os
 import typing
 import pickle


### PR DESCRIPTION
Although the feature will be nicely incorporated in the new GUI (that is, with a nice workspace dock widget), labeling/refinement GUIs can already now be set to automatically open the next unlabeled data folder upon passing `jump_unlabeled=True` to `deeplabcut.label_frames()` or `deeplabcut.refine_labels()`.
This is done by recursively identifying the h5 file most recently modified and selecting the folder coming next alphabetically.

Fixes #1221