### PR TITLE
Fix create dataset model comparison crashing from GUI

### DIFF
--- a/deeplabcut/gui/create_training_dataset.py
+++ b/deeplabcut/gui/create_training_dataset.py
@@ -347,7 +347,7 @@ class Create_training_dataset(wx.Panel):
             if self.model_comparison_choice.GetStringSelection() == "Yes":
                 deeplabcut.create_training_model_comparison(
                     self.config,
-                    trainindex=trainindex,
+                    # trainindex=trainindex,
                     num_shuffles=num_shuffles,
                     userfeedback=userfeedback,
                     net_types=self.net_type,


### PR DESCRIPTION
Fix error `trainindex is not defined` when running compare models from GUI.