### PR TITLE
Add keypoint horizontal flip augmentation

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/datasets/augmentation.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/augmentation.py
@@ -1,6 +1,37 @@
 import imgaug.augmenters as iaa
 import numpy as np
+from imgaug import KeypointsOnImage
 from scipy.spatial.distance import pdist, squareform
+from typing import List, Union, Tuple
+
+
+class KeypointFliplr(iaa.Fliplr):
+    def __init__(
+        self,
+        keypoints: List[str],
+        symmetric_pairs: List[Union[Tuple, List]],
+        p: float = 1.0,
+    ):
+        super().__init__(p=p)
+        self.keypoints = keypoints
+        self.symmetric_pairs = symmetric_pairs
+
+    @property
+    def n_keypoints(self):
+        return len(self.keypoints)
+
+    def _augment_batch_(self, batch, random_state, parents, hooks):
+        batch = super()._augment_batch_(batch, random_state, parents, hooks)
+        keypoints = []
+        for kpts in batch.keypoints:
+            kpts_ = list(kpts)
+            n_kpts = len(kpts_)
+            for i1, i2 in self.symmetric_pairs:
+                for j in range(0, n_kpts, self.n_keypoints):
+                    kpts_[i1 + j], kpts_[i2 + j] = kpts_[i2 + j], kpts_[i1 + j]
+            keypoints.append(KeypointsOnImage(kpts_, kpts.shape))
+        batch.keypoints = keypoints
+        return batch
 
 
 class KeypointAwareCropToFixedSize(iaa.CropToFixedSize):

--- a/tests/test_pose_multianimal_imgaug.py
+++ b/tests/test_pose_multianimal_imgaug.py
@@ -45,7 +45,7 @@ def test_calc_target_and_scoremap_sizes(
 def test_get_batch(ma_dataset):
     for batch_size in 1, 4, 8, 16:
         ma_dataset.batch_size = batch_size
-        (batch_images, joint_ids, batch_joints, data_items,) = ma_dataset.get_batch()
+        batch_images, joint_ids, batch_joints, _, data_items = ma_dataset.get_batch()
         assert (
             len(batch_images)
             == len(joint_ids)
@@ -67,7 +67,8 @@ def test_build_augmentation_pipeline(ma_dataset):
 @pytest.mark.parametrize("num_idchannel", range(4))
 def test_get_targetmaps(ma_dataset, num_idchannel):
     ma_dataset.cfg["num_idchannel"] = num_idchannel
-    batch = ma_dataset.get_batch()[1:]
+    batch = list(ma_dataset.get_batch()[1:])
+    batch.pop(2)
     target_size, sm_size = ma_dataset.calc_target_and_scoremap_sizes()
     scale = np.mean(target_size / ma_dataset.default_size)
     maps = ma_dataset.get_targetmaps_update(*batch, sm_size, scale)


### PR DESCRIPTION
Cleanest implementation I've found to add horizontal flip augmentation within the imgaug framework.
Here are two illustrations of a (naively) flipped image & keypoints using `imgaug.augmenters.Fliplr` and the corrected version using our `KeypointFliplr`:
_naive flip_
![naiveflip](https://user-images.githubusercontent.com/30733203/165283539-6fa98368-c675-426e-a642-ded261975d63.png)
_fixed flip_
![fixedflip](https://user-images.githubusercontent.com/30733203/165283581-2d87a937-81c1-4423-aa04-4227a6cb82e3.png)

