### PR TITLE
Stricter file search based on suffixes

### DIFF
--- a/deeplabcut/refine_training_dataset/stitch.py
+++ b/deeplabcut/refine_training_dataset/stitch.py
@@ -1177,7 +1177,7 @@ def stitch_tracklets(
             stitcher.stitch()
             if transformer_checkpoint:
                 stitcher.write_tracks(
-                    output_name=output_name, animal_names=animal_names, suffix="transformer"
+                    output_name=output_name, animal_names=animal_names, suffix="tr"
                 )
             else:
                 stitcher.write_tracks(

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -723,14 +723,19 @@ def find_analyzed_data(folder, videoname, scorer, filtered=False, track_method="
     candidates = []
     for file in grab_files_in_folder(folder, "h5"):
         stem = Path(file).stem
+        starts_by_scorer = (
+            file.startswith(videoname + scorer)
+            or file.startswith(videoname + scorer_legacy)
+        )
+        if tracker:
+            matches_tracker = stem.endswith(tracker)
+        else:
+            matches_tracker = not any(stem.endswith(s) for s in TRACK_METHODS.values())
         if all(
             (
-                (
-                    file.startswith(videoname + scorer)
-                    or file.startswith(videoname + scorer_legacy)
-                ),
+                starts_by_scorer,
                 "skeleton" not in file,
-                (stem.endswith(tracker) if tracker else not (stem.endswith("_sk") or stem.endswith("_bx"))),
+                matches_tracker,
                 (filtered and "filtered" in file)
                 or (not filtered and "filtered" not in file),
             )

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -722,6 +722,7 @@ def find_analyzed_data(folder, videoname, scorer, filtered=False, track_method="
 
     candidates = []
     for file in grab_files_in_folder(folder, "h5"):
+        stem = Path(file).stem
         if all(
             (
                 (
@@ -729,7 +730,7 @@ def find_analyzed_data(folder, videoname, scorer, filtered=False, track_method="
                     or file.startswith(videoname + scorer_legacy)
                 ),
                 "skeleton" not in file,
-                (tracker in file if tracker else not ("_sk" in file or "_bx" in file)),
+                (stem.endswith(tracker) if tracker else not (stem.endswith("_sk") or stem.endswith("_bx"))),
                 (filtered and "filtered" in file)
                 or (not filtered and "filtered" not in file),
             )


### PR DESCRIPTION
To avoid ambiguities caused by multiple analyzed data files sharing the same track method suffix (e.g., ellipse & ellipse + transformer), we now more strictly test whether a suffix is found at the end of a file name rather than within. This prevents https://github.com/DeepLabCut/DeepLabCut/blob/0de6c132eec7632dadddce8b995c7db92363e16f/deeplabcut/utils/auxiliaryfunctions.py#L756-L759 from happening, and also solves the creation of labeled videos w/ or w/o the transformer.