### PR TITLE
Add more API documentation in user guide

### DIFF
--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e .[docs]
+        python -m pip install -e .[gui,docs]
         pip install jupyter-book
 
     - name: Build the book

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -1113,51 +1113,90 @@ def create_training_model_comparison(
     userfeedback=False,
     windows2linux=False,
 ):
-    """
-    Creates a training dataset with different networks and augmentation types (dataset_loader) so that the shuffles
-    have same training and testing indices.
+    """Creates a training dataset to compare networks and augmentation types.
 
-    Therefore, this function is useful for benchmarking the performance of different network and augmentation types on the same training/testdata.\n
+    The datasets are created such that the shuffles have same training and testing
+    indices. Therefore, this function is useful for benchmarking the performance of
+    different network and augmentation types on the same training/testdata.
 
-    Parameter
+    Parameters
     ----------
-    config : string
-        Full path of the config.yaml file as a string.
+    config: str
+        Full path of the config.yaml file.
 
-    trainindex: int, optional
-        Either (in case uniform = True) indexes which element of TrainingFraction in the config file should be used (note it is a list!).
-        Alternatively (uniform = False) indexes which folder is dropped, i.e. the first if trainindex=0, the second if trainindex =1, etc.
+    trainindex: int, optional, default=0
+        Either (in case uniform = True) indexes which element of TrainingFraction in
+        the config file should be used (note it is a list!).
+        Alternatively (uniform = False) indexes which folder is dropped, i.e. the first
+        if trainindex=0, the second if trainindex=1, etc.
 
-    num_shuffles : int, optional
-        Number of shuffles of training dataset to create, i.e. [1,2,3] for num_shuffles=3. Default is set to 1.
+    num_shuffles : int, optional, default=1
+        Number of shuffles of training dataset to create,
+        i.e. [1,2,3] for num_shuffles=3.
 
-    net_types: list
-        Type of networks. Currently resnet_50, resnet_101, resnet_152, mobilenet_v2_1.0,mobilenet_v2_0.75, mobilenet_v2_0.5, mobilenet_v2_0.35,
-        efficientnet-b0, efficientnet-b1, efficientnet-b2, efficientnet-b3, efficientnet-b4,
-        efficientnet-b5, and efficientnet-b6 are supported.
+    net_types: list[str], optional, default=["resnet_50"]
+        Currently supported networks are
 
-    augmenter_types: list
-        Type of augmenters. Currently "default", "imgaug", "tensorpack", and "deterministic" are supported.
+        * ``"resnet_50"``
+        * ``"resnet_101"``
+        * ``"resnet_152"``
+        * ``"mobilenet_v2_1.0"``
+        * ``"mobilenet_v2_0.75"``
+        * ``"mobilenet_v2_0.5"``
+        * ``"mobilenet_v2_0.35"``
+        * ``"efficientnet-b0"``
+        * ``"efficientnet-b1"``
+        * ``"efficientnet-b2"``
+        * ``"efficientnet-b3"``
+        * ``"efficientnet-b4"``
+        * ``"efficientnet-b5"``
+        * ``"efficientnet-b6"``
 
-    userfeedback: bool, optional
-        If this is set to false, then all requested train/test splits are created (no matter if they already exist). If you
-        want to assure that previous splits etc. are not overwritten, then set this to True and you will be asked for each split.
+    augmenter_types: list[str], optional, default=["imgaug"]
+        Currently supported augmenters are
+
+        * ``"default"``
+        * ``"imgaug"``
+        * ``"tensorpack"``
+        * ``"deterministic"``
+
+    userfeedback: bool, optional, default=False
+        If ``False``, then all requested train/test splits are created, no matter if
+        they already exist. If you want to assure that previous splits etc. are not
+        overwritten, then set this to True and you will be asked for each split.
+
+    windows2linux
+
+        ..deprecated::
+            Has no effect since 2.2.0.4 and will be removed in 2.2.1.
 
     Returns
-    ----------
+    -------
     shuffle_list: list
-        List of indices corresponding to the trainigsplits/models that were created.
+        List of indices corresponding to the trainingsplits/models that were created.
 
-    Example
+    Examples
     --------
-    >>> shuffle_list = deeplabcut.create_training_model_comparison('/analysis/project/reaching-task/config.yaml',num_shuffles=1,net_types=['resnet_50','resnet_152'],augmenter_types=['tensorpack','deterministic'])
+    On Linux/MacOS
 
-    Windows:
-    >>> shuffle_list = deeplabcut.create_training_model_comparison('C:\\Users\\Ulf\\looming-task\\config.yaml',num_shuffles=1,net_types=['resnet_50','resnet_152'],augmenter_types=['tensorpack','deterministic'])
+    >>> shuffle_list = deeplabcut.create_training_model_comparison(
+            '/analysis/project/reaching-task/config.yaml',
+            num_shuffles=1,
+            net_types=['resnet_50','resnet_152'],
+            augmenter_types=['tensorpack','deterministic'],
+        )
 
-    See examples/testscript_openfielddata_augmentationcomparison.py for an example of how to use shuffle_list.
+    On Windows
 
-    --------
+    >>> shuffle_list = deeplabcut.create_training_model_comparison(
+            'C:\\Users\\Ulf\\looming-task\\config.yaml',
+            num_shuffles=1,
+            net_types=['resnet_50','resnet_152'],
+            augmenter_types=['tensorpack','deterministic'],
+        )
+
+    See ``examples/testscript_openfielddata_augmentationcomparison.py`` for an example
+    of how to use ``shuffle_list``.
     """
     # read cfg file
     cfg = auxiliaryfunctions.read_config(config)

--- a/deeplabcut/gui/label_frames.py
+++ b/deeplabcut/gui/label_frames.py
@@ -29,43 +29,63 @@ def label_frames(
     sourceCam=None,
     jump_unlabeled=False,
 ):
-    """
-    Manually label/annotate the extracted frames. Update the list of body parts you want to localize in the config.yaml file first.
+    """Manually label/annotate the extracted frames.
 
-    Parameter
+    Update the list of body parts you want to localize in the config.yaml file first.
+
+    Parameters
     ----------
-    config : string
-        String containing the full path of the config file in the project.
+    config: str
+        Full path of the config.yaml file.
 
-    multiple_individualsGUI: bool, optional
-        If this is set to True, a user can label multiple individuals. Note for "multianimalproject=True" this is automatically used.
-        The default is ``False``; if provided it must be either ``True`` or ``False``.
+    multiple_individualsGUI: bool, optional, default=False
+        If ``True``, a user can label multiple individuals. Note for
+        ``"multianimalproject=True"`` this is automatically used.
 
-    imtypes: list of imagetypes to look for in folder to be labeled.
-        By default only png images are considered.
+    imtypes: list[str], optional, default=["*.png"]
+        Image types to look for in the folder. By default only png images are labeled.
 
-    config3d: string, optional
-        String containing the full path of the config file in the 3D project. Include when epipolar lines would be helpful for labeling additional camera angles.
+    config3d: str or None, optional, default=None
+        Full path of the config file in the 3D project. Include when epipolar lines
+        would be helpful for labeling additional camera angles.
 
-    sourceCam: string, optional
-        String containing the camera name from which to pull labeling data to generate epipolar lines. This must match the pattern in 'camera_names' in the 3D config file.
-        If no value is entered, data will be pulled from either cam1 or cam2
+    sourceCam: str or None, optional, default=None
+        The camera name from which to pull labeling data to generate epipolar lines.
+        This must match the pattern in ``'camera_names'`` in the 3D config file.
+        If no value is entered, data will be pulled from either cam1 or cam2.
 
-    Example
+    jump_unlabeled: bool, optional, default=False
+        Aumatically jump to the next folder containing unlabeled images.
+
+    Returns
+    -------
+    None
+
+    Examples
     --------
-    Standard use case:
+    Standard use case
+
     >>> deeplabcut.label_frames('/myawesomeproject/reaching4thestars/config.yaml')
 
-    To label multiple individuals (without having a multiple individuals project); otherwise this GUI is loaded automatically
-    >>> deeplabcut.label_frames('/analysis/project/reaching-task/config.yaml',multiple_individualsGUI=True)
+    To label multiple individuals (without having a multiple individuals project);
+    otherwise this GUI is loaded automatically
 
-    To label other image types
-    >>> label_frames(config,multiple=False,imtypes=['*.jpg','*.jpeg'])
+    >>> deeplabcut.label_frames(
+            '/analysis/project/reaching-task/config.yaml',
+            multiple_individualsGUI=True,
+        )
 
-    To label with epipolar lines projected from labels in another camera angle #+++
-    >>> label_frames(config, config3d='/analysis/project/reaching-task/reaching-task-3d/config.yaml', sourceCam='cam1')
-    --------
+    To label non-default image types
 
+    >>> label_frames(config, multiple=False, imtypes=['*.jpg','*.jpeg'])
+
+    To label with epipolar lines projected from labels in another camera angle.
+
+    >>> label_frames(
+        config,
+        config3d='/analysis/project/reaching-task/reaching-task-3d/config.yaml',
+        sourceCam='cam1',
+    )
     """
     startpath = os.getcwd()
     wd = Path(config).resolve().parents[0]

--- a/deeplabcut/gui/refine_labels.py
+++ b/deeplabcut/gui/refine_labels.py
@@ -22,27 +22,27 @@ from pathlib import Path
 
 
 def refine_labels(config, multianimal=False, jump_unlabeled=False):
-    """
-    Refines the labels of the outlier frames extracted from the analyzed videos.\n Helps in augmenting the training dataset.
-    Use the function ``analyze_video`` to analyze a video and extracts the outlier frames using the function
-    ``extract_outlier_frames`` before refining the labels.
+    """Refines the labels of the outlier frames extracted from the analyzed videos.
+
+    Helps in augmenting the training dataset. Use ``deeplabcut.analyze_videos`` to
+    analyze a video and extracts the outlier frames using
+    ``deeplabcut.extract_outlier_frames`` before refining the labels.
 
     Parameters
     ----------
-    config : string
-        Full path of the config.yaml file as a string.
+    config: str
+        Full path of the config.yaml file.
 
-    Screens : int value of the number of Screens in landscape mode, i.e. if you have 2 screens, enter 2. Default is 1.
+    multianimal, bool, optional, default=False
+        If ``True``, a user can label multiple individuals. Note for
+        ``"multianimalproject=True"`` this is automatically used.
 
-    scale_h & scale_w : you can modify how much of the screen the GUI should occupy. The default is .9 and .8, respectively.
-
-    img_scale : if you want to make the plot of the frame larger, consider changing this to .008 or more. Be careful though, too large and you will not see the buttons fully!
+    jump_unlabeled: bool, optional, default=False
+        Aumatically jump to the next folder containing unlabeled images.
 
     Examples
     --------
