### PR TITLE
Cleanup internal links in documentation

### DIFF
--- a/docs/Governance.md
+++ b/docs/Governance.md
@@ -1,3 +1,4 @@
+(governance-model)=
 # Governance Model of DeepLabCut
 (adapted from https://napari.org/docs/_sources/developers/GOVERNANCE.md.txt)
 
@@ -84,7 +85,7 @@ The current steering council of DeepLabCut consists of the original developers:
 The SC membership is revisited every January. SC members who do
 not actively engage with the SC duties are expected to resign. New members are
 added by nomination by a core developer. Nominees should have demonstrated
-long-term, continued commitment to the project and its [mission and values](https://github.com/DeepLabCut/DeepLabCut/docs/MISSION_AND_VALUES.md). A
+long-term, continued commitment to the project and its [mission and values](mission-and-values). A
 nomination will result in discussion that cannot take more than a month and
 then admission to the SC by consensus. During that time deadlocked votes of the SC will
 be postponed until the new member has joined and another vote can be held.
@@ -98,7 +99,7 @@ members of the community. All non-sensitive project management discussion takes
 place on the [issue tracker](https://github.com/deeplabcut/deeplabcut/issues). Occasionally,
 sensitive discussions may occur on a private core developer medium.
 
-Decisions should be made in accordance with the [mission and values](https://github.com/DeepLabCut/DeepLabCut/docs/MISSION_AND_VALUES.md)
+Decisions should be made in accordance with the [mission and values](mission-and-values)
 of the DeepLabCut project.
 
 DeepLabCut uses a “consensus seeking” process for making decisions. The group

--- a/docs/HelperFunctions.md
+++ b/docs/HelperFunctions.md
@@ -1,3 +1,4 @@
+(helper-functions)=
 ## Helper & Advanced Optional Function Documentation
 
 ### There are additional functions that are not required, but can be extremely helpful. 
@@ -96,7 +97,8 @@ If you have multiple cameras, you may want to use epipolar lines projected on th
 
 In order to label with epipolar lines, you must complete two additional sets of steps **prior to labeling.**
 
-- First, you must create a 3d project and calibrate the cameras - to do so, complete steps 1-3: https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/Overviewof3D.md. 
+- First, you must create a 3d project and calibrate the cameras - to do so, complete
+  steps 1-3 in [3D Overview](3D-overview).
 
 - Second, you must extract imagr from `camera_1` first; here you would have run the standard `deeplabcut.extract_frames(config_path, userfeedback=True)`, but just extract files from 1 camera. Next, you need to extract matching frames from `camera_2`:
 ```python

--- a/docs/MISSION_AND_VALUES.md
+++ b/docs/MISSION_AND_VALUES.md
@@ -1,10 +1,11 @@
+(mission-and-values)=
 # Mission and Values of DeepLabCut
 
 This document is meant to help guide decisions about the future of `DeepLabCut`, be it in terms of
 whether to accept new functionality, changes to the styling of the code or graphical user interfaces (GUI),
 or whether to take on new dependencies, when to break into other repos, among other things. It serves as a point of reference for core developers actively working on the project, and an introduction for
 newcomers who want to learn a little more about where the project is going and what the team's
-values are. You can also learn more about how the project is managed by looking at our [governance model](https://github.com/DeepLabCut/DeepLabCut/docs/Governance.md).
+values are. You can also learn more about how the project is managed by looking at our [governance model](governance-model).
 
 ## Our founding principles
 

--- a/docs/Overviewof3D.md
+++ b/docs/Overviewof3D.md
@@ -1,3 +1,4 @@
+(3D-overview)=
 # 3D DeepLabCut
 
 In this repo we directly support 2-camera based 3D pose estimation. If you want n camera support, plus nicer optimization methods, please see our new work that was published at [ICRA 2021 on strong baseline 3D models (and a 3D dataset)](https://github.com/African-Robotics-Unit/AcinoSet). In the link you will find how we optimize 6+ camera DLC output data for cheetahs (and see more below).
@@ -7,7 +8,7 @@ In this repo we directly support 2-camera based 3D pose estimation. If you want 
 
 **ATTENTION: Our code base in this repo assumes you:**
 
-A. You have 2D videos and a DeepLabCut network to analyze them as described in the [main documentation](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/UseOverviewGuide.md). This can be with multiple separate networks for each camera (less recommended), or one network trained on all views - recommended! (See [Nath*, Mathis* et al., 2019](https://www.biorxiv.org/content/10.1101/476531v1)). We also support multi-animal 3D with this code (please see [Lauer et al. 2022](https://doi.org/10.1038/s41592-022-01443-0)).
+A. You have 2D videos and a DeepLabCut network to analyze them as described in the [main documentation](overview). This can be with multiple separate networks for each camera (less recommended), or one network trained on all views - recommended! (See [Nath*, Mathis* et al., 2019](https://www.biorxiv.org/content/10.1101/476531v1)). We also support multi-animal 3D with this code (please see [Lauer et al. 2022](https://doi.org/10.1038/s41592-022-01443-0)).
 
 B. You are using 2 cameras, in a [stereo configuration](https://github.com/DeepLabCut/DeepLabCut/blob/5ac4c8cb6bcf2314a3abfcf979b8dd170608e094/deeplabcut/pose_estimation_3d/camera_calibration.py#L223), for 3D*.
 

--- a/docs/PROJECT_GUI.md
+++ b/docs/PROJECT_GUI.md
@@ -1,10 +1,11 @@
+(project-manager-gui)=
 # Interactive Project Manager GUI
 
 As of DeepLabCut 2.1+ now provide a full front-end user experience for DeepLabCut. As some users may be more comfortable working with an interactive interface, we wanted to provide an easy-entry point to the software. All the main functionality is now available in an  easy-to-deploy GUI interface. Thus, while the many advanced features are not fully available in this Project GUI, we hope this gets more users up-and-running quickly.
 
 ## Get Started:
 
-(1) Install DeepLabCut using the simple-install with Anaconda found [here!](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/installation.md)
+(1) Install DeepLabCut using the simple-install with Anaconda found [here!](how-to-install)
 
 or
 
@@ -30,13 +31,13 @@ Now, keep the terminal visible (as well as the GUI) so you can see the ongoing p
 
 [![Watch the video](https://images.squarespace-cdn.com/content/v1/57f6d51c9f74566f55ecf271/1589046800303-OV1CCNZINWDMF1PZWCWE/ke17ZwdGBToddI8pDm48kB4PVlRPKDmSlQNbUD3wvXgUqsxRUqqbr1mOJYKfIPR7LoDQ9mXPOjoJoqy81S2I8N_N4V1vUb5AoIIIbLZhVYxCRW4BPu10St3TBAUQYVKcaja1QZ1SznGf7WzFOi-J6zLusnaF2VdeZcKivwxvFiDfGDqVYuwbAlftad9hfoui/dlc_gui_22.png?format=1000w)](https://www.youtube.com/watch?v=JDsa8R5J0nQ)
 
-[READ MORE HERE](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/UseOverviewGuide.md#important-information-on-using-deeplabcut)
+[READ MORE HERE](important-info-regd-usage)
 
 ### Using the Project Manager GUI with the latest DLC code (multiple identical-looking animals, plus objects):
 
 [![Watch the video](https://images.squarespace-cdn.com/content/v1/57f6d51c9f74566f55ecf271/1589047147498-G1KTFA5BXR4PVHOOR7OG/ke17ZwdGBToddI8pDm48kJDij24pM2COisBTLIGjR1pZw-zPPgdn4jUwVcJE1ZvWQUxwkmyExglNqGp0IvTJZamWLI2zvYWH8K3-s_4yszcp2ryTI0HqTOaaUohrI8PIel60EThn7SDFlTiSprUhmjQQHn9bhdY9dnQSKs8bCCo/Untitled.png?format=1000w)](https://www.youtube.com/watch?v=Kp-stcTm77g)
 
-[READ MORE HERE](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/UseOverviewGuide.md#important-information-on-using-deeplabcut)
+[READ MORE HERE](important-info-regd-usage)
 
 ## VIDEO DEMO: How to benchmark your data with the new networks and data augmentation pipelines:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,4 @@
+(readme)=
 # Welcome to Our Documentation Hub!
 
 <img src="https://images.squarespace-cdn.com/content/v1/57f6d51c9f74566f55ecf271/1572296495650-Y4ZTJ2XP2Z9XF1AD74VW/ke17ZwdGBToddI8pDm48kMulEJPOrz9Y8HeI7oJuXxR7gQa3H78H3Y0txjaiv_0fDoOvxcdMmMKkDsyUqMSsMWxHk725yiiHCCLfrh8O1z5QPOohDIaIeljMHgDF5CVlOqpeNLcJ80NK65_fV7S1UZiU3J6AN9rgO1lHw9nGbkYQrCLTag1XBHRgOrY8YAdXW07ycm2Trb21kYhaLJjddA/DLC_logo_blk-01.png?format=1000w" width="150" title="DLC-live" alt="DLC LIVE!" align="right" vspace = "50">
@@ -8,12 +9,12 @@ If you are new to DeepLabCut, we have 3 resources we recommend before jumping in
 
 **Otherwise, here are the links to all the key steps to get you up and running within a day!**
 
--  **[How to install DeepLabCut](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/installation.md)**
+-  **[How to install DeepLabCut](how-to-install)**
 
--  Decide on your needs: there are **two main modes, standard DeepLabCut or multi-animal DeepLabCut**. We highly recommend carefully considering which one is best for your needs. For example, a white mouse + black mouse would call for standard, while two black mice would use multi-animal. **[Important Information on how to use DLC in different scenarios (single vs multi animal)](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/UseOverviewGuide.md#important-information-on-using-deeplabcut)** Then pick:
+-  Decide on your needs: there are **two main modes, standard DeepLabCut or multi-animal DeepLabCut**. We highly recommend carefully considering which one is best for your needs. For example, a white mouse + black mouse would call for standard, while two black mice would use multi-animal. **[Important Information on how to use DLC in different scenarios (single vs multi animal)](important-info-regd-usage)** Then pick:
 
--  **[How to use standard DeepLabCut](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/standardDeepLabCut_UserGuide.md)**
--  **[How to use multi-animal DeepLabCut](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/maDLC_UserGuide.md)**
+-  **[How to use standard DeepLabCut](single-animal-userguide)**
+-  **[How to use multi-animal DeepLabCut](multi-animal-userguide)**
 
 
 ## More resources for help, additional docs, and roadmap of the project!
@@ -26,11 +27,11 @@ If you are new to DeepLabCut, we have 3 resources we recommend before jumping in
 
  - [Real-time feedback with DeepLabCut: DeepLabCut-live](https://github.com/DeepLabCut/DeepLabCut-live)
 
- - [DeepLabCut 3D](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/Overviewof3D.md)
+ - [DeepLabCut 3D](3D-overview)
 
- - [Helper functions](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/HelperFunctions.md)
+ - [Helper functions](helper-functions)
 
- - [Developer Road Map!](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/roadmap.md)
+ - [Developer Road Map!](dev-roadmap)
 
  - [How to Contribute to DeepLabCut](https://github.com/DeepLabCut/DeepLabCut/blob/master/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/DeepLabCut/DeepLabCut/blob/master/CODE_OF_CONDUCT.md)
 

--- a/docs/UseOverviewGuide.md
+++ b/docs/UseOverviewGuide.md
@@ -1,18 +1,19 @@
+(overview)=
 ## Documentation Overview:
 
 Below we will first outline what you need to get started, the different ways you can use DeepLabCut, and then the full workflow. Note, we highly recommend you also read and follow our [Nature Protocols paper](https://www.nature.com/articles/s41596-019-0176-0), which is (still) fully relevant to standard DeepLabCut.
 
-- [How to install DeepLabCut](/docs/installation.md)
+- [How to install DeepLabCut](how-to-install)
 
-- Decide on your needs: there are **two main modes, standard DeepLabCut or multi-animal DeepLabCut**. We highly recommend carefully considering which one is best for your needs. For example, a white mouse + black mouse would call for standard, while two black mice would use multi-animal. **[Important Information on how to use DLC in different scenarios (single vs multi animal)](/docs/UseOverviewGuide.md#important-information-on-using-deeplabcut)** Then pick:
+- Decide on your needs: there are **two main modes, standard DeepLabCut or multi-animal DeepLabCut**. We highly recommend carefully considering which one is best for your needs. For example, a white mouse + black mouse would call for standard, while two black mice would use multi-animal. **[Important Information on how to use DLC in different scenarios (single vs multi animal)](important-info-regd-usage)** Then pick:
 
-- (1) [How to use standard DeepLabCut](/docs/standardDeepLabCut_UserGuide.md)
-- (2) [How to use multi-animal DeepLabCut](/docs/maDLC_UserGuide.md)
+- (1) [How to use standard DeepLabCut](single-animal-userguide)
+- (2) [How to use multi-animal DeepLabCut](multi-animal-userguide)
 
  **Additional Learning Resources:**
 
  - [TUTORIALS:](https://www.youtube.com/channel/UC2HEbWpC_1v6i9RnDMy-dfA?view_as=subscriber) video tutorials that demonstrate various aspects of using the code base.
- - [HOW-TO-GUIDES:](https://deeplabcut.github.io/docs/UseOverviewGuide.md) step-by-step user guidelines for using DeepLabCut on your own datasets (see below)
+ - [HOW-TO-GUIDES:](overview) step-by-step user guidelines for using DeepLabCut on your own datasets (see below)
  - [EXPLANATIONS:](https://github.com/DeepLabCut/DeepLabCut-Workshop-Materials) resources on understanding how DeepLabCut works
  - [REFERENCES:](https://github.com/DeepLabCut/DeepLabCut#references) read the science behind DeepLabCut
 
@@ -67,6 +68,8 @@ You can have as many projects on your computer as you wish. You can have DeepLab
  </p>
 
 
+(important-info-regd-usage)=
+
 # Specific Advice for Using DeepLabCut:
 
 ### Important information on using DeepLabCut:
@@ -99,25 +102,28 @@ We highly recommend using 2.2 first in the Project Manager GUI ([Option 3](docs/
 
 - **I have a pre-2.2 single animal project, but I want to use 2.2:**
 
-Please read [this convert 2 maDLC guide](/docs/convert_maDLC.md)
+Please read [this convert 2 maDLC guide](convert-maDLC)
 
 ### The options for using DeepLabCut:
 
 Great - now that you get the overall workflow let's jump in! Here, you have several options.
 
-[**Option 1**](/docs/UseOverviewGuide.md#option-1-demo-notebooks) DEMOs: for a quick introduction to DLC on our data.
+[**Option 1**](using-demo-notebooks) DEMOs: for a quick introduction to DLC on our data.
 
-[**Option 2**](/docs/UseOverviewGuide.md#option-2-using-the-project-manager-gui) Standalone GUI: is the perfect place for beginners who want to start using DeepLabCut on your own data.
+[**Option 2**](using-project-manager-gui) Standalone GUI: is the perfect place for
+beginners who want to start using DeepLabCut on your own data.
 
-[**Option 3**](/docs/UseOverviewGuide.md#option-3-using-the-program-terminal-start-ipython) In the terminal: is best for more advanced users, as with the terminal interface you get the most versatility and options.  
+[**Option 3**](using-the-terminal) In the terminal: is best for more advanced users, as
+with the terminal interface you get the most versatility and options.
 
-
+(using-demo-notebooks)=
 ## Option 1: Demo Notebooks:
 [VIDEO TUTORIAL AVAILABLE!](https://www.youtube.com/watch?v=DRT-Cq2vdWs)
 
 We provide Jupyter and COLAB notebooks for using DeepLabCut on both a pre-labeled dataset, and on the end user’s
 own dataset. See all the demo's [here!](/examples) Please note that GUIs are not easily supported in Jupyter in MacOS, as you need a framework build of python. While it's possible to launch them with a few tweaks, we recommend using the Project Manager GUI or terminal, so please follow the instructions below.
 
+(using-project-manager-gui)=
 ## Option 2: using the Project Manager GUI:
 [VIDEO TUTORIAL!](https://www.youtube.com/watch?v=KcXogR-p5Ak)
 
@@ -132,12 +138,12 @@ python -m deeplabcut
 ```
 That's it! Follow the GUI for details
 
-
+(using-the-terminal)=
 ## Option 3: using the program terminal, Start iPython*:
 
 [VIDEO TUTORIAL AVAILABLE!](https://www.youtube.com/watch?v=7xwOhUcIGio)
 
 Please decide with mode you want to use DeepLabCut, and follow one of the following:
 
-- (1) [How to use standard DeepLabCut](/docs/standardDeepLabCut_UserGuide.md)
-- (2) [How to use multi-animal DeepLabCut](/docs/maDLC_UserGuide.md)
+- (1) [How to use standard DeepLabCut](single-animal-userguide)
+- (2) [How to use multi-animal DeepLabCut](multi-animal-userguide)

--- a/docs/convert_maDLC.md
+++ b/docs/convert_maDLC.md
@@ -52,7 +52,7 @@ Now you will see that your data within `labeled-data` are converted to a new for
 ```python
 deeplabcut.create_multianimaltraining_dataset(path_config_file)
 ```
-to begin training. See function details [here](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/functionDetails.md#f-create-training-datasets)).
+to begin training.
 
 **Advanced option:** You can also assign former `bodyparts` to either `uniquebodyparts` or `multianimalbodyparts` (you can even leave some unassigned, which means they will be dropped in the conversion).
 

--- a/docs/convert_maDLC.md
+++ b/docs/convert_maDLC.md
@@ -1,3 +1,4 @@
+(convert-maDLC)=
 ### How to convert a pre-2.2 project for use with DeepLabCut 2.2
 
 <img src="https://images.squarespace-cdn.com/content/v1/57f6d51c9f74566f55ecf271/1572296495650-Y4ZTJ2XP2Z9XF1AD74VW/ke17ZwdGBToddI8pDm48kMulEJPOrz9Y8HeI7oJuXxR7gQa3H78H3Y0txjaiv_0fDoOvxcdMmMKkDsyUqMSsMWxHk725yiiHCCLfrh8O1z5QPOohDIaIeljMHgDF5CVlOqpeNLcJ80NK65_fV7S1UZiU3J6AN9rgO1lHw9nGbkYQrCLTag1XBHRgOrY8YAdXW07ycm2Trb21kYhaLJjddA/DLC_logo_blk-01.png?format=1000w" width="150" title="DLC" alt="DLC!" align="right" vspace = "50">

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,3 +1,4 @@
+(docker-containers)=
 # DeepLabCut Docker containers
 
 For DeepLabCut 2.2.0.2 and onwards, we provide container containers on [DockerHub](https://hub.docker.com/r/deeplabcut/deeplabcut). Using Docker is an alternative approach to using DeepLabCut, which only requires the user to install [Docker](https://www.docker.com/) on your machine, vs. following the step-by-step installation guide for a Anaconda setup. All dependencies needed to run DeepLabCut in terminal or GUI mode, or running Jupyter notebooks with DeepLabCut pre-installed are shipped with the provided Docker images.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,12 +1,13 @@
+(how-to-install)=
 # How To Install DeepLabCut
 
-DeepLabCut can be run on Windows, Linux, or MacOS (see also [technical considerations](/docs/installation.md#technical-considerations)).
+DeepLabCut can be run on Windows, Linux, or MacOS (see also [technical considerations](tech-considerations-during-install)).
 
 ## PIP:
 
 - Everything you need to run DeepLabCut (i.e., our source code and our dependencies) can be installed with `pip install 'deeplabcut[gui]'` (for GUI support) or without: `pip install deeplabcut`.
 
-- Please note, there are several modes of installation, and the user should decide to either use a **system-wide** (see [note below](/docs/installation.md#system-wide-considerations)), **Anaconda environment** based installation (**recommended**), or the supplied [**Docker container**](https://github.com/DeepLabCut/DeepLabCut/tree/master/docker.md) (recommended for Ubuntu advanced users). One can of course also use other Python distributions than Anaconda, but **Anaconda is the easiest route.**
+- Please note, there are several modes of installation, and the user should decide to either use a **system-wide** (see [note below](system-wide-considerations-during-install)), **Anaconda environment** based installation (**recommended**), or the supplied [**Docker container**](docker-containers) (recommended for Ubuntu advanced users). One can of course also use other Python distributions than Anaconda, but **Anaconda is the easiest route.**
 
 ## CONDA: The installation process is as easy as this figure! -->
 
@@ -150,11 +151,12 @@ DEEPLABCUT:
 
 - if you git clone or download this folder, and are inside of it then ``import deeplabcut`` will import the package from there rather than from the latest on PyPi!
 
-
+(system-wide-considerations-during-install)=
 ## System-wide considerations:
 
 If you perform the system-wide installation, and the computer has other Python packages or TensorFlow versions installed that conflict, this will overwrite them. If you have a dedicated machine for DeepLabCut, this is fine. If there are other applications that require different versions of libraries, then one would potentially break those applications. The solution to this problem is to create a virtual environment, a self-contained directory that contains a Python installation for a particular version of Python, plus additional packages. One way to manage virtual environments is to use conda environments (for which you need Anaconda installed).
 
+(tech-considerations-during-install)=
 ## Technical Considerations:
 
 - Computer:
@@ -174,8 +176,8 @@ If you perform the system-wide installation, and the computer has other Python p
      - TensorFlow
        - You will need [TensorFlow](https://www.tensorflow.org/) (we used version 1.0 in the paper, later versions also work with the provided code (we tested **TensorFlow versions 1.0 to 1.15, and 2.0 to 2.5**; we recommend TF2.5 now) for Python 3.7, 3.8, or 3.9 with GPU support.
         - To note, is it possible to run DeepLabCut on your CPU, but it will be VERY slow (see: [Mathis & Warren](https://www.biorxiv.org/content/early/2018/10/30/457242)). However, this is the preferred path if you want to test DeepLabCut on your own computer/data before purchasing a GPU, with the added benefit of a straightforward installation! Otherwise, use our COLAB notebooks for GPU access for testing.
-     - Docker: We highly recommend advanced users use the supplied [Docker container](https://github.com/DeepLabCut/DeepLabCut/tree/master/docker.md)
+     - Docker: We highly recommend advanced users use the supplied [Docker container](docker-containers)
 
 
 
-Return to [readme](../README.md).
+Return to [readme](readme).

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -30,7 +30,7 @@ To get started, click on the **"Welcome to Our Documentation Hub!"** in the tabl
 
 - We have a **real-time DeepLabCut-live!** package available! http://DLClive.deeplabcut.org
 
-- Check out the docs in JupyterBook! https://deeplabcut.github.io/DeepLabCut (or on [github](docs/README.md)).
+- Check out the docs in JupyterBook! https://deeplabcut.github.io/DeepLabCut (or in the [README](readme)).
 
 - For a step-by-step user guide, please also see the [Nature Protocols paper](https://doi.org/10.1038/s41596-019-0176-0)!
 
@@ -75,7 +75,7 @@ This is an actively developed package and we welcome community development and i
 
 - If you want to contribute to the code, please read our guide [here!](https://github.com/DeepLabCut/DeepLabCut/blob/master/CONTRIBUTING.md)
 
-- The project [road map](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/roadmap.md). Get in touch with us if you want to help!
+- The project [road map](dev-roadmap). Get in touch with us if you want to help!
 
 ## References:
 
@@ -179,7 +179,7 @@ VERSION 1.0: The initial, Nature Neuroscience version of [DeepLabCut](https://ww
 - Jan 2021: [Pretraining boosts out-of-domain robustness for pose estimation](https://openaccess.thecvf.com/content/WACV2021/html/Mathis_Pretraining_Boosts_Out-of-Domain_Robustness_for_Pose_Estimation_WACV_2021_paper.html) published in the IEEE Winter Conference on Applications of Computer Vision. We also added EfficientNet backbones to DeepLabCut, those are best trained with cosine decay (see paper). To use them, just pass "`efficientnet-b0`" to "`efficientnet-b6`" when creating the trainingset!
 - Dec 2020: We released a real-time package that allows for online pose estimation and real-time feedback. See [DLClive.deeplabcut.org](http://DLClive.deeplabcut.org).
 - 5/22 2020: We released 2.2beta5. This beta release has some of the features of DeepLabCut 2.2, whose major goal is to integrate multi-animal pose estimation to DeepLabCut.
-- Mar 2020: Inspired by suggestions we heard at this weeks CZI's Essential Open Source Software meeting in Berkeley, CA we updated our [docs](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/UseOverviewGuide.md). Let us know what you think!
+- Mar 2020: Inspired by suggestions we heard at this weeks CZI's Essential Open Source Software meeting in Berkeley, CA we updated our [docs](overview). Let us know what you think!
 - Feb 2020: Our [review on animal pose estimation is published!](https://www.sciencedirect.com/science/article/pii/S0959438819301151)
 - Nov 2019: DeepLabCut was recognized by the Chan Zuckerberg Initiative (CZI) with funding to support this project. Read more in the [Harvard Gazette](https://news.harvard.edu/gazette/story/newsplus/harvard-researchers-awarded-czi-open-source-award/), on [CZI's Essential Open Source Software for Science site](https://chanzuckerberg.com/eoss/proposals/) and in their [Medium post](https://medium.com/@cziscience/how-open-source-software-contributors-are-accelerating-biomedicine-1a5f50f6846a)
 - Oct 2019: DLC 2.1 released with lots of updates. In particular, a Project Manager GUI, MobileNetsV2, and augmentation packages (Imgaug and Tensorpack). For detailed updates see [releases](https://github.com/DeepLabCut/DeepLabCut/releases)

--- a/docs/maDLC_UserGuide.md
+++ b/docs/maDLC_UserGuide.md
@@ -1,10 +1,11 @@
+(multi-animal-userguide)=
 # DeepLabCut for Multi-Animal Projects
 
 This document should serve as the user guide for maDLC,
 and it is here to support the scientific advances presented in [Lauer et al. 2022](https://doi.org/10.1038/s41592-022-01443-0).
 
 
-Note, we strongly encourage you to use the [Project Manager GUI](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/PROJECT_GUI.md) when you first start using multi-animal mode. Each tab is customized for multi-animal when you create or load a multi-animal project. As long as you follow the recommendations within the GUI, you should be good to go!
+Note, we strongly encourage you to use the [Project Manager GUI](project-manager-gui) when you first start using multi-animal mode. Each tab is customized for multi-animal when you create or load a multi-animal project. As long as you follow the recommendations within the GUI, you should be good to go!
 
 ## How to think about using maDLC:
 
@@ -29,7 +30,7 @@ IF you want to use the bleeding edge version to make edits to the code, see here
 **GUI:** simply open your conda env, and windows/linux type `python -m deeplabcut`. MacOS users: `pythonw -m deeplabcut.`
 Then follow the tabs! It might be useful to read the following, however, so you understand what each command does.
 
-**TERMINAL:** To begin, (windows) navigate to anaconda prompt and right-click to "open as admin ", or (unix/MacOS) simply launch "terminal" on your computer. We assume you have DeepLabCut installed (if not, go [here](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/installation.md)). Next, launch your conda env (i.e., for example `conda activate DLC-CPU`).
+**TERMINAL:** To begin, (windows) navigate to anaconda prompt and right-click to "open as admin ", or (unix/MacOS) simply launch "terminal" on your computer. We assume you have DeepLabCut installed (if not, [see installation instructions](how-to-install)). Next, launch your conda env (i.e., for example `conda activate DLC-CPU`).
 
 Start iPython, or if you are using MacOS, you must use ``pythonw`` vs. typing ``ipython`` or ``python``, but otherwise it's the same.
 If you use Windows, please always open the terminal with administrator privileges. Please read more [here](https://github.com/DeepLabCut/Docker4DeepLabCut2.0), and in our Nature Protocols paper [here](https://www.nature.com/articles/s41596-019-0176-0). And, see our [troubleshooting wiki](https://github.com/DeepLabCut/DeepLabCut/wiki/Troubleshooting-Tips).
@@ -75,7 +76,7 @@ deeplabcut.add_new_videos('Full path of the project configuration file*', ['full
 
 *Please note, *Full path of the project configuration file* will be referenced as ``config_path`` throughout this protocol.
 
-You can also use annotated data from singe-animal projects, by converting those files. There are docs for this: [convert single to multianimal annotation data](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/convert_maDLC.md)
+You can also use annotated data from singe-animal projects, by converting those files. There are docs for this: [convert single to multianimal annotation data](convert-maDLC)
 
 ### Configure the Project:
 
@@ -625,4 +626,4 @@ Now, you can run any of the functions described in this documentation.
 
 - if you are looking for resources to increase your understanding of the software and general guidelines, we have an open source, free course: http://DLCcourse.deeplabcut.org.
 
-**Please note:** what we cannot do is provided support or help designing your experiments and data analysis. The number of requests for this is too great to sustain in our inbox. We are happy to answer such questions in the forum as a community, in a scalable way. We hope and believe we have given enough tools and resources to get started and to accelerate your research program, and this is backed by the >700 citations using DLC, 2 clinical trials by others, and countless applications. Thus, we believe this code works, is accessible, and with limited programming knowledge can be used. Please read our [Missions & Values statement](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/MISSION_AND_VALUES.md) to learn more about what we DO hope to provide you.
+**Please note:** what we cannot do is provided support or help designing your experiments and data analysis. The number of requests for this is too great to sustain in our inbox. We are happy to answer such questions in the forum as a community, in a scalable way. We hope and believe we have given enough tools and resources to get started and to accelerate your research program, and this is backed by the >700 citations using DLC, 2 clinical trials by others, and countless applications. Thus, we believe this code works, is accessible, and with limited programming knowledge can be used. Please read our [Missions & Values statement](mission-and-values) to learn more about what we DO hope to provide you.

--- a/docs/recipes/TechHardware.md
+++ b/docs/recipes/TechHardware.md
@@ -2,7 +2,7 @@
 
 ## Quick summary:
 [On our install page](tech-considerations-during-install)
-we highlight that for GPU computing through standard installation you need a NVIDIA GPU, with at least 8 GB of memory. If you have an Intel or AMD GPU, and are on windows, there is an alternative method of installation available which is shown on the [installation tips page](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/recipes/installTips.md) under "How to install Deeplabcut for Intel and AMD GPUs". 
+we highlight that for GPU computing through standard installation you need a NVIDIA GPU, with at least 8 GB of memory. If you have an Intel or AMD GPU, and are on windows, there is an alternative method of installation available which is shown on the [installation tips page](installation-tips) under "How to install Deeplabcut for Intel and AMD GPUs".
 Note, some info is repeated here, and will be updated as systems and hardware changes.
 
 ### Computer:

--- a/docs/recipes/TechHardware.md
+++ b/docs/recipes/TechHardware.md
@@ -1,7 +1,7 @@
 # Technical (Hardware) Considerations
 
 ## Quick summary:
-[On our install page](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/installation.md#technical-considerations)
+[On our install page](tech-considerations-during-install)
 we highlight that for GPU computing through standard installation you need a NVIDIA GPU, with at least 8 GB of memory. If you have an Intel or AMD GPU, and are on windows, there is an alternative method of installation available which is shown on the [installation tips page](https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/recipes/installTips.md) under "How to install Deeplabcut for Intel and AMD GPUs". 
 Note, some info is repeated here, and will be updated as systems and hardware changes.
 

--- a/docs/recipes/installTips.md
+++ b/docs/recipes/installTips.md
@@ -1,3 +1,4 @@
+(installation-tips)=
 # Installation Tips
 
 ## How to use the latest updates directly from GitHub

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,3 +1,4 @@
+(dev-roadmap)=
 ## A development roadmap for DeepLabCut
 
 

--- a/docs/standardDeepLabCut_UserGuide.md
+++ b/docs/standardDeepLabCut_UserGuide.md
@@ -1,6 +1,7 @@
+(single-animal-userguide)=
 # DeepLabCut User Guide (for single animal projects)
 
-This document covers single/standard DeepLabCut use. If you have a complicated multi-animal scenario (i.e., they look the same), then please see our [maDLC user guide](https://deeplabcut.github.io/DeepLabCut/docs/maDLC_UserGuide.html).
+This document covers single/standard DeepLabCut use. If you have a complicated multi-animal scenario (i.e., they look the same), then please see our [maDLC user guide](multi-animal-userguide).
 
 To get started, you can use the GUI, or the terminal. See below.
 
@@ -605,13 +606,14 @@ template for the user to develop a project. Furthermore, we provide a notebook f
 labeled data. The example project, named as Reaching-Mackenzie-2018-08-30 consists of a project configuration file
 with default parameters and 20 images, which are cropped around the region of interest as an example dataset. These
 images are extracted from a video, which was recorded in a study of skilled motor control in mice. Some example
-labels for these images are also provided. See more details [here]((https://github.com/DeepLabCut/DeepLabCut/blob/master/examples).
+labels for these images are also provided. See more details [here](https://github.com/DeepLabCut/DeepLabCut/blob/master/examples).
 
 ## 3D Toolbox
 
-Please find all the information on using the 3D toolbox of DeepLabCut (as of 2.0.7+) here: https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/Overviewof3D.md
-
+Please see [3D overview](3D-overview) for information on using the 3D toolbox of
+DeepLabCut (as of 2.0.7+).
 
 ## Other functions, some are yet-to-be-documented:
 
-We suggest you [check out these additional helper functions]((https://github.com/DeepLabCut/DeepLabCut/blob/master/docs/HelperFunctions.md), that could be useful (they are all optional).
+We suggest you [check out these additional helper functions](helper-functions), that
+could be useful (they are all optional).


### PR DESCRIPTION
There were a number of places where the jupyter book documentation linked to external files on github instead of linking to the same files on jupyter book. This PR fixes that issue. Additionally, in some cases internal links were defined using a path to the file - these too have been updated to use the new references.

Two broken links were also fixed in this commit and a broken link was removed as there is no correct equivalent.

Ref https://jupyterbook.org/en/stable/tutorials/references.html for information about references in jupyter book.

With the changes in this PR, there are no links to documentation on GitHub from the Jupyter Book documentation.

Note that all changed links were manually checked but it would definitely be good to have another pair of eyes.