### PR TITLE
Ignore failing "wx" imports when building api docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,6 +4,8 @@ logo: docs/images/logo.png
 only_build_toc_files: true
 
 sphinx:
+  config:
+    autodoc_mock_imports: ["wx"]
   extra_extensions:
     - numpydoc
 

--- a/docs/standardDeepLabCut_UserGuide.md
+++ b/docs/standardDeepLabCut_UserGuide.md
@@ -159,6 +159,13 @@ Keyboard arrows: advance frames
 delete key: delete label
 ```
 
+#### API Docs
+```{admonition} Click the button to see API Docs
+:class: dropdown
+```{eval-rst}
+.. include:: ./api/deeplabcut.label_frames.rst
+```
+
 ###  (E) Check Annotated Frames
 
 OPTIONAL: Checking if the labels were created and stored correctly is beneficial for training, since labeling
@@ -589,6 +596,12 @@ Now you can run ``create_training_dataset``, then ``train_network``, etc. If you
 
 If after training the network generalizes well to the data, proceed to analyze new videos. Otherwise, consider labeling more data.
 
+#### API Docs for deeplabcut.refine_labels
+```{admonition} Click the button to see API Docs
+:class: dropdown
+```{eval-rst}
+.. include:: ./api/deeplabcut.refine_labels.rst
+```
 
 #### API Docs for deeplabcut.merge_datasets
 ```{admonition} Click the button to see API Docs


### PR DESCRIPTION
Previously, we were having difficulty building api documentation for functions that are defined in modules which rely on the `wx` package.

This PR configures `sphinx` to ignore the failing `wx` imports when building the api documentation.

This PR reverts changes in https://github.com/DeepLabCut/DeepLabCut/pull/1816.