### PR TITLE
Fix a spelling mistake in the docker doc

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -17,7 +17,7 @@ With `deeplabcut-docker`, you can use the images in three modes.
 
 - *Note 1: When running any of the following commands first, it can take some time to complete (a few minutes, depending on your internet connection), since it downloads the Docker image in the background. If you do not see any errors in your terminal, assume that everything is working fine! Subsequent runs of the command will be faster.*
 - *Note 2: The Terminal mode image can be used on all supported platforms (Linux and MacOS). The GUI images can only be considered stable on Linux systems as of DeepLabCut 2.2.0.2 and need additional configuration on Mac.*
-- *Note 3: For any mode below, you might want to set which directory is the base, namely, so you can have read/write (or read only access). Here is how to do so:
+- *Note 3: For any mode below, you might want to set which directory is the base, namely, so you can have read/write (or read-only access). Here is how to do so:
 If you want to mount the whole directory could e.g., pass*
 
 `deeplabcut-docker bash -v /home/mackenzie/DEEPLABCUT:/home/mackenzie/DEEPLABCUT`

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -17,7 +17,7 @@ With `deeplabcut-docker`, you can use the images in three modes.
 
 - *Note 1: When running any of the following commands first, it can take some time to complete (a few minutes, depending on your internet connection), since it downloads the Docker image in the background. If you do not see any errors in your terminal, assume that everything is working fine! Subsequent runs of the command will be faster.*
 - *Note 2: The Terminal mode image can be used on all supported platforms (Linux and MacOS). The GUI images can only be considered stable on Linux systems as of DeepLabCut 2.2.0.2 and need additional configuration on Mac.*
-- *Note 3: For any mode below, you might want to set which directory is the base, namely, so you can have read/write (or ready only access). Here is how to do so:
+- *Note 3: For any mode below, you might want to set which directory is the base, namely, so you can have read/write (or read only access). Here is how to do so:
 If you want to mount the whole directory could e.g., pass*
 
 `deeplabcut-docker bash -v /home/mackenzie/DEEPLABCUT:/home/mackenzie/DEEPLABCUT`


### PR DESCRIPTION
This PR fixes a single spelling mistake in the docker documentation.