### PR TITLE
Remove unused imports from modules

### DIFF
--- a/deeplabcut/cli.py
+++ b/deeplabcut/cli.py
@@ -11,8 +11,6 @@ from pathlib import Path
 
 import click
 
-import deeplabcut
-
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 

--- a/deeplabcut/gui/create_new_project.py
+++ b/deeplabcut/gui/create_new_project.py
@@ -26,7 +26,6 @@ from deeplabcut.gui.evaluate_network import Evaluate_network
 from deeplabcut.gui.extract_frames import Extract_frames
 from deeplabcut.gui.extract_outlier_frames import Extract_outlier_frames
 from deeplabcut.gui.label_frames import Label_frames
-from deeplabcut.gui.refine_labels import Refine_labels
 from deeplabcut.gui.refine_tracklets import Refine_tracklets
 from deeplabcut.gui.train_network import Train_network
 from deeplabcut.gui.video_editing import Video_Editing

--- a/deeplabcut/gui/label_frames.py
+++ b/deeplabcut/gui/label_frames.py
@@ -17,7 +17,7 @@ import wx
 
 from deeplabcut.generate_training_dataset import check_labels
 from deeplabcut.gui import LOGO_PATH
-from deeplabcut.utils import auxiliaryfunctions, skeleton
+from deeplabcut.utils import auxiliaryfunctions
 from pathlib import Path
 
 

--- a/deeplabcut/gui/video_editing.py
+++ b/deeplabcut/gui/video_editing.py
@@ -18,7 +18,6 @@ import wx
 import wx.lib.agw.floatspin as FS
 
 import deeplabcut
-from deeplabcut.utils import auxiliaryfunctions
 
 from deeplabcut.gui import LOGO_PATH
 

--- a/deeplabcut/pose_estimation_3d/triangulation.py
+++ b/deeplabcut/pose_estimation_3d/triangulation.py
@@ -15,7 +15,6 @@ import cv2
 import numpy as np
 import pandas as pd
 from matplotlib.axes._axes import _log as matplotlib_axes_logger
-from tqdm import tqdm
 
 from deeplabcut.utils import auxfun_multianimal, auxiliaryfunctions
 from deeplabcut.utils import auxiliaryfunctions_3d

--- a/deeplabcut/pose_estimation_tensorflow/export.py
+++ b/deeplabcut/pose_estimation_tensorflow/export.py
@@ -16,7 +16,6 @@ import tarfile
 import numpy as np
 import ruamel.yaml
 import tensorflow as tf
-from tensorflow.python.tools import freeze_graph
 
 from deeplabcut.utils import auxiliaryfunctions
 from deeplabcut.pose_estimation_tensorflow.config import load_config

--- a/deeplabcut/pose_estimation_tensorflow/visualizemaps.py
+++ b/deeplabcut/pose_estimation_tensorflow/visualizemaps.py
@@ -11,7 +11,6 @@ Licensed under GNU Lesser General Public License v3.0
 import os
 import matplotlib.pyplot as plt
 import numpy as np
-from skimage.color import rgba2rgb
 from skimage.transform import resize
 
 

--- a/deeplabcut/utils/auxiliaryfunctions_3d.py
+++ b/deeplabcut/utils/auxiliaryfunctions_3d.py
@@ -69,8 +69,6 @@ def compute_triangulation_calibration_images(
     """
     Performs triangulation of the calibration images.
     """
-    from mpl_toolkits.mplot3d import Axes3D
-
     triangulate = []
     P1 = stereo_matrix["P1"]
     P2 = stereo_matrix["P2"]

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -876,7 +876,7 @@ def create_video_with_all_detections(
 
     """
     from deeplabcut.pose_estimation_tensorflow.lib.inferenceutils import Assembler
-    import pickle, re
+    import re
 
     cfg = auxiliaryfunctions.read_config(config)
     trainFraction = cfg["TrainingFraction"][trainingsetindex]


### PR DESCRIPTION
This PR removes unused imports from modules in `deeplabcut`. The only other unused imports in the package are in `__init__.py` files in the package.