### PR TITLE
Fix TypeError when refining outliers

### DIFF
--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -24,6 +24,7 @@ from deeplabcut.pose_estimation_tensorflow.lib import inferenceutils
 from deeplabcut.utils import (
     auxiliaryfunctions,
     auxfun_multianimal,
+    conversioncode,
     visualization,
     frameselectiontools,
 )
@@ -692,23 +693,15 @@ def ExtractFramesbasedonPreselection(
             )
             if isinstance(data, pd.DataFrame):
                 df = data.loc[frames2pick]
-                df.index = [
-                    os.path.join(
-                        "labeled-data",
-                        vname,
-                        "img" + str(index).zfill(strwidth) + ".png",
-                    )
+                df.index = pd.MultiIndex.from_tuples([
+                    ("labeled-data", vname, "img" + str(index).zfill(strwidth) + ".png")
                     for index in df.index
-                ]  # exchange index number by file names.
+                ])  # exchange index number by file names.
             elif isinstance(data, dict):
-                idx = [
-                    os.path.join(
-                        "labeled-data",
-                        vname,
-                        "img" + str(index).zfill(strwidth) + ".png",
-                    )
+                idx = pd.MultiIndex.from_tuples([
+                    ("labeled-data", vname, "img" + str(index).zfill(strwidth) + ".png")
                     for index in frames2pick
-                ]
+                ])
                 filename = os.path.join(
                     str(tmpfolder), f"CollectedData_{cfg['scorer']}.h5"
                 )
@@ -753,6 +746,7 @@ def ExtractFramesbasedonPreselection(
                 return
             if Path(machinefile).is_file():
                 Data = pd.read_hdf(machinefile, "df_with_missing")
+                conversioncode.guarantee_multiindex_rows(Data)
                 DataCombined = pd.concat([Data, df])
                 # drop duplicate labels:
                 DataCombined = DataCombined[

--- a/examples/testscript.py
+++ b/examples/testscript.py
@@ -265,8 +265,6 @@ if __name__ == "__main__":
             "CollectedData_" + scorer + ".h5",
         ),
         "df_with_missing",
-        format="table",
-        mode="w",
     )
 
     print("MERGING")

--- a/examples/testscript_multianimal.py
+++ b/examples/testscript_multianimal.py
@@ -247,14 +247,14 @@ if __name__ == "__main__":
     print("RELABELING")
     DF = pd.read_hdf(file, "df_with_missing")
     DLCscorer = np.unique(DF.columns.get_level_values(0))[0]
-    DF.columns.set_levels([scorer.replace(DLCscorer, scorer)], level=0, inplace=True)
+    DF.columns.set_levels([scorer.replace(DLCscorer, SCORER)], level=0, inplace=True)
     DF = DF.drop("likelihood", axis=1, level=3)
     DF.to_csv(
         os.path.join(
             cfg["project_path"],
             "labeled-data",
             vname,
-            "CollectedData_" + scorer + ".csv",
+            "CollectedData_" + SCORER + ".csv",
         )
     )
     DF.to_hdf(
@@ -262,11 +262,9 @@ if __name__ == "__main__":
             cfg["project_path"],
             "labeled-data",
             vname,
-            "CollectedData_" + scorer + ".h5",
+            "CollectedData_" + SCORER + ".h5",
         ),
         "df_with_missing",
-        format="table",
-        mode="w",
     )
 
     print("MERGING")


### PR DESCRIPTION
Machine labels are now guaranteed to have hierarchical indices, avoiding mixed-format indices when concatenated with GT annotations. 

Fixes #1743 #1673