### PR TITLE
Match order of individuals in DataFrames accross views

### DIFF
--- a/deeplabcut/utils/auxfun_multianimal.py
+++ b/deeplabcut/utils/auxfun_multianimal.py
@@ -25,6 +25,29 @@ from deeplabcut.utils import auxiliaryfunctions, conversioncode
 from deeplabcut.generate_training_dataset import trainingsetmanipulation
 from deeplabcut.pose_estimation_tensorflow.lib.trackingutils import TRACK_METHODS
 
+def reorder_individuals_in_df(df: pd.DataFrame, order: list) -> pd.DataFrame:
+    """
+    Reorders data of df to match the order given in a list 
+
+    Parameters:
+    ----------
+    df: pd.DataFrame
+        Data from tracked .h5 file
+    order: list of str
+        Desired order of individuals 
+
+    Return:
+    -------
+        df: pd.DataFrame
+            Reordered DataFrame
+    """
+    columns = df.columns
+    inds = df.index
+
+    data = df.loc(axis=1)[:, order].to_numpy()
+    df = pd.DataFrame(data, columns=columns, index=inds)
+
+    return df
 
 def extractindividualsandbodyparts(cfg):
     individuals = cfg["individuals"].copy()

--- a/deeplabcut/utils/auxiliaryfunctions_3d.py
+++ b/deeplabcut/utils/auxiliaryfunctions_3d.py
@@ -279,7 +279,7 @@ def _reconstruct_tracks_as_tracklets(df):
 
     tracklets = []
     for _, group in df.groupby("individuals", axis=1):
-        temp = group.dropna()
+        temp = group.dropna(how="all")
         inds = temp.index.to_numpy()
         track = Tracklet(temp.to_numpy().reshape((len(temp), -1, 3)), inds)
         track = track.interpolate(max_gap=len(group))
@@ -314,7 +314,7 @@ def _associate_paired_view_tracks(tracklets1, tracklets2, F):
 
             # cost for any point in time of t1 being the same
             # any point in time of t2
-            cost = np.abs(np.sum(np.matmul(_t1, F) * _t2, axis=2))
+            cost = np.abs(np.nansum(np.matmul(_t1, F) * _t2, axis=2))
             
             # Get average cost of the entire track
             cost = cost.mean()

--- a/tests/test_auxfun_multianimal.py
+++ b/tests/test_auxfun_multianimal.py
@@ -1,5 +1,6 @@
 import networkx as nx
 import numpy as np
+import pandas as pd
 import pytest
 from deeplabcut.utils import auxfun_multianimal
 from itertools import combinations
@@ -22,3 +23,30 @@ def test_prune_paf_graph():
         )
         G = nx.Graph(pruned_edges)
         assert np.mean(list(dict(G.degree).values())) == degree
+
+
+def test_reorder_individuals_in_df():
+    import random
+
+    # Load sample multi animal data
+    df = pd.read_hdf("tests/data/montblanc_tracks.h5")
+    individuals = df.columns.get_level_values("individuals").unique().to_list()
+
+    # Generate a random permutation and reorder data
+    permutation_indices = random.sample(
+        range(len(individuals)), 
+        k=len(individuals)
+    )
+    permutation = [individuals[i] for i in permutation_indices]
+    df_reordered = auxfun_multianimal.reorder_individuals_in_df(df, permutation)
+
+    # Get inverse permutation and reorder the modified data to get back
+    # to the original
+    inverse_permutation_indices = np.argsort(permutation_indices).tolist()
+    inverse_permutation = [individuals[i] for i in inverse_permutation_indices]
+    df_inverse_reordering = auxfun_multianimal.reorder_individuals_in_df(
+        df_reordered, inverse_permutation
+    )
+
+    # Check
+    pd.testing.assert_frame_equal(df, df_inverse_reordering)


### PR DESCRIPTION
- Makes sure that the order of individuals in the DataFrame of view1 is kept in view2 (applies the matching)
- Minor fixes