### PR TITLE
Address an off by one error in the TQDM progress bar in the predict steps

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -446,7 +446,7 @@ def GetPoseF(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes, batchsize):
     step = max(10, int(nframes / 100))
     inds = []
     while cap.isOpened():
-        if counter % step == 0:
+        if counter != 0 and counter % step == 0:
             pbar.update(step)
         ret, frame = cap.read()
         if ret:
@@ -491,7 +491,7 @@ def GetPoseS(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes):
     counter = 0
     step = max(10, int(nframes / 100))
     while cap.isOpened():
-        if counter % step == 0:
+        if counter != 0 and counter % step == 0:
             pbar.update(step)
 
         ret, frame = cap.read()
@@ -530,7 +530,7 @@ def GetPoseS_GTF(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes):
     counter = 0
     step = max(10, int(nframes / 100))
     while cap.isOpened():
-        if counter % step == 0:
+        if counter != 0 and counter % step == 0:
             pbar.update(step)
 
         ret, frame = cap.read()
@@ -582,7 +582,7 @@ def GetPoseF_GTF(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes, batchsize):
     step = max(10, int(nframes / 100))
     inds = []
     while cap.isOpened():
-        if counter % step == 0:
+        if counter != 0 and counter % step == 0:
             pbar.update(step)
         ret, frame = cap.read()
         if ret:
@@ -648,7 +648,7 @@ def GetPoseDynamic(
     counter = 0
     step = max(10, int(nframes / 100))
     while cap.isOpened():
-        if counter % step == 0:
+        if counter != 0 and counter % step == 0:
             pbar.update(step)
 
         ret, frame = cap.read()
@@ -896,7 +896,7 @@ def GetPosesofFrames(
         for counter, framename in enumerate(framelist):
             im = imread(os.path.join(directory, framename), mode="skimage")
 
-            if counter % step == 0:
+            if counter != 0 and counter % step == 0:
                 pbar.update(step)
 
             if cfg["cropping"]:
@@ -915,7 +915,7 @@ def GetPosesofFrames(
         for counter, framename in enumerate(framelist):
             im = imread(os.path.join(directory, framename), mode="skimage")
 
-            if counter % step == 0:
+            if counter != 0 and counter % step == 0:
                 pbar.update(step)
 
             if cfg["cropping"]:


### PR DESCRIPTION
I've been a little obsessed with getting progress bars for our workflows.

I noticed an off by 1 error in the `predict_video` step.

For my 900 frame video, the tqdm progress bar increases incrementally up to 900, then at the "900th" frame, the progress bar shows that it is analyzing the 910th frame (step size is 10 according to `GetPoseF_GTF`.

![image](https://user-images.githubusercontent.com/90008/160424237-900c14ee-afca-4ea4-91cc-79b0a9ddb8de.png)

I believe this is because `tqdm` expects you to call update AFTER the step has been completed. The following "1 liner fix" address the progress bar issue.

I hope this helps.