-    >>> deeplabcut.refine_labels('/analysis/project/reaching-task/config.yaml', Screens=2, imag_scale=.0075)
-    --------
-
+    >>> deeplabcut.refine_labels('/analysis/project/reaching-task/config.yaml')
     """
 
     startpath = os.getcwd()

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -502,58 +502,82 @@ def evaluate_network(
     rescale=False,
     modelprefix="",
 ):
-    """
+    """Evaluates the network.
 
-    Evaluates the network based on the saved models at different stages of the training network.\n
-    The evaluation results are stored in the .h5 and .csv file under the subdirectory 'evaluation_results'.
-    Change the snapshotindex parameter in the config file to 'all' in order to evaluate all the saved models.
+    Evaluates the network based on the saved models at different stages of the training
+    network. The evaluation results are stored in the .h5 and .csv file under the
+    subdirectory 'evaluation_results'. Change the snapshotindex parameter in the config
+    file to 'all' in order to evaluate all the saved models.
+
     Parameters
     ----------
     config : string
-        Full path of the config.yaml file as a string.
+        Full path of the config.yaml file.
 
-    Shuffles: list, optional
-        List of integers specifying the shuffle indices of the training dataset. The default is [1]
+    Shuffles: list, optional, default=[1]
+        List of integers specifying the shuffle indices of the training dataset.
 
-    trainingsetindex: int, optional
-        Integer specifying which TrainingsetFraction to use. By default the first (note that TrainingFraction is a list in config.yaml). This
-        variable can also be set to "all".
+    trainingsetindex: int, optional, default=0
+        Integer specifying which "TrainingsetFraction" to use.
+        Note that "TrainingFraction" is a list in config.yaml). This variable can also
+        be set to "all".
 
-    plotting: bool or str, optional
+    plotting: bool or str, optional, default=False
         Plots the predictions on the train and test images.
-        The default is ``False``; if provided it must be either ``True``, ``False``, "bodypart", or "individual".
+        If provided it must be either ``True``, ``False``, "bodypart", or "individual".
         Setting to ``True`` defaults as "bodypart" for multi-animal projects.
 
-    show_errors: bool, optional
-        Display train and test errors. The default is `True``
+    show_errors: bool, optional, default=True
+        Display train and test errors.
 
-    comparisonbodyparts: list of bodyparts, Default is "all".
-        The average error will be computed for those body parts only (Has to be a subset of the body parts).
+    comparisonbodyparts: str or list, optional, default="all"
+        The average error will be computed for those body parts only.
+        The provided list has to be a subset of the defined body parts.
 
-    gputouse: int, optional. Natural number indicating the number of your GPU (see number in nvidia-smi). If you do not have a GPU put None.
+    gputouse: int or None, optional, default=None
+        Indicates the GPU to use (see number in ``nvidia-smi``). If you do not have a
+        GPU put `None``.
         See: https://nvidia.custhelp.com/app/answers/detail/a_id/3751/~/useful-nvidia-smi-queries
 
-    rescale: bool, default False
-        Evaluate the model at the 'global_scale' variable (as set in the test/pose_config.yaml file for a particular project). I.e. every
-        image will be resized according to that scale and prediction will be compared to the resized ground truth. The error will be reported
-        in pixels at rescaled to the *original* size. I.e. For a [200,200] pixel image evaluated at global_scale=.5, the predictions are calculated
-        on [100,100] pixel images, compared to 1/2*ground truth and this error is then multiplied by 2!. The evaluation images are also shown for the
-        original size!
+    rescale: bool, optional, default=False
+        Evaluate the model at the 'global_scale' variable (as set in the
+        test/pose_config.yaml file for a particular project). I.e. every image will be
+        resized according to that scale and prediction will be compared to the resized
+        ground truth. The error will be reported in pixels at rescaled to the
+        *original* size. I.e. For a [200,200] pixel image evaluated at global_scale=.5,
+        the predictions are calculated on [100,100] pixel images, compared to
+        1/2*ground truth and this error is then multiplied by 2!. The evaluation images
+        are also shown for the original size!
+
+    Returns
+    -------
+    None
 
     Examples
     --------
-    If you do not want to plot, just evaluate shuffle 1.
-    >>> deeplabcut.evaluate_network('/analysis/project/reaching-task/config.yaml', Shuffles=[1])
-    --------
-    If you want to plot and evaluate shuffle 0 and 1.
-    >>> deeplabcut.evaluate_network('/analysis/project/reaching-task/config.yaml',Shuffles=[0, 1],plotting = True)
+    If you do not want to plot and evaluate with shuffle set to 1.
 
-    --------
-    If you want to plot assemblies for a maDLC project:
-    >>> deeplabcut.evaluate_network('/analysis/project/reaching-task/config.yaml',Shuffles=[1],plotting = "individual")
+    >>> deeplabcut.evaluate_network(
+            '/analysis/project/reaching-task/config.yaml', Shuffles=[1],
+        )
 
-    Note: this defaults to standard plotting for single-animal projects.
+    If you want to plot and evaluate with shuffle set to 0 and 1.
 
+    >>> deeplabcut.evaluate_network(
+            '/analysis/project/reaching-task/config.yaml',
+            Shuffles=[0, 1],
+            plotting=True,
+        )
+
+    If you want to plot assemblies for a maDLC project
+
+    >>> deeplabcut.evaluate_network(
+            '/analysis/project/reaching-task/config.yaml',
+            Shuffles=[1],
+            plotting="individual",
+        )
+
+    Note: This defaults to standard plotting for single-animal projects.
     """
     if plotting not in (True, False, "bodypart", "individual"):
         raise ValueError(f"Unknown value for `plotting`={plotting}")

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -517,15 +517,16 @@ def evaluate_network(
     Shuffles: list, optional, default=[1]
         List of integers specifying the shuffle indices of the training dataset.
 
-    trainingsetindex: int, optional, default=0
+    trainingsetindex: int or str, optional, default=0
         Integer specifying which "TrainingsetFraction" to use.
-        Note that "TrainingFraction" is a list in config.yaml). This variable can also
+        Note that "TrainingFraction" is a list in config.yaml. This variable can also
         be set to "all".
 
     plotting: bool or str, optional, default=False
         Plots the predictions on the train and test images.
-        If provided it must be either ``True``, ``False``, "bodypart", or "individual".
-        Setting to ``True`` defaults as "bodypart" for multi-animal projects.
+        If provided it must be either ``True``, ``False``, ``"bodypart"``, or
+        ``"individual"``. Setting to ``True`` defaults as ``"bodypart"`` for
+        multi-animal projects.
 
     show_errors: bool, optional, default=True
         Display train and test errors.
