### PR TITLE
Fix ZeroDivisionError during calibration

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
@@ -316,15 +316,15 @@ class Assembler:
         if self._kde is None:
             raise ValueError("Assembler should be calibrated first with training data.")
 
-        if not len(assembly):
-            # Distance is undefined if the assembly is empty
+        dists = assembly.calc_pairwise_distances() - self._kde.mean
+        mask = np.isnan(dists)
+        # Distance is undefined if the assembly is empty
+        if not len(assembly) or mask.all():
             if return_proba:
                 return np.inf, 0
             return np.inf
 
-        dists = assembly.calc_pairwise_distances() - self._kde.mean
-        mask = np.isnan(dists)
-        if mask.any() and nan_policy == "little":
+        if nan_policy == "little":
             inds = np.flatnonzero(~mask)
             dists = dists[inds]
             inv_cov = self._kde.inv_cov[np.ix_(inds, inds)]

--- a/tests/test_inferenceutils.py
+++ b/tests/test_inferenceutils.py
@@ -293,6 +293,12 @@ def test_assembler_calibration(real_assemblies):
     p = ass.calc_link_probability(link)
     assert np.isclose(p, 0.993, atol=1e-3)
 
+    # Test empty assembly
+    assembly.data[:, :2] = np.nan
+    mahal, proba = ass.calc_assembly_mahalanobis_dist(assembly, return_proba=True)
+    assert np.isinf(mahal)
+    assert proba == 0
+
 
 def test_find_outlier_assemblies(real_assemblies):
     assert len(inferenceutils.find_outlier_assemblies(real_assemblies)) == 13


### PR DESCRIPTION
We now properly catch assemblies that are either empty or contain NaN coordinates.
I improved the unit test too.

Fixes #1818 