### PR TITLE
Add test time image resizing

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -8,7 +8,7 @@ https://github.com/AlexEMG/DeepLabCut/blob/master/AUTHORS
 Licensed under GNU Lesser General Public License v3.0
 """
 
-
+import imgaug.augmenters as iaa
 import os
 import pickle
 from pathlib import Path
@@ -200,6 +200,12 @@ def evaluate_multianimal_full(
                     % (shuffle, trainFraction)
                 )
 
+            pipeline = iaa.Sequential(random_order=False)
+            pre_resize = dlc_cfg.get("pre_resize")
+            if pre_resize:
+                width, height = pre_resize
+                pipeline.add(iaa.Resize({"height": height, "width": width}))
+
             # TODO: IMPLEMENT for different batch sizes?
             dlc_cfg["batch_size"] = 1  # due to differently sized images!!!
 
@@ -315,6 +321,16 @@ def evaluate_multianimal_full(
                             GT = Data.iloc[imageindex]
                             if not GT.any():
                                 continue
+
+                            # Pass the image and the keypoints through the resizer;
+                            # this has no effect if no augmenters were added to it.
+                            keypoints = [GT.to_numpy().reshape((-1, 2)).astype(float)]
+                            frame_, keypoints = pipeline(
+                                images=[frame], keypoints=keypoints
+                            )
+                            frame = frame_[0]
+                            GT[:] = keypoints[0].flatten()
+
                             df = GT.unstack("coords").reindex(joints, level="bodyparts")
 
                             # FIXME Is having an empty array vs nan really that necessary?!

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_multianimal_imgaug.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_multianimal_imgaug.py
@@ -94,14 +94,16 @@ class MAImgaugPoseDataset(BasePoseDataset):
             width, height = pre_resize
             pipeline.add(iaa.Resize({"height": height, "width": width}))
 
-        # Add smart, keypoint-aware image cropping
-        w, h = self.default_crop_size
-        pipeline.add(iaa.PadToFixedSize(w, h))
-        pipeline.add(
-            augmentation.KeypointAwareCropToFixedSize(
-                w, h, cfg.get("max_shift", 0.4), cfg.get("crop_sampling", "hybrid")
+        crop_sampling = cfg.get("crop_sampling", "hybrid")
+        if crop_sampling != "none":
+            # Add smart, keypoint-aware image cropping
+            w, h = self.default_crop_size
+            pipeline.add(iaa.PadToFixedSize(w, h))
+            pipeline.add(
+                augmentation.KeypointAwareCropToFixedSize(
+                    w, h, cfg.get("max_shift", 0.4), crop_sampling,
+                )
             )
-        )
 
         if cfg.get("fliplr", False):
             opt = cfg.get("fliplr", False)

--- a/tests/test_pose_multianimal_imgaug.py
+++ b/tests/test_pose_multianimal_imgaug.py
@@ -69,7 +69,7 @@ def test_get_targetmaps(ma_dataset, num_idchannel):
     ma_dataset.cfg["num_idchannel"] = num_idchannel
     batch = ma_dataset.get_batch()[1:]
     target_size, sm_size = ma_dataset.calc_target_and_scoremap_sizes()
-    scale = np.mean(target_size / ma_dataset.default_crop_size)
+    scale = np.mean(target_size / ma_dataset.default_size)
     maps = ma_dataset.get_targetmaps_update(*batch, sm_size, scale)
     assert all(len(map_) == ma_dataset.batch_size for map_ in maps.values())
     assert (


### PR DESCRIPTION
Image pre-resizing can now be differentially set in the train & test pose configs. 
Note that keypoint-aware cropping can be disabled with `crop_sampling: none` in the train/pose_cfg.yaml.