@@ -540,14 +541,18 @@ def evaluate_network(
         See: https://nvidia.custhelp.com/app/answers/detail/a_id/3751/~/useful-nvidia-smi-queries
 
     rescale: bool, optional, default=False
-        Evaluate the model at the 'global_scale' variable (as set in the
-        test/pose_config.yaml file for a particular project). I.e. every image will be
+        Evaluate the model at the ``'global_scale'`` variable (as set in the
+        ``pose_config.yaml`` file for a particular project). I.e. every image will be
         resized according to that scale and prediction will be compared to the resized
         ground truth. The error will be reported in pixels at rescaled to the
-        *original* size. I.e. For a [200,200] pixel image evaluated at global_scale=.5,
-        the predictions are calculated on [100,100] pixel images, compared to
-        1/2*ground truth and this error is then multiplied by 2!. The evaluation images
-        are also shown for the original size!
+        *original* size. I.e. For a [200,200] pixel image evaluated at
+        ``global_scale=.5``, the predictions are calculated on [100,100] pixel images,
+        compared to 1/2*ground truth and this error is then multiplied by 2!.
+        The evaluation images are also shown for the original size!
+
+    modelprefix: str, optional, default=""
+        Directory containing the deeplabcut models to use when evaluating the network.
+        By default, the models are assumed to exist in the project folder.
 
     Returns
     -------

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -296,7 +296,7 @@ def analyze_videos(
         A list of strings containing the full paths to videos for analysis or a path to
         the directory, where all the videos with same extension are stored.
 
-    videotype: string, optional, default=""
+    videotype: str, optional, default=""
         Checks for the extension of the video in case the input to the video is a
         directory. Only videos with this extension are analyzed. If left unspecified,
         videos with common extensions ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
@@ -345,7 +345,8 @@ def analyze_videos(
         enough given the movement of the animal).
 
     modelprefix: str, optional, default=""
-        ?
+        Directory containing the deeplabcut models to use when evaluating the network.
+        By default, the models are assumed to exist in the project folder.
 
     robust_nframes: bool, optional, default=False
         Evaluate a video's number of frames in a robust manner.
@@ -391,8 +392,8 @@ def analyze_videos(
         animals in the video is different from the number of animals the model was
         trained on.
 
-    use_openvino: str, optional, default=None
-        ?
+    use_openvino: str, optional
+        Use "CPU" for inference if OpenVINO is available in the Python environment.
 
     Returns
     -------

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -289,8 +289,8 @@ def analyze_videos(
 
     Parameters
     ----------
-    config: string
-        Full path of the config.yaml file as a string.
+    config: str
+        Full path of the config.yaml file.
 
     videos: list[str]
         A list of strings containing the full paths to videos for analysis or a path to

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -409,7 +409,7 @@ def analyze_videos(
     Examples
     --------
 
-    Analysing a single video on Windows
+    Analyzing a single video on Windows
 
     >>> deeplabcut.analyze_videos(
             'C:\\myproject\\reaching-task\\config.yaml',

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -282,128 +282,186 @@ def analyze_videos(
     identity_only=False,
     use_openvino="CPU" if is_openvino_available else None,
 ):
-    """
-    Makes prediction based on a trained network. The index of the trained network is specified by parameters in the config file (in particular the variable 'snapshotindex')
+    """Makes prediction based on a trained network.
 
-    Output: The labels are stored as MultiIndex Pandas Array, which contains the name of the network, body part name, (x, y) label position \n
-            in pixels, and the likelihood for each frame per body part. These arrays are stored in an efficient Hierarchical Data Format (HDF) \n
-            in the same directory, where the video is stored. However, if the flag save_as_csv is set to True, the data can also be exported in \n
-            comma-separated values format (.csv), which in turn can be imported in many programs, such as MATLAB, R, Prism, etc.
+    The index of the trained network is specified by parameters in the config file
+    (in particular the variable 'snapshotindex').
 
     Parameters
     ----------
     config: string
         Full path of the config.yaml file as a string.
 
-    videos: list
-        A list of strings containing the full paths to videos for analysis or a path to the directory, where all the videos with same extension are stored.
+    videos: list[str]
+        A list of strings containing the full paths to videos for analysis or a path to
+        the directory, where all the videos with same extension are stored.
 
-    videotype: string, optional
-        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed.
-        If left unspecified, videos with common extensions ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
+    videotype: string, optional, default=""
+        Checks for the extension of the video in case the input to the video is a
+        directory. Only videos with this extension are analyzed. If left unspecified,
+        videos with common extensions ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
 
-    shuffle: int, optional
-        An integer specifying the shuffle index of the training dataset used for training the network. The default is 1.
+    shuffle: int, optional, default=1
+        An integer specifying the shuffle index of the training dataset used for
+        training the network.
 
-    trainingsetindex: int, optional
-        Integer specifying which TrainingsetFraction to use. By default the first (note that TrainingFraction is a list in config.yaml).
+    trainingsetindex: int, optional, default=0
+        Integer specifying which TrainingsetFraction to use.
+        By default the first (note that TrainingFraction is a list in config.yaml).
 
-    gputouse: int, optional. Natural number indicating the number of your GPU (see number in nvidia-smi). If you do not have a GPU put None.
-    See: https://nvidia.custhelp.com/app/answers/detail/a_id/3751/~/useful-nvidia-smi-queries
+    gputouse: int or None, optional, default=None
+        Indicates the GPU to use (see number in ``nvidia-smi``). If you do not have a
+        GPU put ``None``.
+        See: https://nvidia.custhelp.com/app/answers/detail/a_id/3751/~/useful-nvidia-smi-queries
 
-    save_as_csv: bool, optional
-        Saves the predictions in a .csv file. The default is ``False``; if provided it must be either ``True`` or ``False``
+    save_as_csv: bool, optional, default=False
+        Saves the predictions in a .csv file.
 
-    destfolder: string, optional
-        Specifies the destination folder for analysis data (default is the path of the video). Note that for subsequent analysis this
-        folder also needs to be passed.
+    destfolder: string or None, optional, default=None
+        Specifies the destination folder for analysis data. If ``None``, the path of
+        the video is used. Note that for subsequent analysis this folder also needs to
+        be passed.
 
-    batchsize: int, default from pose_cfg.yaml
-        Change batch size for inference; if given overwrites value in pose_cfg.yaml
+    batchsize: int or None, optional, default=None
+        Change batch size for inference; if given overwrites value in ``pose_cfg.yaml``.
 
-    cropping: list, optional (default=None)
+    cropping: list or None, optional, default=None
         List of cropping coordinates as [x1, x2, y1, y2].
         Note that the same cropping parameters will then be used for all videos.
-        If different video crops are desired, run 'analyze_videos' on individual videos
-        with the corresponding cropping coordinates.
+        If different video crops are desired, run ``analyze_videos`` on individual
+        videos with the corresponding cropping coordinates.
 
-    TFGPUinference: bool, default: True
-        Perform inference on GPU with TensorFlow code. Introduced in "Pretraining boosts out-of-domain robustness for pose estimation" by
-        Alexander Mathis, Mert Yüksekgönül, Byron Rogers, Matthias Bethge, Mackenzie W. Mathis Source: https://arxiv.org/abs/1909.11229
+    TFGPUinference: bool, optional, default=True
+        Perform inference on GPU with TensorFlow code. Introduced in "Pretraining
+        boosts out-of-domain robustness for pose estimation" by Alexander Mathis,
+        Mert Yüksekgönül, Byron Rogers, Matthias Bethge, Mackenzie W. Mathis.
+        Source: https://arxiv.org/abs/1909.11229
 
-    dynamic: triple containing (state, detectiontreshold, margin)
+    dynamic: tuple(bool, float, int) triple containing (state, detectiontreshold, margin)
         If the state is true, then dynamic cropping will be performed. That means that if an object is detected (i.e. any body part > detectiontreshold),
         then object boundaries are computed according to the smallest/largest x position and smallest/largest y position of all body parts. This  window is
         expanded by the margin and from then on only the posture within this crop is analyzed (until the object is lost, i.e. <detectiontreshold). The
         current position is utilized for updating the crop window for the next frame (this is why the margin is important and should be set large
         enough given the movement of the animal).
 
-    robust_nframes: bool, optional (default=False)
+    modelprefix: str, optional, default=""
+        ?
+
+    robust_nframes: bool, optional, default=False
         Evaluate a video's number of frames in a robust manner.
         This option is slower (as the whole video is read frame-by-frame),
         but does not rely on metadata, hence its robustness against file corruption.
 
-    allow_growth: bool, default false.
-        For some smaller GPUs the memory issues happen. If true, the memory allocator does not pre-allocate the entire specified
-        GPU memory region, instead starting small and growing as needed. See issue: https://forum.image.sc/t/how-to-stop-running-out-of-vram/30551/2
+    allow_growth: bool, optional, default=False.
+        For some smaller GPUs the memory issues happen. If ``True``, the memory
+        allocator does not pre-allocate the entire specified GPU memory region, instead
+        starting small and growing as needed.
+        See issue: https://forum.image.sc/t/how-to-stop-running-out-of-vram/30551/2
 
-    use_shelve: bool, optional (default=False)
+    use_shelve: bool, optional, default=False
         By default, data are dumped in a pickle file at the end of the video analysis.
-        Otherwise, data are written to disk on the fly using a "shelf"; i.e., a pickle-based,
-        persistent, database-like object by default, resulting in constant memory footprint.
+        Otherwise, data are written to disk on the fly using a "shelf"; i.e., a
+        pickle-based, persistent, database-like object by default, resulting in
+        constant memory footprint.
 
     The following parameters are only relevant for multi-animal projects:
 
-    auto_track: bool, optional (default=True)
-        By default, tracking and stitching are automatically performed, producing the final h5 data file.
-        This is equivalent to the behavior for single-animal projects.
+    auto_track: bool, optional, default=True
+        By default, tracking and stitching are automatically performed, producing the
+        final h5 data file. This is equivalent to the behavior for single-animal
+        projects.
 
-        If False, one must run `convert_detections2tracklets` and `stitch_tracklets` afterwards, in order to obtain the h5 file.
+        If ``False``, one must run ``convert_detections2tracklets`` and
+        ``stitch_tracklets`` afterwards, in order to obtain the h5 file.
 
     This function has 3 related sub-calls:
 
-    identity_only: bool, optional (default=False)
-        If True and animal identity was learned by the model,
-        assembly and tracking rely exclusively on identity prediction.
+    identity_only: bool, optional, default=False
+        If ``True`` and animal identity was learned by the model, assembly and tracking
+        rely exclusively on identity prediction.
 
-    calibrate: bool, optional (default=False)
-        If True, use training data to calibrate the animal assembly procedure.
-        This improves its robustness to wrong body part links,
-        but requires very little missing data.
+    calibrate: bool, optional, default=False
+        If ``True``, use training data to calibrate the animal assembly procedure. This
+        improves its robustness to wrong body part links, but requires very little
+        missing data.
 
-    n_tracks : int, optional
-        Number of tracks to reconstruct. By default, taken as the number
-        of individuals defined in the config.yaml. Another number can be
-        passed if the number of animals in the video is different from
-        the number of animals the model was trained on.
+    n_tracks: int or None, optional, default=None
+        Number of tracks to reconstruct. By default, taken as the number of individuals
+        defined in the config.yaml. Another number can be passed if the number of
+        animals in the video is different from the number of animals the model was
+        trained on.
+
+    use_openvino: str, optional, default=None
+        ?
+
+    Returns
+    -------
+    pandas array
+        The labels are stored as MultiIndex Pandas Array, which contains the name of
+        the network, body part name, (x, y) label position in pixels, and the
+        likelihood for each frame per body part. These arrays are stored in an
+        efficient Hierarchical Data Format (HDF) in the same directory, where the video
+        is stored. However, if the flag save_as_csv is set to True, the data can also
+        be exported in comma-separated values format (.csv), which in turn can be
+        imported in many programs, such as MATLAB, R, Prism, etc.
 
     Examples
     --------
 
-    Windows example for analyzing 1 video
-    >>> deeplabcut.analyze_videos('C:\\myproject\\reaching-task\\config.yaml',['C:\\yourusername\\rig-95\\Videos\\reachingvideo1.avi'])
-    --------
+    Analysing a single video on Windows
 
-    If you want to analyze only 1 video
-    >>> deeplabcut.analyze_videos('/analysis/project/reaching-task/config.yaml',['/analysis/project/videos/reachingvideo1.avi'])
-    --------
+    >>> deeplabcut.analyze_videos(
+            'C:\\myproject\\reaching-task\\config.yaml',
+            ['C:\\yourusername\\rig-95\\Videos\\reachingvideo1.avi'],
+        )
 
-    If you want to analyze all videos of type avi in a folder:
-    >>> deeplabcut.analyze_videos('/analysis/project/reaching-task/config.yaml',['/analysis/project/videos'],videotype='.avi')
-    --------
+    Analyzing a single video on Linux/MacOS
 
-    If you want to analyze multiple videos
-    >>> deeplabcut.analyze_videos('/analysis/project/reaching-task/config.yaml',['/analysis/project/videos/reachingvideo1.avi','/analysis/project/videos/reachingvideo2.avi'])
-    --------
+    >>> deeplabcut.analyze_videos(
+            '/analysis/project/reaching-task/config.yaml',
+            ['/analysis/project/videos/reachingvideo1.avi'],
+        )
 
-    If you want to analyze multiple videos with shuffle = 2
-    >>> deeplabcut.analyze_videos('/analysis/project/reaching-task/config.yaml',['/analysis/project/videos/reachingvideo1.avi','/analysis/project/videos/reachingvideo2.avi'],shuffle=2)
+    Analyze all videos of type ``avi`` in a folder
 
-    --------
-    If you want to analyze multiple videos with shuffle = 2 and save results as an additional csv file too
-    >>> deeplabcut.analyze_videos('/analysis/project/reaching-task/config.yaml',['/analysis/project/videos/reachingvideo1.avi','/analysis/project/videos/reachingvideo2.avi'],shuffle=2,save_as_csv=True)
-    --------
+    >>> deeplabcut.analyze_videos(
+            '/analysis/project/reaching-task/config.yaml',
+            ['/analysis/project/videos'],
+            videotype='.avi',
+        )
 
+    Analyze multiple videos
+
+    >>> deeplabcut.analyze_videos(
+            '/analysis/project/reaching-task/config.yaml',
+            [
+                '/analysis/project/videos/reachingvideo1.avi',
+                '/analysis/project/videos/reachingvideo2.avi',
+            ],
+        )
+
+    Analyze multiple videos with ``shuffle=2``
+
+    >>> deeplabcut.analyze_videos(
+            '/analysis/project/reaching-task/config.yaml',
+            [
+                '/analysis/project/videos/reachingvideo1.avi',
+                '/analysis/project/videos/reachingvideo2.avi',
+            ],
+            shuffle=2,
+        )
+
+    Analyze multiple videos with ``shuffle=2``, save results as an additional csv file
+
+    >>> deeplabcut.analyze_videos(
+            '/analysis/project/reaching-task/config.yaml',
+            [
+                '/analysis/project/videos/reachingvideo1.avi',
+                '/analysis/project/videos/reachingvideo2.avi',
+            ],
+            shuffle=2,
+            save_as_csv=True,
+        )
     """
     if "TF_CUDNN_USE_AUTOTUNE" in os.environ:
         del os.environ["TF_CUDNN_USE_AUTOTUNE"]  # was potentially set during training

--- a/deeplabcut/pose_estimation_tensorflow/training.py
+++ b/deeplabcut/pose_estimation_tensorflow/training.py
@@ -121,6 +121,10 @@ def train_network(
         training from a snapshot. Note that if you change the number of bodyparts, you
         need to set this to false for re-training.
 
+    modelprefix: str, optional, default=""
+        Directory containing the deeplabcut models to use when evaluating the network.
+        By default, the models are assumed to exist in the project folder.
+
     Returns
     -------
     None

--- a/deeplabcut/post_processing/analyze_skeleton.py
+++ b/deeplabcut/post_processing/analyze_skeleton.py
@@ -192,7 +192,10 @@ def analyzeskeleton(
         videos with same extension are stored.
 
     videotype: str, optional, default=""
-        ?
+        Checks for the extension of the video in case the input to the video is a
+        directory. Only videos with this extension are analyzed.
+        If left unspecified, videos with common extensions
+        ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
 
     shuffle : int, optional, default=1
         The shuffle index of training dataset. The extracted frames will be stored in
@@ -214,6 +217,10 @@ def analyzeskeleton(
         Specifies the destination folder for analysis data. If ``None``, the path of
         the video is used. Note that for subsequent analysis this folder also needs to
         be passed.
+
+    modelprefix: str, optional, default=""
+        Directory containing the deeplabcut models to use when evaluating the network.
+        By default, the models are assumed to exist in the project folder.
 
     track_method: string, optional, default=""
         Specifies the tracker used to generate the data.

--- a/deeplabcut/post_processing/analyze_skeleton.py
+++ b/deeplabcut/post_processing/analyze_skeleton.py
@@ -178,38 +178,52 @@ def analyzeskeleton(
     modelprefix="",
     track_method="",
 ):
-    """
-    Extracts length and orientation of each "bone" of the skeleton as defined in the config file.
+    """Extracts length and orientation of each "bone" of the skeleton.
 
-    Parameter
+    The bone and skeleton information is defined in the config file.
+
+    Parameters
     ----------
-    config : string
-        Full path of the config.yaml file as a string.
+    config: string
+        Full path of the config.yaml file.
 
-    videos : list
-        A list of strings containing the full paths to videos for analysis or a path to the directory, where all the videos with same extension are stored.
+    videos: list[str]
+        The full paths to videos for analysis or a path to the directory, where all the
+        videos with same extension are stored.
 
-    shuffle : int, optional
-        The shuffle index of training dataset. The extracted frames will be stored in the labeled-dataset for
-        the corresponding shuffle of training dataset. Default is set to 1
+    videotype: str, optional, default=""
+        ?
 
-    trainingsetindex: int, optional
-        Integer specifying which TrainingsetFraction to use. By default the first (note that TrainingFraction is a list in config.yaml).
+    shuffle : int, optional, default=1
+        The shuffle index of training dataset. The extracted frames will be stored in
+        the labeled-dataset for the corresponding shuffle of training dataset.
 
-    filtered: bool, default false
-        Boolean variable indicating if filtered output should be plotted rather than frame-by-frame predictions. Filtered version can be calculated with deeplabcut.filterpredictions
+    trainingsetindex: int, optional, default=0
+        Integer specifying which TrainingsetFraction to use.
+        Note that TrainingFraction is a list in config.yaml.
 
-    save_as_csv: bool, optional
-        Saves the predictions in a .csv file. The default is ``False``; if provided it must be either ``True`` or ``False``
+    filtered: bool, optional, default=False
+        Boolean variable indicating if filtered output should be plotted rather than
+        frame-by-frame predictions. Filtered version can be calculated with
+        ``deeplabcut.filterpredictions``.
 
-    destfolder: string, optional
-        Specifies the destination folder for analysis data (default is the path of the video). Note that for subsequent analysis this
-        folder also needs to be passed.
+    save_as_csv: bool, optional, default=False
+        Saves the predictions in a .csv file.
 
-    track_method: string, optional
-         Specifies the tracker used to generate the data. Empty by default (corresponding to a single animal project).
-         For multiple animals, must be either 'box', 'skeleton', or 'ellipse' and will be taken from the config.yaml file if none is given.
+    destfolder: string or None, optional, default=None
+        Specifies the destination folder for analysis data. If ``None``, the path of
+        the video is used. Note that for subsequent analysis this folder also needs to
+        be passed.
 
+    track_method: string, optional, default=""
+        Specifies the tracker used to generate the data.
+        Empty by default (corresponding to a single animal project).
+        For multiple animals, must be either 'box', 'skeleton', or 'ellipse' and will
+        be taken from the config.yaml file if none is given.
+
+    Returns
+    -------
+    None
     """
     # Load config file, scorer and videos
     cfg = auxiliaryfunctions.read_config(config)

--- a/deeplabcut/post_processing/analyze_skeleton.py
+++ b/deeplabcut/post_processing/analyze_skeleton.py
@@ -184,7 +184,7 @@ def analyzeskeleton(
 
     Parameters
     ----------
-    config: string
+    config: str
         Full path of the config.yaml file.
 
     videos: list[str]

--- a/deeplabcut/post_processing/filtering.py
+++ b/deeplabcut/post_processing/filtering.py
@@ -164,7 +164,7 @@ def filterpredictions(
             MAdegree=2,
         )
 
-    Use median filter over 10bins:
+    Use median filter over 10 bins:
 
     >>> deeplabcut.filterpredictions(
             'C:\\myproject\\reaching-task\\config.yaml',

--- a/deeplabcut/post_processing/filtering.py
+++ b/deeplabcut/post_processing/filtering.py
@@ -136,8 +136,9 @@ def filterpredictions(
         the video is used by default. Note that for subsequent analysis this folder
         also needs to be passed.
 
-    modelprefix: string, optional, default=""
-        ?
+    modelprefix: str, optional, default=""
+        Directory containing the deeplabcut models to use when evaluating the network.
+        By default, the models are assumed to exist in the project folder.
 
     track_method: string, optional, default=""
         Specifies the tracker used to generate the data.

--- a/deeplabcut/post_processing/filtering.py
+++ b/deeplabcut/post_processing/filtering.py
@@ -81,75 +81,112 @@ def filterpredictions(
     modelprefix="",
     track_method="",
 ):
-    """
+    """Fits frame-by-frame pose predictions.
 
-    Fits frame-by-frame pose predictions with ARIMA model (filtertype='arima') or median filter (default).
+    The pose predictions are fitted with ARIMA model (filtertype='arima') or median
+    filter (default).
 
-    Parameter
+    Parameters
     ----------
     config : string
-        Full path of the config.yaml file as a string.
+        Full path of the config.yaml file.
 
     video : string
-        Full path of the video to extract the frame from. Make sure that this video is already analyzed.
+        Full path of the video to extract the frame from. Make sure that this video is
+        already analyzed.
 
-    shuffle : int, optional
-        The shuffle index of training dataset. The extracted frames will be stored in the labeled-dataset for
-        the corresponding shuffle of training dataset. Default is set to 1
+    shuffle : int, optional, default=1
+        The shuffle index of training dataset. The extracted frames will be stored in
+        the labeled-dataset for the corresponding shuffle of training dataset.
 
-    trainingsetindex: int, optional
-        Integer specifying which TrainingsetFraction to use. By default the first (note that TrainingFraction is a list in config.yaml).
+    trainingsetindex: int, optional, default=0
+        Integer specifying which TrainingsetFraction to use.
+        Note that TrainingFraction is a list in config.yaml.
 
-    filtertype: string
-        Select which filter, 'arima', 'median' or 'spline'.
+    filtertype: string, optional, default="median".
+        The filter type - 'arima', 'median' or 'spline'.
 
-    windowlength: int
-        For filtertype='median' filters the input array using a local window-size given by windowlength. The array will automatically be zero-padded.
-        https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.medfilt.html The windowlenght should be an odd number.
+    windowlength: int, optional, default=5
+        For filtertype='median' filters the input array using a local window-size given
+        by windowlength. The array will automatically be zero-padded.
+        https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.medfilt.html.
+        The windowlenght should be an odd number.
         If filtertype='spline', windowlength is the maximal gap size to fill.
 
-    p_bound: float between 0 and 1, optional
+    p_bound: float between 0 and 1, optional, default=0.001
         For filtertype 'arima' this parameter defines the likelihood below,
         below which a body part will be consided as missing data for filtering purposes.
 
-    ARdegree: int, optional
+    ARdegree: int, optional, default=3
         For filtertype 'arima' Autoregressive degree of Sarimax model degree.
         see https://www.statsmodels.org/dev/generated/statsmodels.tsa.statespace.sarimax.SARIMAX.html
 
-    MAdegree: int
+    MAdegree: int, optional, default=1
         For filtertype 'arima' Moving Average degree of Sarimax model degree.
         See https://www.statsmodels.org/dev/generated/statsmodels.tsa.statespace.sarimax.SARIMAX.html
 
-    alpha: float
+    alpha: float, optional, default=0.01
         Significance level for detecting outliers based on confidence interval of fitted SARIMAX model.
 
-    save_as_csv: bool, optional
-        Saves the predictions in a .csv file. The default is ``False``; if provided it must be either ``True`` or ``False``
+    save_as_csv: bool, optional, default=True
+        Saves the predictions in a .csv file.
 
-    destfolder: string, optional
-        Specifies the destination folder for analysis data (default is the path of the video). Note that for subsequent analysis this
-        folder also needs to be passed.
+    destfolder: string, optional, default=None
+        Specifies the destination folder for analysis data. If ``None``, the path of
+        the video is used by default. Note that for subsequent analysis this folder
+        also needs to be passed.
 
-    track_method: string, optional
-         Specifies the tracker used to generate the data. Empty by default (corresponding to a single animal project).
-         For multiple animals, must be either 'box', 'skeleton', or 'ellipse' and will be taken from the config.yaml file if none is given.
+    modelprefix: string, optional, default=""
+        ?
 
-    Example
+    track_method: string, optional, default=""
+        Specifies the tracker used to generate the data.
+        Empty by default (corresponding to a single animal project).
+        For multiple animals, must be either 'box', 'skeleton', or 'ellipse' and will
+        be taken from the config.yaml file if none is given.
+
+    Returns
+    -------
+    None
+
+    Examples
     --------
+
     Arima model:
-    deeplabcut.filterpredictions('C:\\myproject\\reaching-task\\config.yaml',['C:\\myproject\\trailtracking-task\\test.mp4'],shuffle=3,filterype='arima',ARdegree=5,MAdegree=2)
+
+    >>> deeplabcut.filterpredictions(
+            'C:\\myproject\\reaching-task\\config.yaml',
+            ['C:\\myproject\\trailtracking-task\\test.mp4'],
+            shuffle=3,
+            filterype='arima',
+            ARdegree=5,
+            MAdegree=2,
+        )
 
     Use median filter over 10bins:
-    deeplabcut.filterpredictions('C:\\myproject\\reaching-task\\config.yaml',['C:\\myproject\\trailtracking-task\\test.mp4'],shuffle=3,windowlength=10)
+
+    >>> deeplabcut.filterpredictions(
+            'C:\\myproject\\reaching-task\\config.yaml',
+            ['C:\\myproject\\trailtracking-task\\test.mp4'],
+            shuffle=3,
+            windowlength=10,
+        )
 
     One can then use the filtered rather than the frame-by-frame predictions by calling:
 
-    deeplabcut.plot_trajectories('C:\\myproject\\reaching-task\\config.yaml',['C:\\myproject\\trailtracking-task\\test.mp4'],shuffle=3,filtered=True)
+    >>> deeplabcut.plot_trajectories(
+            'C:\\myproject\\reaching-task\\config.yaml',
+            ['C:\\myproject\\trailtracking-task\\test.mp4'],
+            shuffle=3,
+            filtered=True,
+        )
 
-    deeplabcut.create_labeled_video('C:\\myproject\\reaching-task\\config.yaml',['C:\\myproject\\trailtracking-task\\test.mp4'],shuffle=3,filtered=True)
-    --------
-
-    Returns filtered pandas array with the same structure as normal output of network.
+    >>> deeplabcut.create_labeled_video(
+            'C:\\myproject\\reaching-task\\config.yaml',
+            ['C:\\myproject\\trailtracking-task\\test.mp4'],
+            shuffle=3,
+            filtered=True,
+        )
     """
     cfg = auxiliaryfunctions.read_config(config)
     track_method = auxfun_multianimal.get_track_method(cfg, track_method=track_method)

--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -200,7 +200,7 @@ def extract_outlier_frames(
 
     Parameters
     ----------
-    config : string
+    config: str
         Full path of the config.yaml file.
 
     videos : list[str]
@@ -264,7 +264,7 @@ def extract_outlier_frames(
         Significance level for detecting outliers based on confidence interval of
         fitted ARIMA model. Only the distance is used however.
 
-    extractionalgorithm : string, optional, default="kmeans"
+    extractionalgorithm : str, optional, default="kmeans"
         String specifying the algorithm to use for selecting the frames from the
         identified putatative outlier frames. Currently, deeplabcut supports either
         ``kmeans`` or ``uniform`` based selection (same logic as for extract_frames).
@@ -295,7 +295,7 @@ def extract_outlier_frames(
         Directory containing the deeplabcut models to use when evaluating the network.
         By default, the models are assumed to exist in the project folder.
 
-    track_method: string, optional, default=""
+    track_method: str, optional, default=""
          Specifies the tracker used to generate the data.
          Empty by default (corresponding to a single animal project).
          For multiple animals, must be either 'box', 'skeleton', or 'ellipse' and will
@@ -982,7 +982,7 @@ def merge_datasets(config, forceiterate=None):
 
     Parameters
     ----------
-    config : string
+    config: str
         Full path of the config.yaml file.
 
     forceiterate: int or None, optional, default=None

--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -190,103 +190,153 @@ def extract_outlier_frames(
     modelprefix="",
     track_method="",
 ):
-    """
-    Extracts the outlier frames in case, the predictions are not correct for a certain video from the cropped video running from
-    start to stop as defined in config.yaml.
+    """Extracts the outlier frames.
 
-    Another crucial parameter in config.yaml is how many frames to extract 'numframes2extract'.
+    Extracts the outlier frames if the predictions are not correct for a certain video
+    from the cropped video running from start to stop as defined in config.yaml.
 
-    Parameter
+    Another crucial parameter in config.yaml is how many frames to extract
+    ``numframes2extract``.
+
+    Parameters
     ----------
     config : string
-        Full path of the config.yaml file as a string.
+        Full path of the config.yaml file.
 
-    videos : list
-        A list of strings containing the full paths to videos for analysis or a path to the directory, where all the videos with same extension are stored.
+    videos : list[str]
+        The full paths to videos for analysis or a path to the directory, where all the
+        videos with same extension are stored.
 
-    videotype: string, optional
-        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed.
-        If left unspecified, videos with common extensions ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
+    videotype: string, optional, default=""
+        Checks for the extension of the video in case the input to the video is a
+        directory. Only videos with this extension are analyzed.
+        If left unspecified, videos with common extensions
+        ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
 
-    shuffle : int, optional
-        The shuffle index of training dataset. The extracted frames will be stored in the labeled-dataset for
-        the corresponding shuffle of training dataset. Default is set to 1
+    shuffle : int, optional, default=1
+        The shuffle index of training dataset. The extracted frames will be stored in
+        the labeled-dataset for the corresponding shuffle of training dataset.
 
-    trainingsetindex: int, optional
-        Integer specifying which TrainingsetFraction to use. By default the first (note that TrainingFraction is a list in config.yaml).
+    trainingsetindex: int, optional, default=0
+        Integer specifying which TrainingsetFraction to use.
+        Note that TrainingFraction is a list in config.yaml.
 
-    outlieralgorithm: 'fitting', 'jump', 'uncertain', or 'manual'
-        String specifying the algorithm used to detect the outliers. Currently, deeplabcut supports three methods + a manual GUI option. 'Fitting'
-        fits a Auto Regressive Integrated Moving Average model to the data and computes the distance to the estimated data. Larger distances than
-        epsilon are then potentially identified as outliers. The methods 'jump' identifies larger jumps than 'epsilon' in any body part; and 'uncertain'
-        looks for frames with confidence below p_bound. The default is set to ``jump``.
+    outlieralgorithm: str, optional, default="jump".
+        String specifying the algorithm used to detect the outliers.
 
-    comparisonbodyparts: list of strings, optional
-        This selects the body parts for which the comparisons with the outliers are carried out. Either ``all``, then all body parts
-        from config.yaml are used orr a list of strings that are a subset of the full list.
-        E.g. ['hand','Joystick'] for the demo Reaching-Mackenzie-2018-08-30/config.yaml to select only these two body parts.
+        * ``'Fitting'`` fits a Auto Regressive Integrated Moving Average model to the
+          data and computes the distance to the estimated data. Larger distances than
+          epsilon are then potentially identified as outliers
+        * ``'jump'`` identifies larger jumps than 'epsilon' in any body part
+        * ``'uncertain'`` looks for frames with confidence below p_bound
+        * ``'manual'`` launches a GUI from which the user can choose the frames
 
-    p_bound: float between 0 and 1, optional
-        For outlieralgorithm 'uncertain' this parameter defines the likelihood below, below which a body part will be flagged as a putative outlier.
+    comparisonbodyparts: list[str] or str, optional, default="all"
+        This selects the body parts for which the comparisons with the outliers are
+        carried out. If ``"all"``, then all body parts from config.yaml are used. If a
+        list of strings that are a subset of the full list E.g. ['hand','Joystick'] for
+        the demo Reaching-Mackenzie-2018-08-30/config.yaml to select only these body
+        parts.
 
-    epsilon; float,optional
-        Meaning depends on outlieralgoritm. The default is set to 20 pixels.
-        For outlieralgorithm 'fitting': Float bound according to which frames are picked when the (average) body part estimate deviates from model fit
-        For outlieralgorithm 'jump': Float bound specifying the distance by which body points jump from one frame to next (Euclidean distance)
+    p_bound: float between 0 and 1, optional, default=0.01
+        For outlieralgorithm ``'uncertain'`` this parameter defines the likelihood
+        below which a body part will be flagged as a putative outlier.
 
-    ARdegree: int, optional
-        For outlieralgorithm 'fitting': Autoregressive degree of ARIMA model degree. (Note we use SARIMAX without exogeneous and seasonal part)
-        see https://www.statsmodels.org/dev/generated/statsmodels.tsa.statespace.sarimax.SARIMAX.html
+    epsilon: float, optional, default=20
+        If ``'outlieralgorithm'`` is ``'fitting'``, this is the float bound according
+        to which frames are picked when the (average) body part estimate deviates from
+        model fit.
 
-    MAdegree: int
-        For outlieralgorithm 'fitting': MovingAvarage degree of ARIMA model degree. (Note we use SARIMAX without exogeneous and seasonal part)
+        If ``'outlieralgorithm'`` is ``'jump'``, this is the float bound specifying the
+        distance by which body points jump from one frame to next (Euclidean distance).
+
+    ARdegree: int, optional, default=3
+        For outlieralgorithm ``'fitting'``: Autoregressive degree of ARIMA model degree.
+        (Note we use SARIMAX without exogeneous and seasonal part)
         See https://www.statsmodels.org/dev/generated/statsmodels.tsa.statespace.sarimax.SARIMAX.html
 
-    alpha: float
-        Significance level for detecting outliers based on confidence interval of fitted ARIMA model. Only the distance is used however.
+    MAdegree: int, optional, default=1
+        For outlieralgorithm ``'fitting'``: MovingAvarage degree of ARIMA model degree.
+        (Note we use SARIMAX without exogeneous and seasonal part)
+        See https://www.statsmodels.org/dev/generated/statsmodels.tsa.statespace.sarimax.SARIMAX.html
 
-    extractionalgorithm : string, optional
-        String specifying the algorithm to use for selecting the frames from the identified putatative outlier frames. Currently, deeplabcut
-        supports either ``kmeans`` or ``uniform`` based selection (same logic as for extract_frames).
-        The default is set to``uniform``, if provided it must be either ``uniform`` or ``kmeans``.
+    alpha: float, optional, default=0.01
+        Significance level for detecting outliers based on confidence interval of
+        fitted ARIMA model. Only the distance is used however.
 
-    automatic : bool, optional
-        Set it to True, if you want to extract outliers without being asked for user feedback.
+    extractionalgorithm : string, optional, default="kmeans"
+        String specifying the algorithm to use for selecting the frames from the
+        identified putatative outlier frames. Currently, deeplabcut supports either
+        ``kmeans`` or ``uniform`` based selection (same logic as for extract_frames).
 
-    cluster_resizewidth: number, default: 30
-        For k-means one can change the width to which the images are downsampled (aspect ratio is fixed).
+    automatic : bool, optional, default=False
+        If ``True``, extract outliers without being asked for user feedback.
 
-    cluster_color: bool, default: False
-        If false then each downsampled image is treated as a grayscale vector (discarding color information). If true, then the color channels are considered. This increases
-        the computational complexity.
+    cluster_resizewidth: number, default=30
+        If ``"extractionalgorithm"`` is ``"kmeans"``, one can change the width to which
+        the images are downsampled (aspect ratio is fixed).
 
-    opencv: bool, default: True
-        Uses openCV for loading & extractiong (otherwise moviepy (legacy))
+    cluster_color: bool, optional, default=False
+        If ``False``, each downsampled image is treated as a grayscale vector
+        (discarding color information). If ``True``, then the color channels are
+        considered. This increases the computational complexity.
 
-    savelabeled: bool, default: False
-        If true also saves frame with predicted labels in each folder.
+    opencv: bool, optional, default=True
+        Uses openCV for loading & extractiong (otherwise moviepy (legacy)).
 
-    destfolder: string, optional
-        Specifies the destination folder that was used for storing analysis data (default is the path of the video).
+    savelabeled: bool, optional, default=False
+        If ``True``, frame are saved with predicted labels in each folder.
 
-    track_method: string, optional
-         Specifies the tracker used to generate the data. Empty by default (corresponding to a single animal project).
-         For multiple animals, must be either 'box', 'skeleton', or 'ellipse' and will be taken from the config.yaml file if none is given.
+    destfolder: str or None, optional, default=None
+        Specifies the destination folder that was used for storing analysis data. If
+        ``None``, the path of the video is used.
+
+    modelprefix: str, optional, default=None
+        ?
+
+    track_method: string, optional, default=""
+         Specifies the tracker used to generate the data.
+         Empty by default (corresponding to a single animal project).
+         For multiple animals, must be either 'box', 'skeleton', or 'ellipse' and will
+         be taken from the config.yaml file if none is given.
+
+    Returns
+    -------
+    None
 
     Examples
+    --------
 
-    Windows example for extracting the frames with default settings
-    >>> deeplabcut.extract_outlier_frames('C:\\myproject\\reaching-task\\config.yaml',['C:\\yourusername\\rig-95\\Videos\\reachingvideo1.avi'])
-    --------
-    for extracting the frames with default settings
-    >>> deeplabcut.extract_outlier_frames('/analysis/project/reaching-task/config.yaml',['/analysis/project/video/reachinvideo1.avi'])
-    --------
-    for extracting the frames with kmeans
-    >>> deeplabcut.extract_outlier_frames('/analysis/project/reaching-task/config.yaml',['/analysis/project/video/reachinvideo1.avi'],extractionalgorithm='kmeans')
-    --------
-    for extracting the frames with kmeans and epsilon = 5 pixels.
-    >>> deeplabcut.extract_outlier_frames('/analysis/project/reaching-task/config.yaml',['/analysis/project/video/reachinvideo1.avi'],epsilon = 5,extractionalgorithm='kmeans')
-    --------
+    Extract the frames with default settings on Windows.
+
+    >>> deeplabcut.extract_outlier_frames(
+            'C:\\myproject\\reaching-task\\config.yaml',
+            ['C:\\yourusername\\rig-95\\Videos\\reachingvideo1.avi'],
+        )
+
+    Extract the frames with default settings on Linux/MacOS.
+
+    >>> deeplabcut.extract_outlier_frames(
+            '/analysis/project/reaching-task/config.yaml',
+            ['/analysis/project/video/reachinvideo1.avi'],
+        )
+
+    Extract the frames using the "kmeans" algorithm.
+
+    >>> deeplabcut.extract_outlier_frames(
+            '/analysis/project/reaching-task/config.yaml',
+            ['/analysis/project/video/reachinvideo1.avi'],
+            extractionalgorithm='kmeans',
+        )
+
+    Extract the frames using the "kmeans" algorithm and ``"epsilon=5"`` pixels.
+
+    >>> deeplabcut.extract_outlier_frames(
+            '/analysis/project/reaching-task/config.yaml',
+            ['/analysis/project/video/reachinvideo1.avi'],
+            epsilon=5,
+            extractionalgorithm='kmeans',
+        )
     """
 
     cfg = auxiliaryfunctions.read_config(config)
@@ -921,22 +971,27 @@ def PlottingSingleFramecv2(
 
 
 def merge_datasets(config, forceiterate=None):
-    """
-    Checks if the original training dataset can be merged with the newly refined training dataset. To do so it will check
-    if the frames in all extracted video sets were relabeled. If this is the case then the iterate variable is advanced by 1.
+    """Merge the original training dataset with the newly refined data.
 
-    Parameter
+    Checks if the original training dataset can be merged with the newly refined
+    training dataset. To do so it will check if the frames in all extracted video sets
+    were relabeled.
+
+    If this is the case then the ``"iteration"`` variable is advanced by 1.
+
+    Parameters
     ----------
     config : string
-        Full path of the config.yaml file as a string.
+        Full path of the config.yaml file.
 
-    forceiterate: int, optional
-        If an integer is given the iteration variable is set to this value (this is only done if all datasets were labeled or refined)
+    forceiterate: int or None, optional, default=None
+        If an integer is given the iteration variable is set to this value
+        This is only done if all datasets were labeled or refined.
 
-    Example
+    Examples
     --------
+
     >>> deeplabcut.merge_datasets('/analysis/project/reaching-task/config.yaml')
-    --------
     """
 
     cfg = auxiliaryfunctions.read_config(config)

--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -207,7 +207,7 @@ def extract_outlier_frames(
         The full paths to videos for analysis or a path to the directory, where all the
         videos with same extension are stored.
 
-    videotype: string, optional, default=""
+    videotype: str, optional, default=""
         Checks for the extension of the video in case the input to the video is a
         directory. Only videos with this extension are analyzed.
         If left unspecified, videos with common extensions
@@ -291,8 +291,9 @@ def extract_outlier_frames(
         Specifies the destination folder that was used for storing analysis data. If
         ``None``, the path of the video is used.
 
-    modelprefix: str, optional, default=None
-        ?
+    modelprefix: str, optional, default=""
+        Directory containing the deeplabcut models to use when evaluating the network.
+        By default, the models are assumed to exist in the project folder.
 
     track_method: string, optional, default=""
          Specifies the tracker used to generate the data.

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -362,103 +362,156 @@ def create_labeled_video(
     modelprefix="",
     track_method="",
 ):
-    """
-    Labels the bodyparts in a video. Make sure the video is already analyzed by the function 'analyze_video'
+    """Labels the bodyparts in a video.
+
+    Make sure the video is already analyzed by the function
+    ``deeplabcut.analyze_videos``.
 
     Parameters
     ----------
     config : string
-        Full path of the config.yaml file as a string.
+        Full path of the config.yaml file.
 
-    videos : list
-        A list of strings containing the full paths to videos for analysis or a path to the directory, where all the videos with same extension are stored.
+    videos : list[str]
+        A list of strings containing the full paths to videos for analysis or a path
+        to the directory, where all the videos with same extension are stored.
 
-    videotype: string, optional
-        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed.
-        If left unspecified, videos with common extensions ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
+    videotype: string, optional, default=""
+        Checks for the extension of the video in case the input to the video is a
+        directory. Only videos with this extension are analyzed.
+        If left unspecified, videos with common extensions
+        ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
 
-    shuffle : int, optional
-        Number of shuffles of training dataset. Default is set to 1.
+    shuffle : int, optional, default=1
+        Number of shuffles of training dataset.
 
-    trainingsetindex: int, optional
-        Integer specifying which TrainingsetFraction to use. By default the first (note that TrainingFraction is a list in config.yaml).
+    trainingsetindex: int, optional, default=0
+        Integer specifying which TrainingsetFraction to use.
+        Note that TrainingFraction is a list in config.yaml.
 
-    filtered: bool, default false
-        Boolean variable indicating if filtered output should be plotted rather than frame-by-frame predictions. Filtered version can be calculated with deeplabcut.filterpredictions
+    filtered: bool, optional, default=False
+        Boolean variable indicating if filtered output should be plotted rather than
+        frame-by-frame predictions. Filtered version can be calculated with
+        ``deeplabcut.filterpredictions``.
 
-    fastmode: bool
-        If true uses openCV (much faster but less customization of video) vs matplotlib (if false). You can also
-        "save_frames" individually or not in the matplotlib mode (if you set the "save_frames" variable accordingly).
-        However, using matplotlib to create the frames it therefore allows much more flexible (one can set transparency of markers, crop, and easily customize).
+    fastmode: bool, optional, default=True
+        If ``True``, uses openCV (much faster but less customization of video) instead
+        of matplotlib if ``False``. You can also "save_frames" individually or not in
+        the matplotlib mode (if you set the "save_frames" variable accordingly).
+        However, using matplotlib to create the frames it therefore allows much more
+        flexible (one can set transparency of markers, crop, and easily customize).
 
-    save_frames: bool
-        If true creates each frame individual and then combines into a video. This variant is relatively slow as
-        it stores all individual frames.
+    save_frames: bool, optional, default=False
+        If ``True``, creates each frame individual and then combines into a video.
+        Setting this to ``True`` is relatively slow as it stores all individual frames.
 
-    keypoints_only: bool, optional
-        By default, both video frames and keypoints are visible. If true, only the keypoints are shown. These clips are an hommage to Johansson movies,
-        see https://www.youtube.com/watch?v=1F5ICP9SYLU and of course his seminal paper: "Visual perception of biological motion and a model for its analysis"
+    keypoints_only: bool, optional, default=False
+        By default, both video frames and keypoints are visible. If ``True``, only the
+        keypoints are shown. These clips are an hommage to Johansson movies,
+        see https://www.youtube.com/watch?v=1F5ICP9SYLU and of course his seminal
+        paper: "Visual perception of biological motion and a model for its analysis"
         by Gunnar Johansson in Perception & Psychophysics 1973.
 
-    Frames2plot: List of indices
-        If not None & save_frames=True then the frames corresponding to the index will be plotted. For example, Frames2plot=[0,11] will plot the first and the 12th frame.
+    Frames2plot: List[int] or None, optional, default=None
+        If not ``None`` and ``save_frames=True`` then the frames corresponding to the
+        index will be plotted. For example, ``Frames2plot=[0,11]`` will plot the first
+        and the 12th frame.
 
-    displayedbodyparts: list of strings, optional
-        This selects the body parts that are plotted in the video. Either ``all``, then all body parts
-        from config.yaml are used orr a list of strings that are a subset of the full list.
-        E.g. ['hand','Joystick'] for the demo Reaching-Mackenzie-2018-08-30/config.yaml to select only these two body parts.
+    displayedbodyparts: list[str] or str, optional, default="all"
+        This selects the body parts that are plotted in the video. If ``all``, then all
+        body parts from config.yaml are used. If a list of strings that are a subset of
+        the full list. E.g. ['hand','Joystick'] for the demo
+        Reaching-Mackenzie-2018-08-30/config.yaml to select only these body parts.
 
-    displayedindividuals: list of strings, optional
-        Individuals plotted in the video. By default, all individuals present in the config will be showed.
+    displayedindividuals: list[str] or str, optional, default="all"
+        Individuals plotted in the video.
+        By default, all individuals present in the config will be showed.
 
-    codec: codec for labeled video. Options see http://www.fourcc.org/codecs.php [depends on your ffmpeg installation.]
+    codec: str, optional, default="mp4v"
+        Codec for labeled video. For available options, see
+        http://www.fourcc.org/codecs.php. Note that this depends on your ffmpeg
+        installation.
 
-    outputframerate: positive number, output frame rate for labeled video (only available for the mode with saving frames.) By default: None, which results in the original video rate.
+    outputframerate: int or None, optional, default=None
+        Positive number, output frame rate for labeled video (only available for the
+        mode with saving frames.) If ``None``, which results in the original video
+        rate.
 
-    destfolder: string, optional
-        Specifies the destination folder that was used for storing analysis data (default is the path of the video).
+    destfolder: string or None, optional, default=None
+        Specifies the destination folder that was used for storing analysis data. If
+        ``None``, the path of the video file is used.
 
-    draw_skeleton: bool
-        If ``True`` adds a line connecting the body parts making a skeleton on on each frame. The body parts to be connected and the color of these connecting lines are specified in the config file. By default: ``False``
+    draw_skeleton: bool, optional, default=False
+        If ``True`` adds a line connecting the body parts making a skeleton on each
+        frame. The body parts to be connected and the color of these connecting lines
+        are specified in the config file.
 
-    trailpoints: int
-        Number of revious frames whose body parts are plotted in a frame (for displaying history). Default is set to 0.
+    trailpoints: int, optional, default=0
+        Number of previous frames whose body parts are plotted in a frame
+        (for displaying history).
 
-    displaycropped: bool, optional
-        Specifies whether only cropped frame is displayed (with labels analyzed therein), or the original frame with the labels analyzed in the cropped subset.
+    displaycropped: bool, optional, default=False
+        Specifies whether only cropped frame is displayed (with labels analyzed
+        therein), or the original frame with the labels analyzed in the cropped subset.
 
-    color_by : string, optional (default='bodypart')
+    color_by : string, optional, default='bodypart'
         Coloring rule. By default, each bodypart is colored differently.
-        If set to 'individual', points belonging to a single individual are colored the same.
+        If set to 'individual', points belonging to a single individual are colored the
+        same.
 
-    track_method: string, optional
-         Specifies the tracker used to generate the data. Empty by default (corresponding to a single animal project).
-         For multiple animals, must be either 'box', 'skeleton', or 'ellipse' and will be taken from the config.yaml file if none is given.
+    track_method: string, optional, default=""
+        Specifies the tracker used to generate the data.
+        Empty by default (corresponding to a single animal project).
+        For multiple animals, must be either 'box', 'skeleton', or 'ellipse' and will
+        be taken from the config.yaml file if none is given.
 
+    Returns
+    -------
+    None
 
     Examples
     --------
-    If you want to create the labeled video for only 1 video
-    >>> deeplabcut.create_labeled_video('/analysis/project/reaching-task/config.yaml',['/analysis/project/videos/reachingvideo1.avi'])
-    --------
 
-    If you want to create the labeled video for only 1 video and store the individual frames
-    >>> deeplabcut.create_labeled_video('/analysis/project/reaching-task/config.yaml',['/analysis/project/videos/reachingvideo1.avi'],fastmode=True, save_frames=True)
-    --------
+    Create the labeled video for a single video
 
-    If you want to create the labeled video for multiple videos
-    >>> deeplabcut.create_labeled_video('/analysis/project/reaching-task/config.yaml',['/analysis/project/videos/reachingvideo1.avi','/analysis/project/videos/reachingvideo2.avi'])
-    --------
+    >>> deeplabcut.create_labeled_video(
+            '/analysis/project/reaching-task/config.yaml',
+            ['/analysis/project/videos/reachingvideo1.avi'],
+        )
 
-    If you want to create the labeled video for all the videos (as .avi extension) in a directory.
-    >>> deeplabcut.create_labeled_video('/analysis/project/reaching-task/config.yaml',['/analysis/project/videos/'])
+    Create the labeled video for a single video and store the individual frames
 
-    --------
-    If you want to create the labeled video for all the videos (as .mp4 extension) in a directory.
-    >>> deeplabcut.create_labeled_video('/analysis/project/reaching-task/config.yaml',['/analysis/project/videos/'],videotype='mp4')
+    >>> deeplabcut.create_labeled_video(
+            '/analysis/project/reaching-task/config.yaml',
+            ['/analysis/project/videos/reachingvideo1.avi'],
+            fastmode=True,
+            save_frames=True,
+        )
 
-    --------
+    Create the labeled video for multiple videos
 
+    >>> deeplabcut.create_labeled_video(
+            '/analysis/project/reaching-task/config.yaml',
+            [
+                '/analysis/project/videos/reachingvideo1.avi',
+                '/analysis/project/videos/reachingvideo2.avi',
+            ],
+        )
+
+    Create the labeled video for all the videos with an .avi extension in a directory.
+
+    >>> deeplabcut.create_labeled_video(
+            '/analysis/project/reaching-task/config.yaml',
+            ['/analysis/project/videos/'],
+        )
+
+    Create the labeled video for all the videos with an .mp4 extension in a directory.
+
+    >>> deeplabcut.create_labeled_video(
+            '/analysis/project/reaching-task/config.yaml',
+            ['/analysis/project/videos/'],
+            videotype='mp4',
+        )
     """
     cfg = auxiliaryfunctions.read_config(config)
     track_method = auxfun_multianimal.get_track_method(cfg, track_method=track_method)

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -376,7 +376,7 @@ def create_labeled_video(
         A list of strings containing the full paths to videos for analysis or a path
         to the directory, where all the videos with same extension are stored.
 
-    videotype: string, optional, default=""
+    videotype: str, optional, default=""
         Checks for the extension of the video in case the input to the video is a
         directory. Only videos with this extension are analyzed.
         If left unspecified, videos with common extensions
@@ -458,6 +458,10 @@ def create_labeled_video(
         Coloring rule. By default, each bodypart is colored differently.
         If set to 'individual', points belonging to a single individual are colored the
         same.
+
+    modelprefix: str, optional, default=""
+        Directory containing the deeplabcut models to use when evaluating the network.
+        By default, the models are assumed to exist in the project folder.
 
     track_method: string, optional, default=""
         Specifies the tracker used to generate the data.

--- a/deeplabcut/utils/plotting.py
+++ b/deeplabcut/utils/plotting.py
@@ -188,7 +188,7 @@ def plot_trajectories(
         Full paths to videos for analysis or a path to the directory, where all the
         videos with same extension are stored.
 
-    videotype: string, optional, default=""
+    videotype: str, optional, default=""
         Checks for the extension of the video in case the input to the video is a
         directory. Only videos with this extension are analyzed.
         If left unspecified, videos with common extensions
@@ -219,6 +219,10 @@ def plot_trajectories(
     destfolder: string or None, optional, default=None
         Specifies the destination folder that was used for storing analysis data. If
         ``None``, the path of the video is used.
+
+    modelprefix: str, optional, default=""
+        Directory containing the deeplabcut models to use when evaluating the network.
+        By default, the models are assumed to exist in the project folder.
 
     imagetype: string, optional, default=".png"
         Specifies the output image format - '.tif', '.jpg', '.svg' and ".png".

--- a/deeplabcut/utils/plotting.py
+++ b/deeplabcut/utils/plotting.py
@@ -194,8 +194,8 @@ def plot_trajectories(
         If left unspecified, videos with common extensions
         ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
 
-    shuffle: list, optional, default=1
-        List of integers specifying the shuffle indices of the training dataset.
+    shuffle: int, optional, default=1
+        Integer specifying the shuffle index of the training dataset.
 
     trainingsetindex: int, optional, default=0
         Integer specifying which TrainingsetFraction to use.

--- a/deeplabcut/utils/plotting.py
+++ b/deeplabcut/utils/plotting.py
@@ -177,61 +177,78 @@ def plot_trajectories(
     linewidth=1.0,
     track_method="",
 ):
-    """
-    Plots the trajectories of various bodyparts across the video.
+    """Plots the trajectories of various bodyparts across the video.
 
     Parameters
     ----------
-     config : string
-    Full path of the config.yaml file as a string.
+    config: string
+        Full path of the config.yaml file as a string.
 
-    videos : list
-        A list of strings containing the full paths to videos for analysis or a path to the directory, where all the videos with same extension are stored.
+    videos: list[str]
+        Full paths to videos for analysis or a path to the directory, where all the
+        videos with same extension are stored.
 
-    videotype: string, optional
-        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed.
-        If left unspecified, videos with common extensions ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
+    videotype: string, optional, default=""
+        Checks for the extension of the video in case the input to the video is a
+        directory. Only videos with this extension are analyzed.
+        If left unspecified, videos with common extensions
+        ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
 
-    shuffle: list, optional
-    List of integers specifying the shuffle indices of the training dataset. The default is [1]
+    shuffle: list, optional, default=1
+        List of integers specifying the shuffle indices of the training dataset.
 
-    trainingsetindex: int, optional
-    Integer specifying which TrainingsetFraction to use. By default the first (note that TrainingFraction is a list in config.yaml).
+    trainingsetindex: int, optional, default=0
+        Integer specifying which TrainingsetFraction to use.
+        Note that TrainingFraction is a list in config.yaml.
 
-    filtered: bool, default false
-    Boolean variable indicating if filtered output should be plotted rather than frame-by-frame predictions. Filtered version can be calculated with deeplabcut.filterpredictions
+    filtered: bool, optional, default=False
+        Boolean variable indicating if filtered output should be plotted rather than
+        frame-by-frame predictions. Filtered version can be calculated with
+        ``deeplabcut.filterpredictions``.
 
-    displayedbodyparts: list of strings, optional
+    displayedbodyparts: list[str] or str, optional, default="all"
         This select the body parts that are plotted in the video.
         Either ``all``, then all body parts from config.yaml are used,
         or a list of strings that are a subset of the full list.
-        E.g. ['hand','Joystick'] for the demo Reaching-Mackenzie-2018-08-30/config.yaml to select only these two body parts.
+        E.g. ['hand','Joystick'] for the demo Reaching-Mackenzie-2018-08-30/config.yaml
+        to select only these two body parts.
 
-    showfigures: bool, default false
-    If true then plots are also displayed.
+    showfigures: bool, optional, default=False
+        If ``True`` then plots are also displayed.
 
-    destfolder: string, optional
-        Specifies the destination folder that was used for storing analysis data (default is the path of the video).
+    destfolder: string or None, optional, default=None
+        Specifies the destination folder that was used for storing analysis data. If
+        ``None``, the path of the video is used.
 
-    imagetype: string, default ".png"
-        Specifies the output image format, tested '.tif', '.jpg', '.svg' and ".png".
+    imagetype: string, optional, default=".png"
+        Specifies the output image format - '.tif', '.jpg', '.svg' and ".png".
 
-    resolution: int, default 100
-        Specifies the resolution (in dpi) of saved figures. Note higher resolution figures take longer to generate.
+    resolution: int, optional, default=100
+        Specifies the resolution (in dpi) of saved figures.
+        Note higher resolution figures take longer to generate.
 
-    linewidth: float, default 1.0
+    linewidth: float, optional, default=1.0
         Specifies width of line for line and histogram plots.
 
-    track_method: string, optional
-         Specifies the tracker used to generate the data. Empty by default (corresponding to a single animal project).
-         For multiple animals, must be either 'box', 'skeleton', or 'ellipse' and will be taken from the config.yaml file if none is given.
+    track_method: string, optional, default=""
+         Specifies the tracker used to generate the data.
+         Empty by default (corresponding to a single animal project).
+         For multiple animals, must be either 'box', 'skeleton', or 'ellipse' and will
+         be taken from the config.yaml file if none is given.
 
-    Example
-    --------
-    for labeling the frames
-    >>> deeplabcut.plot_trajectories('home/alex/analysis/project/reaching-task/config.yaml',['/home/alex/analysis/project/videos/reachingvideo1.avi'])
+    Returns
+    -------
+    None
+
+    Examples
     --------
 
+    To label the frames
+
+    >>> deeplabcut.plot_trajectories(
+            'home/alex/analysis/project/reaching-task/config.yaml',
+            ['/home/alex/analysis/project/videos/reachingvideo1.avi'],
+        )
     """
     cfg = auxiliaryfunctions.read_config(config)
     track_method = auxfun_multianimal.get_track_method(cfg, track_method=track_method)

--- a/deeplabcut/utils/plotting.py
+++ b/deeplabcut/utils/plotting.py
@@ -181,8 +181,8 @@ def plot_trajectories(
 
     Parameters
     ----------
-    config: string
-        Full path of the config.yaml file as a string.
+    config: str
+        Full path of the config.yaml file.
 
     videos: list[str]
         Full paths to videos for analysis or a path to the directory, where all the

--- a/docs/api/deeplabcut.analyze_videos.rst
+++ b/docs/api/deeplabcut.analyze_videos.rst
@@ -1,0 +1,1 @@
+.. autofunction:: deeplabcut.pose_estimation_tensorflow.predict_videos.analyze_videos

--- a/docs/api/deeplabcut.analyzeskeleton.rst
+++ b/docs/api/deeplabcut.analyzeskeleton.rst
@@ -1,0 +1,1 @@
+.. autofunction:: deeplabcut.post_processing.analyze_skeleton.analyzeskeleton

--- a/docs/api/deeplabcut.create_labeled_video.rst
+++ b/docs/api/deeplabcut.create_labeled_video.rst
@@ -1,0 +1,1 @@
+.. autofunction:: deeplabcut.utils.make_labeled_video.create_labeled_video

--- a/docs/api/deeplabcut.create_training_model_comparison.rst
+++ b/docs/api/deeplabcut.create_training_model_comparison.rst
@@ -1,0 +1,1 @@
+.. autofunction:: deeplabcut.generate_training_dataset.trainingsetmanipulation.create_training_model_comparison

--- a/docs/api/deeplabcut.evaluate_network.rst
+++ b/docs/api/deeplabcut.evaluate_network.rst
@@ -1,0 +1,1 @@
+.. autofunction:: deeplabcut.pose_estimation_tensorflow.core.evaluate.evaluate_network

--- a/docs/api/deeplabcut.extract_outlier_frames.rst
+++ b/docs/api/deeplabcut.extract_outlier_frames.rst
@@ -1,0 +1,1 @@
+.. autofunction:: deeplabcut.refine_training_dataset.outlier_frames.extract_outlier_frames

--- a/docs/api/deeplabcut.filterpredictions.rst
+++ b/docs/api/deeplabcut.filterpredictions.rst
@@ -1,0 +1,1 @@
+.. autofunction:: deeplabcut.post_processing.filtering.filterpredictions

--- a/docs/api/deeplabcut.label_frames.rst
+++ b/docs/api/deeplabcut.label_frames.rst
@@ -1,0 +1,1 @@
+.. autofunction:: deeplabcut.gui.label_frames.label_frames

--- a/docs/api/deeplabcut.merge_datasets.rst
+++ b/docs/api/deeplabcut.merge_datasets.rst
@@ -1,0 +1,1 @@
+.. autofunction:: deeplabcut.refine_training_dataset.outlier_frames.merge_datasets

--- a/docs/api/deeplabcut.plot_trajectories.rst
+++ b/docs/api/deeplabcut.plot_trajectories.rst
@@ -1,0 +1,1 @@
+.. autofunction:: deeplabcut.utils.plotting.plot_trajectories

--- a/docs/api/deeplabcut.refine_labels.rst
+++ b/docs/api/deeplabcut.refine_labels.rst
@@ -1,0 +1,1 @@
+.. autofunction:: deeplabcut.gui.refine_labels.refine_labels

--- a/docs/standardDeepLabCut_UserGuide.md
+++ b/docs/standardDeepLabCut_UserGuide.md
@@ -266,7 +266,6 @@ The variables ``display_iters`` and ``save_iters`` in the **pose_cfg.yaml** file
 ```
 
 ### (H) Evaluate the Trained Network
-[DOCSTRING](https://github.com/DeepLabCut/DeepLabCut/wiki/DOCSTRINGS#evaluate_network)
 
 It is important to evaluate the performance of the trained network. This performance is measured by computing
 the mean average Euclidean error (MAE; which is proportional to the average root mean square error) between the
@@ -326,8 +325,14 @@ deeplabcut.extract_save_all_maps(config_path, shuffle=shuffle, Indices=[0, 5])
 ```
 you can drop "Indices" to run this on all training/testing images (this is slow!)
 
+#### API Docs
+```{admonition} Click the button to see API Docs
+:class: dropdown
+```{eval-rst}
+.. include:: ./api/deeplabcut.evaluate_network.rst
+```
+
 ### (I) Novel Video Analysis:
-[DOCSTRING](https://github.com/DeepLabCut/DeepLabCut/wiki/DOCSTRINGS#analyze_videos)
 
 The trained network can be used to analyze new videos. The user needs to first choose a checkpoint with the best
 evaluation results for analyzing the videos. In this case, the user can enter the corresponding index of the checkpoint
@@ -346,6 +351,13 @@ However, if the flag ``save_as_csv`` is set to ``True``, the data can also be ex
 (.csv), which in turn can be imported in many programs, such as MATLAB, R, Prism, etc.; This flag is set to ``False``
 by default. You can also set a destination folder (``destfolder``) for the output files by passing a path of the folder you wish to write to.
 
+#### API Docs
+```{admonition} Click the button to see API Docs
+:class: dropdown
+```{eval-rst}
+.. include:: ./api/deeplabcut.analyze_videos.rst
+```
+
 ### (I) Novel Video Analysis: extra features
 
 #### Dynamic-cropping of videos:
@@ -358,7 +370,6 @@ dynamic: triple containing (state, detectiontreshold, margin)
         If the state is true, then dynamic cropping will be performed. That means that if an object is detected (i.e., any body part > detectiontreshold), then object boundaries are computed according to the smallest/largest x position and smallest/largest y position of all body parts. This window is expanded by the margin and from then on only the posture within this crop is analyzed (until the object is lost; i.e., <detectiontreshold). The current position is utilized for updating the crop window for the next frame (this is why the margin is important and should be set large enough given the movement of the animal).
 ```
 #### Filter data (RECOMMENDED!):
-[DOCSTRING](https://github.com/DeepLabCut/DeepLabCut/wiki/DOCSTRINGS#filterpredictions)
 
 You can also filter the predictions with a median filter (default) or with a [SARIMAX model](https://www.statsmodels.org/dev/generated/statsmodels.tsa.statespace.sarimax.SARIMAX.html), if you wish. This creates a new .h5 file with the ending *_filtered* that you can use in create_labeled_data and/or plot trajectories.
 ```python
@@ -378,8 +389,14 @@ deeplabcut.filterpredictions(config_path, ['fullpath/analysis/project/videos/rea
 <img src="https://static1.squarespace.com/static/57f6d51c9f74566f55ecf271/t/5ccc8b8ae6e8df000100a995/1556908943893/filter_example-01.png?format=1000w" width="70%">
 </p>
 
+##### API Docs
+```{admonition} Click the button to see API Docs
+:class: dropdown
+```{eval-rst}
+.. include:: ./api/deeplabcut.filterpredictions.rst
+```
+
 #### Plot Trajectories:
-[DOCSTRING](https://github.com/DeepLabCut/DeepLabCut/wiki/DOCSTRINGS#plot_trajectories)
 
 The plotting components of this toolbox utilizes matplotlib. Therefore, these plots can easily be customized by
 the end user. We also provide a function to plot the trajectory of the extracted poses across the analyzed video, which
@@ -388,15 +405,22 @@ can be called by typing:
 ```
 deeplabcut.plot_trajectories(config_path, [‘fullpath/analysis/project/videos/reachingvideo1.avi’])
 ```
- It creates a folder called ``plot-poses`` (in the directory of the video). The plots display the coordinates of body parts vs. time, likelihoods vs time, the x- vs. y- coordinate of the body parts, as well as histograms of consecutive coordinate differences. These plots help the user to quickly assess the tracking performance for a video. Ideally, the likelihood stays high and the histogram of consecutive coordinate differences has values close to zero (i.e. no jumps in body part detections across frames). Here are example plot outputs on a demo video (left):
+
+It creates a folder called ``plot-poses`` (in the directory of the video). The plots display the coordinates of body parts vs. time, likelihoods vs time, the x- vs. y- coordinate of the body parts, as well as histograms of consecutive coordinate differences. These plots help the user to quickly assess the tracking performance for a video. Ideally, the likelihood stays high and the histogram of consecutive coordinate differences has values close to zero (i.e. no jumps in body part detections across frames). Here are example plot outputs on a demo video (left):
 
 <p align="center">
 <img src="https://images.squarespace-cdn.com/content/v1/57f6d51c9f74566f55ecf271/1559946148685-WHDO5IG9MMCHU0T7RC62/ke17ZwdGBToddI8pDm48kEOb1vFO6oRDmR8SXh4iL21Zw-zPPgdn4jUwVcJE1ZvWEtT5uBSRWt4vQZAgTJucoTqqXjS3CfNDSuuf31e0tVG1gXK66ltnjKh4U2immgm7AVAdfOWODmXNLQLqbLRZ2DqWIIaSPh2v08GbKqpiV54/file0289.png?format=500w" height="240">
 <img src="https://images.squarespace-cdn.com/content/v1/57f6d51c9f74566f55ecf271/1559939762886-CCB0R107I2HXAHZLHECP/ke17ZwdGBToddI8pDm48kNeA8e5AnyMqj80u4_mB0hV7gQa3H78H3Y0txjaiv_0fDoOvxcdMmMKkDsyUqMSsMWxHk725yiiHCCLfrh8O1z5QPOohDIaIeljMHgDF5CVlOqpeNLcJ80NK65_fV7S1UcpboONgOQYHLzaUWEI1Ir9fXt7Ehyn7DSgU3GCReAA-ZDqXZYzu2fuaodM4POSZ4w/plot_poses-01.png?format=1000w" height="250">
 </p>
 
+##### API Docs
+```{admonition} Click the button to see API Docs
+:class: dropdown
+```{eval-rst}
+.. include:: ./api/deeplabcut.plot_trajectories.rst
+```
+
 #### Create Labeled Videos:
-[DOCSTRING](https://github.com/DeepLabCut/DeepLabCut/wiki/DOCSTRINGS#create_labeled_video)
 
 Additionally, the toolbox provides a function to create labeled videos based on the extracted poses by plotting the
 labels on top of the frame and creating a video. There are two modes to create videos: FAST and SLOW (but higher quality!). If you want to create high-quality videos, please add ``save_frames=True``. One can use the command as follows to create multiple labeled videos:
@@ -440,19 +464,14 @@ deeplabcut.create_labeled_video(config_path,['fullpath/afolderofvideos'], videot
 <img src="https://images.squarespace-cdn.com/content/v1/57f6d51c9f74566f55ecf271/1559935526258-KFYZC8BDHK01ZIDPNVIX/ke17ZwdGBToddI8pDm48kJbosy0LGK_KqcAZRQ_Qph1Zw-zPPgdn4jUwVcJE1ZvWQUxwkmyExglNqGp0IvTJZUJFbgE-7XRK3dMEBRBhUpzkC6kmM1CbNgeHQVxASNv0wiXikHv274BIFe4LR7nd1rKmAka4uxYMJ9FupazBoaU/mouse_skel_trail.gif?format=750w" width="40%">
 </p>
 
-**Other optional Parameters:**
-```
-videotype: string, optional. Checks for the extension of the video in case the input is a directory. Only videos with this extension are analyzed. The default is ``.avi``
-
-save_frames: bool (i.e. True or False). If true creates each frame individually and then combines into a video. This variant is relatively slow as it stores all individual frames. However, it uses matplotlib to create the frames and is therefore much more flexible (one can set transparency of markers, crop, and easily customize).
-
-delete: bool (i.e. True or False). If true then the individual frames created during the video generation will be deleted.
-
-displayedbodyparts: list of strings, optional. This selects the body parts that are plotted in the video. Either `all`, then all body parts from config.yaml are used or a list of strings that are a subset of the full list. E.g. ['Hand','Joystick'] for the demo Reaching-Mackenzie-2018-08-30/config.yaml to select only these two body parts.
-
-displaycropped: If =True then the video will be cropped (to the size in  the config.yaml file) and points plotted.
-```
 This function has various other parameters, in particular the user can set the ``colormap``, the ``dotsize``, and ``alphavalue`` of the labels in **config.yaml** file.
+
+##### API Docs
+```{admonition} Click the button to see API Docs
+:class: dropdown
+```{eval-rst}
+.. include:: ./api/deeplabcut.create_labeled_video.rst
+```
 
 ### Extract "Skeleton" Features:
 
@@ -461,8 +480,13 @@ NEW, as of 2.0.7+: You can save the "skeleton" that was applied in ``create_labe
 ```python
 deeplabcut.analyzeskeleton(config, video, videotype='avi', shuffle=1, trainingsetindex=0, save_as_csv=False, destfolder=None)
 ```
-See more details here: https://github.com/DeepLabCut/DeepLabCut/blob/master/deeplabcut/post_processing/analyze_skeleton.py
 
+##### API Docs
+```{admonition} Click the button to see API Docs
+:class: dropdown
+```{eval-rst}
+.. include:: ./api/deeplabcut.analyzeskeleton.rst
+```
 
 ### (J) Optional Active Learning -> Network Refinement: Extract Outlier Frames
 
@@ -511,6 +535,13 @@ list (``extractionalgorithm='uniform'``), by performing ``extractionalgorithm='k
 
 In the automatic configuration, before the frame selection happens, the user is informed about the amount of frames satisfying the criteria and asked if the selection should proceed. This step allows the user to perhaps change the parameters of the frame-selection heuristics first (i.e. to make sure that not too many frames are qualified). The user can run the extract_outlier_frames iteratively, and (even) extract additional frames from the same video. Once enough outlier frames are extracted the refinement GUI can be used to adjust the labels based on user feedback (see below).
 
+#### API Docs
+```{admonition} Click the button to see API Docs
+:class: dropdown
+```{eval-rst}
+.. include:: ./api/deeplabcut.extract_outlier_frames.rst
+```
+
  ### (K) Refine Labels: Augmentation of the Training Dataset
 
  Based on the performance of DeepLabCut, four scenarios are possible:
@@ -551,6 +582,13 @@ automatically done).
 Now you can run ``create_training_dataset``, then ``train_network``, etc. If your original labels were adjusted at all, start from fresh weights (the typically recommended path anyhow), otherwise consider using your already trained network weights (see Box 2).
 
 If after training the network generalizes well to the data, proceed to analyze new videos. Otherwise, consider labeling more data.
+
+#### API Docs
+```{admonition} Click the button to see API Docs for merge_datasets
+:class: dropdown
+```{eval-rst}
+.. include:: ./api/deeplabcut.merge_datasets.rst
+```
 
 ### Jupyter Notebooks for Demonstration of the DeepLabCut Workflow
 

--- a/docs/standardDeepLabCut_UserGuide.md
+++ b/docs/standardDeepLabCut_UserGuide.md
@@ -371,7 +371,7 @@ by default. You can also set a destination folder (``destfolder``) for the outpu
 .. include:: ./api/deeplabcut.analyze_videos.rst
 ```
 
-### (I) Novel Video Analysis: extra features
+### Novel Video Analysis: extra features
 
 #### Dynamic-cropping of videos:
 
@@ -382,7 +382,7 @@ dynamic: triple containing (state, detectiontreshold, margin)
 
         If the state is true, then dynamic cropping will be performed. That means that if an object is detected (i.e., any body part > detectiontreshold), then object boundaries are computed according to the smallest/largest x position and smallest/largest y position of all body parts. This window is expanded by the margin and from then on only the posture within this crop is analyzed (until the object is lost; i.e., <detectiontreshold). The current position is utilized for updating the crop window for the next frame (this is why the margin is important and should be set large enough given the movement of the animal).
 ```
-#### Filter data (RECOMMENDED!):
+### (J) Filter pose data data (RECOMMENDED!):
 
 You can also filter the predictions with a median filter (default) or with a [SARIMAX model](https://www.statsmodels.org/dev/generated/statsmodels.tsa.statespace.sarimax.SARIMAX.html), if you wish. This creates a new .h5 file with the ending *_filtered* that you can use in create_labeled_data and/or plot trajectories.
 ```python
@@ -402,14 +402,14 @@ deeplabcut.filterpredictions(config_path, ['fullpath/analysis/project/videos/rea
 <img src="https://static1.squarespace.com/static/57f6d51c9f74566f55ecf271/t/5ccc8b8ae6e8df000100a995/1556908943893/filter_example-01.png?format=1000w" width="70%">
 </p>
 
-##### API Docs
+#### API Docs
 ```{admonition} Click the button to see API Docs
 :class: dropdown
 ```{eval-rst}
 .. include:: ./api/deeplabcut.filterpredictions.rst
 ```
 
-#### Plot Trajectories:
+### (K) Plot Trajectories:
 
 The plotting components of this toolbox utilizes matplotlib. Therefore, these plots can easily be customized by
 the end user. We also provide a function to plot the trajectory of the extracted poses across the analyzed video, which
@@ -426,14 +426,14 @@ It creates a folder called ``plot-poses`` (in the directory of the video). The p
 <img src="https://images.squarespace-cdn.com/content/v1/57f6d51c9f74566f55ecf271/1559939762886-CCB0R107I2HXAHZLHECP/ke17ZwdGBToddI8pDm48kNeA8e5AnyMqj80u4_mB0hV7gQa3H78H3Y0txjaiv_0fDoOvxcdMmMKkDsyUqMSsMWxHk725yiiHCCLfrh8O1z5QPOohDIaIeljMHgDF5CVlOqpeNLcJ80NK65_fV7S1UcpboONgOQYHLzaUWEI1Ir9fXt7Ehyn7DSgU3GCReAA-ZDqXZYzu2fuaodM4POSZ4w/plot_poses-01.png?format=1000w" height="250">
 </p>
 
-##### API Docs
+#### API Docs
 ```{admonition} Click the button to see API Docs
 :class: dropdown
 ```{eval-rst}
 .. include:: ./api/deeplabcut.plot_trajectories.rst
 ```
 
-#### Create Labeled Videos:
+### (L) Create Labeled Videos:
 
 Additionally, the toolbox provides a function to create labeled videos based on the extracted poses by plotting the
 labels on top of the frame and creating a video. There are two modes to create videos: FAST and SLOW (but higher quality!). If you want to create high-quality videos, please add ``save_frames=True``. One can use the command as follows to create multiple labeled videos:
@@ -486,7 +486,7 @@ This function has various other parameters, in particular the user can set the `
 .. include:: ./api/deeplabcut.create_labeled_video.rst
 ```
 
-### Extract "Skeleton" Features:
+#### Extract "Skeleton" Features:
 
 NEW, as of 2.0.7+: You can save the "skeleton" that was applied in ``create_labeled_videos`` for more computations. Namely,  it extracts length and orientation of each "bone" of the skeleton as defined in the **config.yaml** file. You can use the function by:
 
@@ -501,7 +501,7 @@ deeplabcut.analyzeskeleton(config, video, videotype='avi', shuffle=1, trainingse
 .. include:: ./api/deeplabcut.analyzeskeleton.rst
 ```
 
-### (J) Optional Active Learning -> Network Refinement: Extract Outlier Frames
+### (M) Optional Active Learning -> Network Refinement: Extract Outlier Frames
 
 While DeepLabCut typically generalizes well across datasets, one might want to optimize its performance in various,
 perhaps unexpected, situations. For generalization to large data sets, images with insufficient labeling performance
@@ -555,7 +555,7 @@ In the automatic configuration, before the frame selection happens, the user is 
 .. include:: ./api/deeplabcut.extract_outlier_frames.rst
 ```
 
- ### (K) Refine Labels: Augmentation of the Training Dataset
+ ### (N) Refine Labels: Augmentation of the Training Dataset
 
  Based on the performance of DeepLabCut, four scenarios are possible:
 

--- a/docs/standardDeepLabCut_UserGuide.md
+++ b/docs/standardDeepLabCut_UserGuide.md
@@ -222,7 +222,7 @@ The differences of the loaders are as follows:
 
 Alternatively, you can set the loader (as well as other training parameters) in the **pose_cfg.yaml** file of the model that you want to train. Note, to get details on the options, look at the default file: [**pose_cfg.yaml**](https://github.com/DeepLabCut/DeepLabCut/blob/master/deeplabcut/pose_cfg.yaml).
 
-**MODEL COMPARISON:** You can also test several models by creating the same test/train split for different networks. You can easily do this in the Project Manager GUI, or use the function ``deeplabcut.create_training_model_comparison(`` ([check the docstring for more details!](https://github.com/DeepLabCut/DeepLabCut/wiki/DOCSTRINGS#or-use-create_training_model_comparison)).
+**MODEL COMPARISON:** You can also test several models by creating the same test/train split for different networks. You can easily do this in the Project Manager GUI, or use the function ``deeplabcut.create_training_model_comparison``.
 
 Please also consult the following page on selecting models: https://deeplabcut.github.io/DeepLabCut/docs/recipes/nn.html#what-neural-network-should-i-use-trade-offs-speed-performance-and-considerations
 
@@ -232,11 +232,18 @@ Please also consult the following page on selecting models: https://deeplabcut.g
 <img src="https://images.squarespace-cdn.com/content/v1/57f6d51c9f74566f55ecf271/1570325287859-NHCTKWOFWPVWLH8B79PS/ke17ZwdGBToddI8pDm48kApwhYXjNb7J-ZG10ZuuPUJ7gQa3H78H3Y0txjaiv_0fDoOvxcdMmMKkDsyUqMSsMWxHk725yiiHCCLfrh8O1z4YTzHvnKhyp6Da-NYroOW3ZGjoBKy3azqku80C789l0uRNgJXBmK_J7vOfsoUyYccR03UZyExumRKzyR7hPRvjPGikK2uEIM-3GOD5thTJoQ/Box2-01.png?format=1000w" width="90%">
 </p>
 
-#### API Docs
+#### API Docs for deeplabcut.create_training_dataset
 ```{admonition} Click the button to see API Docs
 :class: dropdown
 ```{eval-rst}
 .. include:: ./api/deeplabcut.create_training_dataset.rst
+```
+
+#### API Docs for deeplabcut.create_training_model_comparison
+```{admonition} Click the button to see API Docs
+:class: dropdown
+```{eval-rst}
+.. include:: ./api/deeplabcut.create_training_model_comparison.rst
 ```
 
 ### (G) Train The Network

--- a/docs/standardDeepLabCut_UserGuide.md
+++ b/docs/standardDeepLabCut_UserGuide.md
@@ -130,7 +130,6 @@ bar to navigate across the video and *Grab a Frame* (or a range of frames, as of
 ```
 
 ### (D) Label Frames
-[DOCSTRING](https://github.com/DeepLabCut/DeepLabCut/wiki/DOCSTRINGS#label_frames)
 
 The toolbox provides a function **label_frames** which helps the user to easily label all the extracted frames using
 an interactive graphical user interface (GUI). The user should have already named the body parts to label (points of
@@ -158,6 +157,13 @@ HOT KEYS IN THE Labeling GUI (also see "help" in GUI):
 Ctrl + C: Copy labels from previous frame. With multi-animal DLC, only the keypoints of the animal currently selected are duplicated.
 Keyboard arrows: advance frames
 delete key: delete label
+```
+
+#### API Docs
+```{admonition} Click the button to see API Docs
+:class: dropdown
+```{eval-rst}
+.. include:: ./api/deeplabcut.label_frames.rst
 ```
 
 ###  (E) Check Annotated Frames
@@ -481,7 +487,7 @@ NEW, as of 2.0.7+: You can save the "skeleton" that was applied in ``create_labe
 deeplabcut.analyzeskeleton(config, video, videotype='avi', shuffle=1, trainingsetindex=0, save_as_csv=False, destfolder=None)
 ```
 
-##### API Docs
+#### API Docs
 ```{admonition} Click the button to see API Docs
 :class: dropdown
 ```{eval-rst}
@@ -583,8 +589,15 @@ Now you can run ``create_training_dataset``, then ``train_network``, etc. If you
 
 If after training the network generalizes well to the data, proceed to analyze new videos. Otherwise, consider labeling more data.
 
-#### API Docs
-```{admonition} Click the button to see API Docs for merge_datasets
+#### API Docs for deeplabcut.refine_labels
+```{admonition} Click the button to see API Docs
+:class: dropdown
+```{eval-rst}
+.. include:: ./api/deeplabcut.refine_labels.rst
+```
+
+#### API Docs for deeplabcut.merge_datasets
+```{admonition} Click the button to see API Docs
 :class: dropdown
 ```{eval-rst}
 .. include:: ./api/deeplabcut.merge_datasets.rst


### PR DESCRIPTION
API documentation for the following functions are added in this PR

- ``deeplabcut.analyze_videos``
- ``deeplabcut.analyzeskeleton``
- ``deeplabcut.create_labeled_video``
- ``deeplabcut.create_training_model_comparison``
- ``deeplabcut.evaluate_network``
- ``deeplabcut.extract_outlier_frames``
- ``deeplabcut.filterpredictions``
- ``deeplabcut.label_frames``
- ``deeplabcut.merge_datasets``
- ``deeplabcut.plot_trajectories``
- ``deeplabcut.refine_labels``

Note that additionally, this PR updates the GitHub Action that builds Jupyter Book documentation to install GUI dependencies. This is necessary as the functions - ``deeplabcut.label_frames`` and ``deeplabcut.refine_labels`` - live in modules which rely on GUI dependencies.

Finally, with the changes introduced in this PR, there are no links to the "DOCSTRINGS" wiki page in the user guide.