### PR TITLE
Ensure data is loaded upon each function evaluation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,13 +38,13 @@ def pytest_sessionfinish(session, exitstatus):
     shutil.rmtree(session.__DATA_FOLDER)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def ground_truth_detections():
     with open(os.path.join(TEST_DATA_DIR, "dets.pickle"), "rb") as file:
         return pickle.load(file)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def model_outputs():
     with open(os.path.join(TEST_DATA_DIR, "outputs.pickle"), "rb") as file:
         scmaps, locrefs, pafs = pickle.load(file)
@@ -54,19 +54,19 @@ def model_outputs():
     return scmaps, locrefs, pafs
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def sample_image():
     return np.asarray(Image.open(os.path.join(TEST_DATA_DIR, "image.png")))
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def sample_keypoints():
     with open(os.path.join(TEST_DATA_DIR, "trimouse_assemblies.pickle"), "rb") as file:
         temp = pickle.load(file)
     return np.concatenate(temp[0])[:, :2]
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def real_assemblies():
     with open(os.path.join(TEST_DATA_DIR, "trimouse_assemblies.pickle"), "rb") as file:
         temp = pickle.load(file)
@@ -74,7 +74,7 @@ def real_assemblies():
     return inferenceutils._parse_ground_truth_data(data)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def real_assemblies_montblanc():
     with open(os.path.join(TEST_DATA_DIR, "montblanc_assemblies.pickle"), "rb") as file:
         temp = pickle.load(file)
@@ -86,19 +86,19 @@ def real_assemblies_montblanc():
     return inferenceutils._parse_ground_truth_data(data), single
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def real_tracklets():
     with open(os.path.join(TEST_DATA_DIR, "trimouse_tracklets.pickle"), "rb") as file:
         return pickle.load(file)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def real_tracklets_montblanc():
     with open(os.path.join(TEST_DATA_DIR, "montblanc_tracklets.pickle"), "rb") as file:
         return pickle.load(file)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def evaluation_data_and_metadata():
     full_data_file = os.path.join(TEST_DATA_DIR, "trimouse_eval.pickle")
     metadata_file = full_data_file.replace("eval", "meta")
@@ -109,7 +109,7 @@ def evaluation_data_and_metadata():
     return data, metadata
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def evaluation_data_and_metadata_montblanc():
     full_data_file = os.path.join(TEST_DATA_DIR, "montblanc_eval.pickle")
     metadata_file = full_data_file.replace("eval", "meta")


### PR DESCRIPTION
In the test `test_benchmark_paf_graphs`

https://github.com/DeepLabCut/DeepLabCut/blob/master/tests/test_crossvalutils.py#L37

a call to `_benchmark_paf_graphs` where a call to `data.pop` is made. This mutates the shared copy of the data between tests and can cause subsequent tests to fail.

This is obvious if you are trying to run the test suite with [pytest-random-order](https://pypi.org/project/pytest-random-order/).

While you could try to make sure that all your test do not mutate the data, it is somewhat easier to simply create fresh copies for each test.

I hope this helps.