### PR TITLE
Avoid asserting specific values for tracker ids

### DIFF
--- a/tests/test_trackingutils.py
+++ b/tests/test_trackingutils.py
@@ -32,9 +32,8 @@ def test_ellipse_fitter():
 
 def test_ellipse_tracker(ellipse):
     tracker1 = trackingutils.EllipseTracker(ellipse.parameters)
-    assert tracker1.id == 0
     tracker2 = trackingutils.EllipseTracker(ellipse.parameters)
-    assert tracker2.id == 1
+    assert tracker1.id != tracker2.id
     tracker1.update(ellipse.parameters)
     assert tracker1.hit_streak == 1
     state = tracker1.predict()
@@ -75,9 +74,8 @@ def test_tracking_ellipse(real_assemblies, real_tracklets):
 def test_box_tracker():
     bbox = 0, 0, 100, 100
     tracker1 = trackingutils.BoxTracker(bbox)
-    assert tracker1.id == 0
     tracker2 = trackingutils.BoxTracker(bbox)
-    assert tracker2.id == 1
+    assert tracker1.id != tracker2.id
     tracker1.update(bbox)
     assert tracker1.hit_streak == 1
     state = tracker1.predict()


### PR DESCRIPTION
When running tests in a random order, the values of the tracker IDs are non-deterministic since the trackers may have been created in a previous test.

This adapts the test to ensure that the tracker IDs are unique, though not necessarily 0 and 1.


I hope this helps.

You may run the tests in a random order with: https://pypi.org/project/pytest-random-order/#description