### PR TITLE
[WIP] Cap number of frames to maximum frames in video

### DIFF
--- a/deeplabcut/generate_training_dataset/frame_extraction.py
+++ b/deeplabcut/generate_training_dataset/frame_extraction.py
@@ -253,6 +253,7 @@ def extract_frames(
                 if not nframes:
                     print("Video could not be opened. Skipping...")
                     continue
+                numframes2pick = max(cfg["numframes2pick"], nframes)
 
                 indexlength = int(np.ceil(np.log10(nframes)))
 


### PR DESCRIPTION
This line allows for either the kmeans or uniform method to sample the maximum possible number of frames without error

i.e. if I specify 100,000 frames in a 20 frame video, uniform sampling would error out and kmeans would take a long time to cluster and sample the same 20 frames over and over again. This parameter helps stop that.
This is also a way to sample all of the frames in a video (i.e. by setting the number of frames to pick as 999,999 or something)  