### PR TITLE
Update python-package.yml

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-11, windows-latest]
-        python-version: [3.7, 3.8, 3.9] #3.9 only failing for tables on macos and windows; mwm 6302021
+        python-version: [3.7, 3.8, 3.9, "3.10"] #3.9 only failing for tables on macos and windows; mwm 6302021
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip


### PR DESCRIPTION
- adds tests for 3.10 python
- proposal: drop tests for 3.7 python in the future // soon-ish ... discussed with @AlexEMG, we will keep 3.7 for now as M1 chip uses 3.7 in conda file for the time being! 