### PR TITLE
fix dockerfiles

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,12 +1,19 @@
 FROM nvidia/cuda:11.4.0-cudnn8-runtime-ubuntu20.04
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -yy \ 
-    && apt-get install -yy --no-install-recommends python3 python3-pip ffmpeg libsm6 libxext6 \
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -yy \ 
+    && apt-get install -yy --no-install-recommends python3 python3-pip python3-dev ffmpeg libsm6 libxext6 \
+    && apt-get install -yy --no-install-recommends build-essential make cmake gcc g++ \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir --upgrade pip \
- && pip install --no-cache-dir --upgrade "deeplabcut>=2.2.0.2" numpy==1.19.5 decorator==4.4.2 tensorflow==2.5.0
+RUN pip3 install --no-cache-dir --upgrade pip \
+ && pip3 install --no-cache-dir --upgrade "deeplabcut>=2.2.0.2" numpy==1.19.5 decorator==4.4.2 tensorflow==2.5.0 \
+ && pip3 list
+
+#protobuf==3.20.1
 
 # TODO required to fix permission errors when running the container with limited permission.
 RUN chmod a+rwx -R /usr/local/lib/python3.8/dist-packages/deeplabcut/pose_estimation_tensorflow/models/pretrained
+

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -12,8 +12,6 @@ RUN pip3 install --no-cache-dir --upgrade pip \
  && pip3 install --no-cache-dir --upgrade "deeplabcut>=2.2.0.2" numpy==1.19.5 decorator==4.4.2 tensorflow==2.5.0 \
  && pip3 list
 
-#protobuf==3.20.1
-
 # TODO required to fix permission errors when running the container with limited permission.
 RUN chmod a+rwx -R /usr/local/lib/python3.8/dist-packages/deeplabcut/pose_estimation_tensorflow/models/pretrained
 

--- a/docker/Dockerfile.latest-gui
+++ b/docker/Dockerfile.latest-gui
@@ -8,10 +8,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -yy \
     && rm -rf /var/lib/apt/lists/* \
     && locale-gen en_US.UTF-8 en_GB.UTF-8
 
-RUN pip install --no-cache-dir --upgrade pip \
- && pip install --no-cache-dir --upgrade "deeplabcut[gui]>=2.2.0.2" numpy==1.19.5 decorator==4.4.2 tensorflow==2.5.0 \
- && pip uninstall --yes tensorboard \
- && pip install --no-cache-dir --upgrade protobuf==3.20.1
+RUN pip3 install --no-cache-dir --upgrade pip \
+ && pip3 install --no-cache-dir --upgrade "deeplabcut[gui]>=2.2.0.2" numpy==1.19.5 decorator==4.4.2 tensorflow==2.5.0 \
+ && pip3 uninstall --yes tensorboard \
+ && pip3 install --no-cache-dir --upgrade protobuf==3.20.1
 
 ENV DLClight=False
 CMD ["python3", "-m", "deeplabcut"]

--- a/docker/Dockerfile.latest-gui
+++ b/docker/Dockerfile.latest-gui
@@ -9,7 +9,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -yy \
     && locale-gen en_US.UTF-8 en_GB.UTF-8
 
 RUN pip install --no-cache-dir --upgrade pip \
- && pip install --no-cache-dir --upgrade "deeplabcut[gui]>=2.2.0.2" numpy==1.19.5 decorator==4.4.2 tensorflow==2.5.0
+ && pip install --no-cache-dir --upgrade "deeplabcut[gui]>=2.2.0.2" numpy==1.19.5 decorator==4.4.2 tensorflow==2.5.0 \
+ && pip uninstall --yes tensorboard \
+ && pip install --no-cache-dir --upgrade protobuf==3.20.1
 
 ENV DLClight=False
 CMD ["python3", "-m", "deeplabcut"]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -3,6 +3,7 @@
 # > docker/build.sh [build|test|push]
 
 set -e
+set -x
 
 DOCKER=${DOCKER:-'docker'}
 DOCKER_BUILD="$DOCKER build"


### PR DESCRIPTION
This PR fixes two things:
1) At container build time using `docker/build.sh build` it is necessary to add a compiler toolchain to the image to make OpenCV build and install successfully via `pip`.
2) At runtime TensorFlow complains about the recent protobuf version automatically pulled in via `pip`, so we add explicitly the protobuf version TensorFlow 2.5.0 requires.