### PR TITLE
Experiment : API documentation in Jupyter Book docs

### DIFF
--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -19,6 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install -e .[docs]
         pip install jupyter-book
 
     - name: Build the book

--- a/_config.yml
+++ b/_config.yml
@@ -5,8 +5,6 @@ only_build_toc_files: true
 
 sphinx:
   extra_extensions:
-    - sphinx.ext.autodoc
-    - sphinx.ext.autosummary
     - numpydoc
 
 execute:

--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,12 @@ author: The DeepLabCut Team
 logo: docs/images/logo.png
 only_build_toc_files: true
 
+sphinx:
+  extra_extensions:
+    - sphinx.ext.autodoc
+    - sphinx.ext.autosummary
+    - numpydoc
+
 execute:
   execute_notebooks: "off"
 

--- a/deeplabcut/create_project/new.py
+++ b/deeplabcut/create_project/new.py
@@ -25,40 +25,73 @@ def create_new_project(
     videotype="",
     multianimal=False,
 ):
-    """Creates a new project directory, sub-directories and a basic configuration file. The configuration file is loaded with the default values. Change its parameters to your projects need.
+    r"""Create the necessary folders and files for a new project.
+
+    Creating a new project involves creating the project directory, sub-directories and
+    a basic configuration file. The configuration file is loaded with the default
+    values. Change its parameters to your projects need.
 
     Parameters
     ----------
     project : string
-        String containing the name of the project.
+        The name of the project.
 
     experimenter : string
-        String containing the name of the experimenter.
+        The name of the experimenter.
 
-    videos : list
-        A list of string containing the full paths of the videos to include in the project.
-        Attention: Can also be a directory, then all videos of videotype will be imported.
+    videos : list[str]
+        A list of strings representing the full paths of the videos to include in the
+        project. If the strings represent a directory instead of a file, all videos of
+        ``videotype`` will be imported.
 
     working_directory : string, optional
-        The directory where the project will be created. The default is the ``current working directory``; if provided, it must be a string.
+        The directory where the project will be created. The default is the
+        ``current working directory``.
 
-    copy_videos : bool, optional
-        If this is set to True, the videos are copied to the ``videos`` directory. If it is False,symlink of the videos are copied to the project/videos directory. The default is ``False``; if provided it must be either
-        ``True`` or ``False``.
+    copy_videos : bool, optional, Default: False.
+        If True, the videos are copied to the ``videos`` directory. If False, symlinks
+        of the videos will be created in the ``project/videos`` directory.
 
     multianimal: bool, optional. Default: False.
         For creating a multi-animal project (introduced in DLC 2.2)
 
-    Example
+    Returns
+    -------
+    str
+        Path to the new project configuration file.
+
+    Examples
     --------
-    Linux/MacOs
-    >>> deeplabcut.create_new_project('reaching-task','Linus',['/data/videos/mouse1.avi','/data/videos/mouse2.avi','/data/videos/mouse3.avi'],'/analysis/project/')
-    >>> deeplabcut.create_new_project('reaching-task','Linus',['/data/videos'],videotype='.mp4')
+
+    Linux/MacOS:
+
+    >>> deeplabcut.create_new_project(
+            project='reaching-task',
+            experimenter='Linus',
+            videos=[
+                '/data/videos/mouse1.avi',
+                '/data/videos/mouse2.avi',
+                '/data/videos/mouse3.avi'
+            ],
+            working_directory='/analysis/project/',
+        )
+    >>> deeplabcut.create_new_project(
+            project='reaching-task',
+            experimenter='Linus',
+            videos=['/data/videos'],
+            videotype='.mp4',
+        )
 
     Windows:
-    >>> deeplabcut.create_new_project('reaching-task','Bill',[r'C:\yourusername\rig-95\Videos\reachingvideo1.avi'], copy_videos=True)
-    Users must format paths with either:  r'C:\ OR 'C:\\ <- i.e. a double backslash \ \ )
 
