### PR TITLE
Its "add_new_videos", not "add_new_video"

### DIFF
--- a/deeplabcut/cli.py
+++ b/deeplabcut/cli.py
@@ -141,7 +141,7 @@ def add_new_videos(_, *args, **kwargs):
 def extract_frames(_, *args, **kwargs):
     """
     Extracts frames from the videos in the config.yaml file. Only the videos in the config.yaml will be used to select the frames.\n
-    Use the function ``add_new_video`` at any stage of the project to add new videos to the config file and extract their frames. \n
+    Use the function ``add_new_videos`` at any stage of the project to add new videos to the config file and extract their frames.\n
 
     CONFIG : string \n
         Full path of the config.yaml file as a string.  \n \n \n

--- a/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
@@ -111,7 +111,7 @@ def create_multianimaltraining_dataset(
     """
     Creates a training dataset for multi-animal datasets. Labels from all the extracted frames are merged into a single .h5 file.\n
     Only the videos included in the config file are used to create this dataset.\n
-    [OPTIONAL] Use the function 'add_new_video' at any stage of the project to add more videos to the project.
+    [OPTIONAL] Use the function 'add_new_videos' at any stage of the project to add more videos to the project.
 
     Imporant differences to standard:
      - stores coordinates with numdigits as many digits


### PR DESCRIPTION
There were a few places where the function was misdocumented as `add_new_video` when the actual function is `add_new_videos`. These were fixed in this PR. A couple more were fixed in the following commit https://github.com/DeepLabCut/DeepLabCut/pull/1798/commits/1e0ef2f5b51a97c78a75b4a6bfc7d7bb8b24c24c in a separate PR.