### PR TITLE
Improved behavior of get_list_of_videos

### DIFF
--- a/deeplabcut/create_project/modelzoo.py
+++ b/deeplabcut/create_project/modelzoo.py
@@ -68,7 +68,7 @@ def create_pretrained_human_project(
     videos,
     working_directory=None,
     copy_videos=False,
-    videotype=".mp4",
+    videotype="",
     createlabeledvideo=True,
     analyzevideo=True,
 ):
@@ -106,7 +106,7 @@ def create_pretrained_project(
     model="full_human",
     working_directory=None,
     copy_videos=False,
-    videotype=None,
+    videotype="",
     analyzevideo=True,
     filtered=True,
     createlabeledvideo=True,

--- a/deeplabcut/create_project/new.py
+++ b/deeplabcut/create_project/new.py
@@ -22,7 +22,7 @@ def create_new_project(
     videos,
     working_directory=None,
     copy_videos=False,
-    videotype=".avi",
+    videotype="",
     multianimal=False,
 ):
     """Creates a new project directory, sub-directories and a basic configuration file. The configuration file is loaded with the default values. Change its parameters to your projects need.
@@ -107,7 +107,7 @@ def create_new_project(
         # Check if it is a folder
         if os.path.isdir(i):
             vids_in_dir = [
-                os.path.join(i, vp) for vp in os.listdir(i) if videotype in vp
+                os.path.join(i, vp) for vp in os.listdir(i) if vp.endswith(videotype)
             ]
             vids = vids + vids_in_dir
             if len(vids_in_dir) == 0:

--- a/deeplabcut/gui/analyze_videos.py
+++ b/deeplabcut/gui/analyze_videos.py
@@ -19,6 +19,7 @@ import webbrowser
 import deeplabcut
 import wx
 from deeplabcut.utils import auxiliaryfunctions
+from deeplabcut.utils.auxfun_videos import SUPPORTED_VIDEOS
 from deeplabcut.gui import LOGO_PATH
 
 
@@ -106,9 +107,8 @@ class Analyze_videos(wx.Panel):
         videotype_text = wx.StaticBox(self, label="Specify the videotype")
         videotype_text_boxsizer = wx.StaticBoxSizer(videotype_text, wx.VERTICAL)
 
-        videotypes = [".avi", ".mp4", ".mov"]
-        self.videotype = wx.ComboBox(self, choices=videotypes, style=wx.CB_READONLY)
-        self.videotype.SetValue(".avi")
+        self.videotype = wx.ComboBox(self, choices=("",) + SUPPORTED_VIDEOS, style=wx.CB_READONLY)
+        self.videotype.SetValue("")
         videotype_text_boxsizer.Add(
             self.videotype, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1
         )
@@ -585,7 +585,6 @@ class Analyze_videos(wx.Panel):
             # self.select_destfolder.SetPath("None")
         #self.config = []
         #self.sel_config.SetPath("")
-        #self.videotype.SetStringSelection(".avi")
         self.sel_vids.SetLabel("Select videos to analyze")
         self.filelist = []
         self.shuffle.SetValue(1)

--- a/deeplabcut/gui/create_videos.py
+++ b/deeplabcut/gui/create_videos.py
@@ -19,6 +19,7 @@ import deeplabcut
 
 from deeplabcut.gui import LOGO_PATH
 from deeplabcut.utils import auxiliaryfunctions, skeleton, auxfun_multianimal
+from deeplabcut.utils.auxfun_videos import SUPPORTED_VIDEOS
 
 
 class Create_Labeled_Videos(wx.Panel):
@@ -94,9 +95,8 @@ class Create_Labeled_Videos(wx.Panel):
         videotype_text = wx.StaticBox(self, label="Specify the videotype")
         videotype_text_boxsizer = wx.StaticBoxSizer(videotype_text, wx.VERTICAL)
 
-        videotypes = [".avi", ".mp4", ".mov"]
-        self.videotype = wx.ComboBox(self, choices=videotypes, style=wx.CB_READONLY)
-        self.videotype.SetValue(".avi")
+        self.videotype = wx.ComboBox(self, choices=("",) + SUPPORTED_VIDEOS, style=wx.CB_READONLY)
+        self.videotype.SetValue("")
         videotype_text_boxsizer.Add(
             self.videotype, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1
         )
@@ -388,7 +388,7 @@ class Create_Labeled_Videos(wx.Panel):
         """
         self.config = []
         self.sel_config.SetPath("")
-        self.videotype.SetStringSelection(".avi")
+        self.videotype.SetStringSelection("")
         self.sel_vids.SetLabel("Select videos")
         self.filelist = []
         self.shuffle.SetValue(1)

--- a/deeplabcut/gui/extract_outlier_frames.py
+++ b/deeplabcut/gui/extract_outlier_frames.py
@@ -17,6 +17,7 @@ import wx
 
 import deeplabcut
 from deeplabcut import utils
+from deeplabcut.utils.auxfun_videos import SUPPORTED_VIDEOS
 
 from deeplabcut.gui import LOGO_PATH
 
@@ -89,9 +90,8 @@ class Extract_outlier_frames(wx.Panel):
 
         videotype_text = wx.StaticBox(self, label="Specify the videotype")
         videotype_text_boxsizer = wx.StaticBoxSizer(videotype_text, wx.VERTICAL)
-        videotypes = [".avi", ".mp4", ".mov"]
-        self.videotype = wx.ComboBox(self, choices=videotypes, style=wx.CB_READONLY)
-        self.videotype.SetValue(".avi")
+        self.videotype = wx.ComboBox(self, choices=("",) + SUPPORTED_VIDEOS, style=wx.CB_READONLY)
+        self.videotype.SetValue("")
         videotype_text_boxsizer.Add(
             self.videotype, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1
         )
@@ -201,7 +201,7 @@ class Extract_outlier_frames(wx.Panel):
         """
         self.config = []
         self.sel_config.SetPath("")
-        self.videotype.SetValue(".avi")
+        self.videotype.SetValue("")
         self.algotype.SetValue("jump")
         self.sel_vids.SetLabel("Select videos to analyze")
         self.SetSizer(self.sizer)

--- a/deeplabcut/gui/refine_tracklets.py
+++ b/deeplabcut/gui/refine_tracklets.py
@@ -17,6 +17,7 @@ import wx
 
 import deeplabcut
 from deeplabcut.utils import auxiliaryfunctions
+from deeplabcut.utils.auxfun_videos import SUPPORTED_VIDEOS
 
 from deeplabcut.gui import LOGO_PATH
 from pathlib import Path
@@ -96,9 +97,8 @@ class Refine_tracklets(wx.Panel):
         hbox_ = wx.BoxSizer(wx.HORIZONTAL)
         videotype_text = wx.StaticBox(self, label="Specify the videotype")
         videotype_text_boxsizer = wx.StaticBoxSizer(videotype_text, wx.VERTICAL)
-        videotypes = [".avi", ".mp4", ".mov"]
-        self.videotype = wx.ComboBox(self, choices=videotypes, style=wx.CB_READONLY)
-        self.videotype.SetValue(".avi")
+        self.videotype = wx.ComboBox(self, choices=("",) + SUPPORTED_VIDEOS, style=wx.CB_READONLY)
+        self.videotype.SetValue("")
         videotype_text_boxsizer.Add(
             self.videotype, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 10
         )

--- a/deeplabcut/gui/transformerID.py
+++ b/deeplabcut/gui/transformerID.py
@@ -19,6 +19,7 @@ import deeplabcut
 from deeplabcut import utils
 
 from deeplabcut.gui import LOGO_PATH
+from deeplabcut.utils.auxfun_videos import SUPPORTED_VIDEOS
 
 
 class TransformerID(wx.Panel):
@@ -90,9 +91,8 @@ class TransformerID(wx.Panel):
 
         videotype_text = wx.StaticBox(self, label="Specify the videotype")
         videotype_text_boxsizer = wx.StaticBoxSizer(videotype_text, wx.VERTICAL)
-        videotypes = [".avi", ".mp4", ".mov"]
-        self.videotype = wx.ComboBox(self, choices=videotypes, style=wx.CB_READONLY)
-        self.videotype.SetValue(".avi")
+        self.videotype = wx.ComboBox(self, choices=("",) + SUPPORTED_VIDEOS, style=wx.CB_READONLY)
+        self.videotype.SetValue("")
         videotype_text_boxsizer.Add(self.videotype, 1, wx.EXPAND | wx.TOP | wx.BOTTOM, 1)
 
         shuffles_text = wx.StaticBox(self, label="Specify the shuffle")
@@ -207,7 +207,7 @@ class TransformerID(wx.Panel):
         """
         self.config = []
         self.sel_config.SetPath("")
-        self.videotype.SetValue(".avi")
+        self.videotype.SetValue("")
         self.sel_vids.SetLabel("Select videos to analyze")
         self.SetSizer(self.sizer)
         self.sizer.Fit(self)

--- a/deeplabcut/gui/video_editing.py
+++ b/deeplabcut/gui/video_editing.py
@@ -250,7 +250,6 @@ class Video_Editing(wx.Panel):
         """
         self.config = []
         self.sel_config.SetPath("")
-        # self.videotype.SetStringSelection(".avi")
         self.sel_vids.SetLabel("Select videos")
         self.filelist = []
         self.rotate.SetSelection(1)

--- a/deeplabcut/pose_estimation_3d/plotting3D.py
+++ b/deeplabcut/pose_estimation_3d/plotting3D.py
@@ -60,7 +60,7 @@ def create_labeled_video_3d(
     start=0,
     end=None,
     trailpoints=0,
-    videotype="avi",
+    videotype="",
     view=(-113, -270),
     xlim=None,
     ylim=None,
@@ -95,7 +95,8 @@ def create_labeled_video_3d(
         Number of revious frames whose body parts are plotted in a frame (for displaying history). Default is set to 0.
 
     videotype: string, optional
-        Checks for the extension of the video in case the input is a directory.\nOnly videos with this extension are analyzed. The default is ``.avi``
+        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed.
+        If left unspecified, videos with common extensions ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
 
     view: list
         A list that sets the elevation angle in z plane and azimuthal angle in x,y plane of 3d view. Useful for rotating the axis for 3d view

--- a/deeplabcut/pose_estimation_3d/triangulation.py
+++ b/deeplabcut/pose_estimation_3d/triangulation.py
@@ -27,7 +27,7 @@ matplotlib_axes_logger.setLevel("ERROR")
 def triangulate(
     config,
     video_path,
-    videotype="avi",
+    videotype="",
     filterpredictions=True,
     filtertype="median",
     gputouse=None,
@@ -50,8 +50,9 @@ def triangulate(
         i.e. [['video1-camera-1.avi','video1-camera-2.avi']]
 
     videotype: string, optional
-        Checks for the extension of the video in case the input to the video is a directory.\n
-        Only videos with this extension are analyzed. The default is ``.avi``
+        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed.
+        If left unspecified, videos with common extensions ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
+
 
     filterpredictions: Bool, optional
         Filter the predictions with filter specified by "filtertype". If specified it

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -50,7 +50,7 @@ def create_tracking_dataset(
     config,
     videos,
     track_method,
-    videotype="avi",
+    videotype="",
     shuffle=1,
     trainingsetindex=0,
     gputouse=None,
@@ -262,7 +262,7 @@ def create_tracking_dataset(
 def analyze_videos(
     config,
     videos,
-    videotype="avi",
+    videotype="",
     shuffle=1,
     trainingsetindex=0,
     gputouse=None,
@@ -299,7 +299,8 @@ def analyze_videos(
         A list of strings containing the full paths to videos for analysis or a path to the directory, where all the videos with same extension are stored.
 
     videotype: string, optional
-        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed. The default is ``.avi``
+        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed.
+        If left unspecified, videos with common extensions ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
 
     shuffle: int, optional
         An integer specifying the shuffle index of the training dataset used for training the network. The default is 1.
@@ -1480,7 +1481,7 @@ def _convert_detections_to_tracklets(
 def convert_detections2tracklets(
     config,
     videos,
-    videotype="avi",
+    videotype="",
     shuffle=1,
     trainingsetindex=0,
     overwrite=False,
@@ -1506,7 +1507,8 @@ def convert_detections2tracklets(
         A list of strings containing the full paths to videos for analysis or a path to the directory, where all the videos with same extension are stored.
 
     videotype: string, optional
-        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed. The default is ``.avi``
+        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed.
+        If left unspecified, videos with common extensions ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
 
     shuffle: int, optional
         An integer specifying the shuffle index of the training dataset used for training the network. The default is 1.

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -213,7 +213,7 @@ def create_tracking_dataset(
     ##################################################
     # Looping over videos
     ##################################################
-    Videos = auxiliaryfunctions.Getlistofvideos(videos, videotype)
+    Videos = auxiliaryfunctions.get_list_of_videos(videos, videotype)
     if len(Videos) > 0:
         if "multi-animal" in dlc_cfg["dataset_type"]:
             for video in Videos:
@@ -544,7 +544,7 @@ def analyze_videos(
     ##################################################
     # Looping over videos
     ##################################################
-    Videos = auxiliaryfunctions.Getlistofvideos(videos, videotype)
+    Videos = auxiliaryfunctions.get_list_of_videos(videos, videotype)
     if len(Videos) > 0:
         if "multi-animal" in dlc_cfg["dataset_type"]:
             from deeplabcut.pose_estimation_tensorflow.predict_multianimal import (
@@ -1657,7 +1657,7 @@ def convert_detections2tracklets(
     ##################################################
     # Looping over videos
     ##################################################
-    Videos = auxiliaryfunctions.Getlistofvideos(videos, videotype)
+    Videos = auxiliaryfunctions.get_list_of_videos(videos, videotype)
     if len(Videos) > 0:
         for video in Videos:
             print("Processing... ", video)

--- a/deeplabcut/pose_tracking_pytorch/apis.py
+++ b/deeplabcut/pose_tracking_pytorch/apis.py
@@ -12,7 +12,7 @@ Licensed under GNU Lesser General Public License v3.0
 def transformer_reID(
     config,
     videos,
-    videotype=".mp4",
+    videotype="",
     shuffle=1,
     trainingsetindex=0,
     track_method="ellipse",
@@ -43,8 +43,9 @@ def transformer_reID(
     videos: list
         A list of strings containing the full paths to videos for analysis or a path to the directory, where all the videos with same extension are stored.
 
-    videotype: (optional) str
-        extension for the video file
+    videotype: string, optional
+        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed.
+        If left unspecified, videos with common extensions ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
 
     shuffle : int, optional
         which shuffle to use

--- a/deeplabcut/pose_tracking_pytorch/train_dlctransreid.py
+++ b/deeplabcut/pose_tracking_pytorch/train_dlctransreid.py
@@ -12,6 +12,7 @@ import torch
 import numpy as np
 import os
 import glob
+from deeplabcut.utils import auxiliaryfunctions
 from pathlib import Path
 from .config import cfg
 from .datasets import make_dlc_dataloader
@@ -61,7 +62,7 @@ def train_tracking_transformer(
     path_config_file,
     dlcscorer,
     videos,
-    videotype="avi",
+    videotype="",
     train_frac=0.8,
     modelprefix="",
     train_epochs=100,
@@ -69,7 +70,7 @@ def train_tracking_transformer(
     ckpt_folder="",
 ):
     npy_list = []
-    #TODO: use Videos = auxiliaryfunctions.Getlistofvideos(videos, videotype)
+    videos = auxiliaryfunctions.get_list_of_videos(videos, videotype)
     for video in videos:
         videofolder = str(Path(video).parents[0])
         video_name = Path(video).stem

--- a/deeplabcut/post_processing/analyze_skeleton.py
+++ b/deeplabcut/post_processing/analyze_skeleton.py
@@ -224,7 +224,7 @@ def analyzeskeleton(
         modelprefix=modelprefix,
     )
 
-    Videos = auxiliaryfunctions.Getlistofvideos(videos, videotype)
+    Videos = auxiliaryfunctions.get_list_of_videos(videos, videotype)
     for video in Videos:
         print("Processing %s" % (video))
         if destfolder is None:

--- a/deeplabcut/post_processing/analyze_skeleton.py
+++ b/deeplabcut/post_processing/analyze_skeleton.py
@@ -169,7 +169,7 @@ def analyzebone(bp1, bp2):
 def analyzeskeleton(
     config,
     videos,
-    videotype="avi",
+    videotype="",
     shuffle=1,
     trainingsetindex=0,
     filtered=False,

--- a/deeplabcut/post_processing/filtering.py
+++ b/deeplabcut/post_processing/filtering.py
@@ -67,7 +67,7 @@ def columnwise_spline_interp(data, max_gap=0):
 def filterpredictions(
     config,
     video,
-    videotype="avi",
+    videotype="",
     shuffle=1,
     trainingsetindex=0,
     filtertype="median",

--- a/deeplabcut/post_processing/filtering.py
+++ b/deeplabcut/post_processing/filtering.py
@@ -160,7 +160,7 @@ def filterpredictions(
         trainFraction=cfg["TrainingFraction"][trainingsetindex],
         modelprefix=modelprefix,
     )
-    Videos = auxiliaryfunctions.Getlistofvideos(video, videotype)
+    Videos = auxiliaryfunctions.get_list_of_videos(video, videotype)
 
     if not len(Videos):
         print("No video(s) were found. Please check your paths and/or 'videotype'.")

--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -303,7 +303,7 @@ def extract_outlier_frames(
         modelprefix=modelprefix,
     )
 
-    Videos = auxiliaryfunctions.Getlistofvideos(videos, videotype)
+    Videos = auxiliaryfunctions.get_list_of_videos(videos, videotype)
     if len(Videos) == 0:
         print("No suitable videos found in", videos)
 

--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -169,7 +169,7 @@ def find_outliers_in_raw_detections(
 def extract_outlier_frames(
     config,
     videos,
-    videotype=".avi",
+    videotype="",
     shuffle=1,
     trainingsetindex=0,
     outlieralgorithm="jump",
@@ -204,7 +204,8 @@ def extract_outlier_frames(
         A list of strings containing the full paths to videos for analysis or a path to the directory, where all the videos with same extension are stored.
 
     videotype: string, optional
-        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed. The default is ``.avi``
+        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed.
+        If left unspecified, videos with common extensions ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
 
     shuffle : int, optional
         The shuffle index of training dataset. The extracted frames will be stored in the labeled-dataset for

--- a/deeplabcut/refine_training_dataset/stitch.py
+++ b/deeplabcut/refine_training_dataset/stitch.py
@@ -986,7 +986,7 @@ class TrackletStitcher:
 def stitch_tracklets(
     config_path,
     videos,
-    videotype="avi",
+    videotype="",
     shuffle=1,
     trainingsetindex=0,
     n_tracks=None,
@@ -1014,7 +1014,8 @@ def stitch_tracklets(
         A list of strings containing the full paths to videos for analysis or a path to the directory, where all the videos with same extension are stored.
 
     videotype: string, optional
-        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed. The default is ``.avi``
+        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed.
+        If left unspecified, videos with common extensions ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
 
     shuffle: int, optional
         An integer specifying the shuffle index of the training dataset used for training the network. The default is 1.

--- a/deeplabcut/refine_training_dataset/stitch.py
+++ b/deeplabcut/refine_training_dataset/stitch.py
@@ -1081,7 +1081,7 @@ def stitch_tracklets(
     -------
     A TrackletStitcher object
     """
-    vids = deeplabcut.utils.auxiliaryfunctions.Getlistofvideos(videos, videotype)
+    vids = deeplabcut.utils.auxiliaryfunctions.get_list_of_videos(videos, videotype)
     if not vids:
         print("No video(s) found. Please check your path!")
         return

--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -20,7 +20,9 @@ import subprocess
 import warnings
 
 
-SUPPORTED_VIDEOS = 'avi', 'mp4', 'mov', 'mpeg', 'mkv'
+# more videos are in principle covered, as OpenCV is used and allows many formats.
+SUPPORTED_VIDEOS = 'avi', 'mp4', 'mov', 'mpeg', 'mpg', 'mpv', 'mkv', 'flv', 'qt', 'yuv'
+
 
 
 class VideoReader:

--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -9,9 +9,6 @@ https://github.com/AlexEMG/DeepLabCut/blob/master/AUTHORS
 Licensed under GNU Lesser General Public License v3.0
 """
 
-#from deeplabcut.utils.auxfun_videos import imread
-#auxfun_videos.imread(image_path, mode="skimage")
-
 import skimage.color
 from skimage import io
 from skimage.util import img_as_ubyte
@@ -20,8 +17,11 @@ import datetime
 import numpy as np
 import os
 import subprocess
-import warnings                        
-                            
+import warnings
+
+
+SUPPORTED_VIDEOS = 'avi', 'mp4', 'mov', 'mpeg', 'mkv'
+
 
 class VideoReader:
     def __init__(self, video_path):
@@ -353,7 +353,7 @@ def check_video_integrity(video_path):
     vid.check_integrity_robust()
 
 def imread(image_path, mode="skimage"):
-    ''' Read image either with skimage or cv2. 
+    ''' Read image either with skimage or cv2.
     Returns frame in uint with 3 color channels. '''
     if mode == "skimage":
         image = io.imread(image_path)
@@ -363,7 +363,7 @@ def imread(image_path, mode="skimage"):
             image = skimage.color.rgba2rgb(image)
 
         return img_as_ubyte(image)
-    
+
     elif mode=="cv2":
         return cv2.imread(image_path, cv2.IMREAD_UNCHANGED)[..., ::-1]  # ~10% faster than using cv2.cvtColor
 

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -19,6 +19,7 @@ import ruamel.yaml.representer
 import yaml
 from ruamel.yaml import YAML
 from deeplabcut.pose_estimation_tensorflow.lib.trackingutils import TRACK_METHODS
+from deeplabcut.utils import auxfun_videos
 
 
 def create_config_template(multianimal=False):
@@ -321,7 +322,7 @@ def write_pickle(filename, data):
 
 def get_list_of_videos(
     videos: typing.Union[typing.List[str], str],
-    videotype: typing.Optional[str] = None
+    videotype: typing.Union[typing.List[str], str] = ""
 ) -> typing.List[str]:
     """ Returns list of videos of videotype "videotype" in
     folder videos or for list of videos.
@@ -334,19 +335,19 @@ def get_list_of_videos(
     Args:
         videos (list[str], str): List of video paths or a single path string. If string (or len() == 1 list of strings) is a directory,
             finds all videos whose extension matches  ``videotype`` in the directory
-        videotype (None, str): File extension used to filter videos. Optional if ``videos`` is a list of video files,
-            but raises a ``ValueError`` if not provided if ``videos`` is a directory.
+
+        videotype (list[str], str): File extension used to filter videos. Optional if ``videos`` is a list of video files,
+            and filters with common video extensions if a directory is passed in.
     """
     if isinstance(videos, str):
         videos = [videos]
-
 
     if [os.path.isdir(i) for i in videos] == [True]:  # checks if input is a directory
         """
         Returns all the videos in the directory.
         """
-        if videotype is None:
-            raise ValueError('When given a directory of videos, must be given a videotype')
+        if not videotype:
+            videotype = auxfun_videos.SUPPORTED_VIDEOS
 
         from random import shuffle
 
@@ -358,17 +359,15 @@ def get_list_of_videos(
 
         shuffle(videos) # this is useful so multiple nets can be used to analyze simultaneously
 
-    # if not given a videotype and given a list of files, use empty string
-    # ( 'file.mp4'.endswith('')  == True )
-    if videotype is None:
-        videotype = ''
+    if not isinstance(videotype, typing.Sequence):
+        videotype = [videotype]
 
     # filter list of videos
     videos = [
         v
         for v in videos
         if os.path.isfile(v)
-        and v.endswith(videotype)
+        and any(v.endswith(ext) for ext in videotype)
         and "_labeled." not in v
         and "_full." not in v
     ]

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -359,7 +359,7 @@ def get_list_of_videos(
 
         shuffle(videos) # this is useful so multiple nets can be used to analyze simultaneously
 
-    if not isinstance(videotype, typing.Sequence):
+    if isinstance(videotype, str):
         videotype = [videotype]
 
     # filter list of videos

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -319,8 +319,10 @@ def write_pickle(filename, data):
         pickle.dump(data, handle, protocol=pickle.HIGHEST_PROTOCOL)
 
 
-def Getlistofvideos(videos: typing.Union[typing.List[str], str],
-                    videotype: typing.Optional[str] = None) -> typing.List[str]:
+def get_list_of_videos(
+    videos: typing.Union[typing.List[str], str],
+    videotype: typing.Optional[str] = None
+) -> typing.List[str]:
     """ Returns list of videos of videotype "videotype" in
     folder videos or for list of videos.
 

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -485,7 +485,7 @@ def create_labeled_video(
         skeleton_color = None
 
     start_path = os.getcwd()
-    Videos = auxiliaryfunctions.Getlistofvideos(videos, videotype)
+    Videos = auxiliaryfunctions.get_list_of_videos(videos, videotype)
 
     if not Videos:
         return
@@ -882,7 +882,7 @@ def create_video_with_all_detections(
         cfg, shuffle, trainFraction, modelprefix=modelprefix
     )
 
-    videos = auxiliaryfunctions.Getlistofvideos(videos, videotype)
+    videos = auxiliaryfunctions.get_list_of_videos(videos, videotype)
     if not videos:
         return
 

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -342,7 +342,7 @@ def CreateVideoSlow(
 def create_labeled_video(
     config,
     videos,
-    videotype="avi",
+    videotype="",
     shuffle=1,
     trainingsetindex=0,
     filtered=False,
@@ -374,7 +374,8 @@ def create_labeled_video(
         A list of strings containing the full paths to videos for analysis or a path to the directory, where all the videos with same extension are stored.
 
     videotype: string, optional
-        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed. The default is ``.avi``
+        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed.
+        If left unspecified, videos with common extensions ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
 
     shuffle : int, optional
         Number of shuffles of training dataset. Default is set to 1.
@@ -836,7 +837,7 @@ def create_video_with_keypoints_only(
 def create_video_with_all_detections(
     config,
     videos,
-    videotype="avi",
+    videotype="",
     shuffle=1,
     trainingsetindex=0,
     displayedbodyparts="all",
@@ -856,7 +857,8 @@ def create_video_with_all_detections(
         where all the videos with same extension are stored.
 
     videotype: string, optional
-        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed. The default is ``.avi``
+        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed.
+        If left unspecified, videos with common extensions ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
 
     shuffle : int, optional
         Number of shuffles of training dataset. Default is set to 1.

--- a/deeplabcut/utils/plotting.py
+++ b/deeplabcut/utils/plotting.py
@@ -163,7 +163,7 @@ def PlottingResults(
 def plot_trajectories(
     config,
     videos,
-    videotype=".avi",
+    videotype="",
     shuffle=1,
     trainingsetindex=0,
     filtered=False,
@@ -189,7 +189,8 @@ def plot_trajectories(
         A list of strings containing the full paths to videos for analysis or a path to the directory, where all the videos with same extension are stored.
 
     videotype: string, optional
-        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed. The default is ``.avi``
+        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed.
+        If left unspecified, videos with common extensions ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
 
     shuffle: list, optional
     List of integers specifying the shuffle indices of the training dataset. The default is [1]

--- a/deeplabcut/utils/plotting.py
+++ b/deeplabcut/utils/plotting.py
@@ -245,7 +245,7 @@ def plot_trajectories(
     individuals = auxfun_multianimal.IntersectionofIndividualsandOnesGivenbyUser(
         cfg, displayedindividuals
     )
-    Videos = auxiliaryfunctions.Getlistofvideos(videos, videotype)
+    Videos = auxiliaryfunctions.get_list_of_videos(videos, videotype)
     if not len(Videos):
         print(
             "No videos found. Make sure you passed a list of videos and that *videotype* is right."

--- a/tests/test_auxiliaryfunctions.py
+++ b/tests/test_auxiliaryfunctions.py
@@ -17,11 +17,9 @@ def test_get_list_of_videos(tmpdir_factory):
         path = _create_fake_file(f"fake.{ext}")
         fake_videos.append(path)
     
-    #add some other office files:
-    path = _create_fake_file(f"fake.{xls}")
-    fake_videos.append(path)
-    path = _create_fake_file(f"fake.{pptx}")
-    fake_videos.append(path)
+    # Add some other office files:
+    path = _create_fake_file("fake.xls")
+    path = _create_fake_file("fake.pptx")
         
     # Add a .pickle and .h5 files
     _ = _create_fake_file("fake.pickle")

--- a/tests/test_auxiliaryfunctions.py
+++ b/tests/test_auxiliaryfunctions.py
@@ -1,0 +1,61 @@
+from deeplabcut.utils import auxiliaryfunctions
+from deeplabcut.utils.auxfun_videos import SUPPORTED_VIDEOS
+
+
+def test_get_list_of_videos(tmpdir_factory):
+    fake_folder = tmpdir_factory.mktemp('videos')
+    n_ext = len(SUPPORTED_VIDEOS)
+
+    def _create_fake_file(filename):
+        path = str(fake_folder.join(filename))
+        with open(path, "w") as f:
+            f.write("")
+        return path
+
+    fake_videos = []
+    for ext in SUPPORTED_VIDEOS:
+        path = _create_fake_file(f"fake.{ext}")
+        fake_videos.append(path)
+    # Add a .pickle and .h5 files
+    _ = _create_fake_file("fake.pickle")
+    _ = _create_fake_file("fake.h5")
+
+    # By default, all videos with common extensions are taken from a directory
+    videos = auxiliaryfunctions.get_list_of_videos(
+        str(fake_folder), videotype="",
+    )
+    assert len(videos) == n_ext
+
+    # A list of extensions can also be passed in
+    videos = auxiliaryfunctions.get_list_of_videos(
+        str(fake_folder), videotype=SUPPORTED_VIDEOS,
+    )
+    assert len(videos) == n_ext
+
+    for ext in SUPPORTED_VIDEOS:
+        videos = auxiliaryfunctions.get_list_of_videos(
+            str(fake_folder), videotype=ext,
+        )
+        assert len(videos) == 1
+
+    videos = auxiliaryfunctions.get_list_of_videos(
+        str(fake_folder), videotype="unknown",
+    )
+    assert not len(videos)
+
+    videos = auxiliaryfunctions.get_list_of_videos(
+        fake_videos, videotype="",
+    )
+    assert len(videos) == n_ext
+
+    for video in fake_videos:
+        videos = auxiliaryfunctions.get_list_of_videos(
+            [video], videotype=""
+        )
+        assert len(videos) == 1
+
+    for ext in SUPPORTED_VIDEOS:
+        videos = auxiliaryfunctions.get_list_of_videos(
+            fake_videos, videotype=ext,
+        )
+        assert len(videos) == 1

--- a/tests/test_auxiliaryfunctions.py
+++ b/tests/test_auxiliaryfunctions.py
@@ -16,6 +16,13 @@ def test_get_list_of_videos(tmpdir_factory):
     for ext in SUPPORTED_VIDEOS:
         path = _create_fake_file(f"fake.{ext}")
         fake_videos.append(path)
+    
+    #add some other office files:
+    path = _create_fake_file(f"fake.{xls}")
+    fake_videos.append(path)
+    path = _create_fake_file(f"fake.{pptx}")
+    fake_videos.append(path)
+        
     # Add a .pickle and .h5 files
     _ = _create_fake_file("fake.pickle")
     _ = _create_fake_file("fake.h5")


### PR DESCRIPTION
Follow-up of #1704 ([this one comment](https://github.com/DeepLabCut/DeepLabCut/pull/1704#issuecomment-1049300871) specifically)

- [x] videotype now defaults to "", preserving the old behavior when passing a list of videos, and filtering videos with common extensions when passing a directory
- [x] add option to specify multiple extensions
- [x] unit tested 