+    >>> deeplabcut.create_new_project(
+            'reaching-task',
+            'Bill',
+            [r'C:\yourusername\rig-95\Videos\reachingvideo1.avi'],
+            copy_videos=True,
+        )
+
+    Users must format paths with either:  r'C:\ OR 'C:\\ <- i.e. a double backslash \ \ )
     """
     from datetime import datetime as dt
     from deeplabcut.utils import auxiliaryfunctions

--- a/docs/api/deeplabcut.create_project.new.rst
+++ b/docs/api/deeplabcut.create_project.new.rst
@@ -1,0 +1,1 @@
+.. autofunction:: deeplabcut.create_project.new.create_new_project

--- a/docs/standardDeepLabCut_UserGuide.md
+++ b/docs/standardDeepLabCut_UserGuide.md
@@ -20,7 +20,6 @@ As a reminder, the core functions are described in our [Nature Protocols](https:
 To begin, navigate to anaconda prompt and right-click to "open as admin "(windows), or simply launch "terminal" (unix/MacOS) on your computer. We assume you have DeepLabCut installed (if not, go here). Next, launch your conda env (i.e., for example `conda activate DLC-CPU`) and then type (windows/unix) `ipython` or  (macOS) `pythonw`. Then type `import deeplabcut`.
 
 ### (A) Create a New Project
-[DOCSTRING](https://github.com/AlexEMG/DeepLabCut/wiki/DOCSTRINGS#create_new_project)
 
 The function **create\_new\_project** creates a new project directory, required subdirectories, and a basic project configuration file. Each project is identified by the name of the project (e.g. Reaching), name of the experimenter (e.g. YourName), as well as the date at creation.
 
@@ -64,6 +63,10 @@ The ``create_new_project`` step writes the following parameters to the configura
 <p align="center">
 <img src="https://static1.squarespace.com/static/57f6d51c9f74566f55ecf271/t/5c40f4124d7a9c0b2ce651c1/1547760716298/Box1-01.png?format=1000w" width="90%">
 </p>
+
+```{eval-rst}
+.. include:: ./api/deeplabcut.create_project.new.rst
+```
 
 ### (B) Configure the Project
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setuptools.setup(
     extras_require={
         "gui": ["wxpython<4.1"],
         "openvino": ["openvino-dev==2022.1.0"],
+        "docs": ["numpydoc"],
     },
     scripts=["deeplabcut/pose_estimation_tensorflow/models/pretrained/download.sh"],
     packages=setuptools.find_packages(),


### PR DESCRIPTION
At the moment, the API documentation for the user-facing functions in `deeplabcut` are hosted on the [docstrings wiki page](https://github.com/DeepLabCut/DeepLabCut/wiki/DOCSTRINGS). This isn't ideal as every time the docstring of a function is updated, the wiki needs to be updated, which external contributions don't often have edit access to.

This is experimental PR demonstrates including API documentation in the Jupyter Book documentation directly. The necessary changes are:

- add a new `docs/api/deeplabcut.create_project.new.rst` file, which automatically documents the function `create_new_project`. This file was created and populated manually
- include this file in `docs/standardDeepLabCut_UserGuide.md` in the "(A) Create a New Project" section
- install the `deeplabcut` package into the environment before building the jupyter book docs

With these changes, the API documentation for the `create_new_project` function can be included in the "(A) Create a New Project" section of the "DeepLabCut user guide".

<img width="954" alt="image" src="https://user-images.githubusercontent.com/1926457/164956079-b6bea9bc-a9cd-41c8-8471-aa7d34ec1e3c.png">

Additionally, this PR introduces a few more changes

- formats and updates the docstring for `create_new_project` according to the [numpydoc style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
- make `numpydoc` an optional documentation dependency of `deeplabcut`
- include `numpydoc` as an extra sphinx extension in the jupyter book config file
- update the github workflow to install the docs dependencies when installing `deeplabcut`