### PR TITLE
Exit while loop prematurely if not finding valid image sizes

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
@@ -285,12 +285,23 @@ class ImgaugPoseDataset(BasePoseDataset):
         data_items = []
         # Scale is sampled only once to transform all of the images of a batch into same size.
         scale = self.sample_scale()
-        while True:
+
+        found_valid = False
+        n_tries = 5
+        while n_tries > 1:
             idx = np.random.choice(self.num_images)
             size = self.data[idx].im_size
             target_size = np.ceil(size[1:3] * scale).astype(int)
             if self.is_valid_size(target_size[1] * target_size[0]):
+                found_valid = True
                 break
+            n_tries -= 1
+        if not found_valid:
+            raise ValueError(
+                f"Image size {size[1:3]} may be too large. "
+                "Consider increasing `max_input_size` and/or decreasing `global_scale` "
+                "in the train/pose_cfg.yaml."
+            )
 
         stride = self.cfg["stride"]
         for i in range(self.batch_size):

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
@@ -287,7 +287,7 @@ class ImgaugPoseDataset(BasePoseDataset):
         scale = self.sample_scale()
 
         found_valid = False
-        n_tries = 5
+        n_tries = 10 
         while n_tries > 1:
             idx = np.random.choice(self.num_images)
             size = self.data[idx].im_size

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
@@ -297,9 +297,13 @@ class ImgaugPoseDataset(BasePoseDataset):
                 break
             n_tries -= 1
         if not found_valid:
+            if size[1] * size[2] > self.max_input_sizesquare:
+                s = "large", "increasing `max_input_size`", "decreasing"
+            else:
+                s = "small", "decreasing `min_input_size`", "increasing"
             raise ValueError(
-                f"Image size {size[1:3]} may be too large. "
-                "Consider increasing `max_input_size` and/or decreasing `global_scale` "
+                f"Image size {size[1:3]} may be too {s[0]}. "
+                f"Consider {s[1]} and/or {s[2]} `global_scale` "
                 "in the train/pose_cfg.yaml."
             )
 


### PR DESCRIPTION
In single-animal projects, I realized that one could remain endlessly in the while loop [here](https://github.com/DeepLabCut/DeepLabCut/blob/e24bf034cd6b72109f63e738d6de4ec9528d1f76/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py#L288-L293)  in case no single image fits within `min_input_size` and `max_input_size`, explaining why training never actually starts.
Now an informative error message is raised after 5 unsuccessful tries, inviting the user to edit `global_scale` or `max_input_size`/`min_input_size` accordingly.

Fixes #1725