### PR TITLE
Ignore "_build" directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+#Jupyter book build directory
+_build/*
 #Data and examples
 /examples/open*
 /examples/Reac*


### PR DESCRIPTION
The "_build" directory is created by `jupyter-book build .` and git needs to ignore it.