### PR TITLE
Simplify checking and downloading weights

### DIFF
--- a/deeplabcut/utils/auxfun_models.py
+++ b/deeplabcut/utils/auxfun_models.py
@@ -47,12 +47,15 @@ def Check4weights(modeltype, parent_path, num_shuffles):
     model_path = parent_path / MODELTYPE_FILEPATH_MAP[modeltype]
 
     if not model_path.exists():
-        Downloadweights(modeltype)
+        if "efficientnet" in modeltype:
+            Downloadweights(modeltype, model_path.parent)
+        else:
+            Downloadweights(modeltype, model_path)
 
     return str(model_path), num_shuffles
 
 
-def Downloadweights(modeltype, model_path=None):
+def Downloadweights(modeltype, model_path):
     """
     Downloads the ImageNet pretrained weights for ResNets, MobileNets et al. from TensorFlow...
     """
@@ -60,8 +63,9 @@ def Downloadweights(modeltype, model_path=None):
     import tarfile
     from io import BytesIO
 
+    target_dir = model_path.parents[0]
     neturls = auxiliaryfunctions.read_plainconfig(
-        MODEL_BASE_PATH / "pretrained_model_urls.yaml"
+        target_dir / "pretrained_model_urls.yaml"
     )
     try:
         if "efficientnet" in modeltype:
@@ -72,7 +76,7 @@ def Downloadweights(modeltype, model_path=None):
         print("Downloading a ImageNet-pretrained model from {}....".format(url))
         response = urllib.request.urlopen(url)
         with tarfile.open(fileobj=BytesIO(response.read()), mode="r:gz") as tar:
-            tar.extractall(path=MODEL_BASE_PATH)
+            tar.extractall(path=target_dir)
     except KeyError:
         print("Model does not exist: ", modeltype)
         print("Pick one of the following: ", neturls.keys())

--- a/deeplabcut/utils/auxfun_models.py
+++ b/deeplabcut/utils/auxfun_models.py
@@ -47,11 +47,10 @@ def Check4weights(modeltype, parent_path, num_shuffles):
     model_path = parent_path / MODELTYPE_FILEPATH_MAP[modeltype]
 
     if num_shuffles > 0:
-        if "efficientnet" in modeltype:
-            if not model_path.exists():
+        if not model_path.exists():
+            if "efficientnet" in modeltype:
                 Downloadweights(modeltype, model_path.parent)
-        else:
-            if not model_path.is_file():
+            else:
                 Downloadweights(modeltype, model_path)
 
     return str(model_path), num_shuffles

--- a/deeplabcut/utils/auxfun_models.py
+++ b/deeplabcut/utils/auxfun_models.py
@@ -47,15 +47,12 @@ def Check4weights(modeltype, parent_path, num_shuffles):
     model_path = parent_path / MODELTYPE_FILEPATH_MAP[modeltype]
 
     if not model_path.exists():
-        if "efficientnet" in modeltype:
-            Downloadweights(modeltype, model_path.parent)
-        else:
-            Downloadweights(modeltype, model_path)
+        Downloadweights(modeltype)
 
     return str(model_path), num_shuffles
 
 
-def Downloadweights(modeltype, model_path):
+def Downloadweights(modeltype, model_path=None):
     """
     Downloads the ImageNet pretrained weights for ResNets, MobileNets et al. from TensorFlow...
     """
@@ -63,9 +60,8 @@ def Downloadweights(modeltype, model_path):
     import tarfile
     from io import BytesIO
 
-    target_dir = model_path.parents[0]
     neturls = auxiliaryfunctions.read_plainconfig(
-        target_dir / "pretrained_model_urls.yaml"
+        MODEL_BASE_PATH / "pretrained_model_urls.yaml"
     )
     try:
         if "efficientnet" in modeltype:
@@ -76,7 +72,7 @@ def Downloadweights(modeltype, model_path):
         print("Downloading a ImageNet-pretrained model from {}....".format(url))
         response = urllib.request.urlopen(url)
         with tarfile.open(fileobj=BytesIO(response.read()), mode="r:gz") as tar:
-            tar.extractall(path=target_dir)
+            tar.extractall(path=MODEL_BASE_PATH)
     except KeyError:
         print("Model does not exist: ", modeltype)
         print("Pick one of the following: ", neturls.keys())

--- a/deeplabcut/utils/auxfun_models.py
+++ b/deeplabcut/utils/auxfun_models.py
@@ -14,52 +14,42 @@ from pathlib import Path
 from deeplabcut.utils import auxiliaryfunctions
 
 
+# This dictionary maps the model types to the file locations where the models exist.
+MODEL_BASE_PATH = Path("pose_estimation_tensorflow") / "models" / "pretrained"
+MODELTYPE_FILEPATH_MAP = {
+    "resnet_50": MODEL_BASE_PATH / "resnet_v1_50.ckpt",
+    "resnet_101": MODEL_BASE_PATH / "resnet_v1_101.ckpt",
+    "resnet_152": MODEL_BASE_PATH / "resnet_v1_152.ckpt",
+    "mobilenet_v2_1.0": MODEL_BASE_PATH / "mobilenet_v2_1.0_224.ckpt",
+    "mobilenet_v2_0.75":MODEL_BASE_PATH / "mobilenet_v2_0.75_224.ckpt",
+    "mobilenet_v2_0.5": MODEL_BASE_PATH / "mobilenet_v2_0.5_224.ckpt",
+    "mobilenet_v2_0.35":MODEL_BASE_PATH / "mobilenet_v2_0.35_224.ckpt",
+    "efficientnet-b0": MODEL_BASE_PATH / "efficientnet-b0" / "model.ckpt",
+    "efficientnet-b1": MODEL_BASE_PATH / "efficientnet-b1" / "model.ckpt",
+    "efficientnet-b2": MODEL_BASE_PATH / "efficientnet-b2" / "model.ckpt",
+    "efficientnet-b3": MODEL_BASE_PATH / "efficientnet-b3" / "model.ckpt",
+    "efficientnet-b4": MODEL_BASE_PATH / "efficientnet-b4" / "model.ckpt",
+    "efficientnet-b5": MODEL_BASE_PATH / "efficientnet-b5" / "model.ckpt",
+    "efficientnet-b6": MODEL_BASE_PATH / "efficientnet-b6" / "model.ckpt",
+}
+
+
 def Check4weights(modeltype, parent_path, num_shuffles):
     """ gets local path to network weights and checks if they are present. If not, downloads them from tensorflow.org """
-    if "resnet_50" == modeltype:
-        model_path = (
-            parent_path
-            / "pose_estimation_tensorflow/models/pretrained/resnet_v1_50.ckpt"
-        )
-    elif "resnet_101" == modeltype:
-        model_path = (
-            parent_path
-            / "pose_estimation_tensorflow/models/pretrained/resnet_v1_101.ckpt"
-        )
-    elif "resnet_152" == modeltype:
-        model_path = (
-            parent_path
-            / "pose_estimation_tensorflow/models/pretrained/resnet_v1_152.ckpt"
-        )
-    elif "mobilenet" in modeltype:
-        model_path = Path(
-            os.path.join(
-                parent_path,
-                "pose_estimation_tensorflow/models/pretrained/"
-                + str(modeltype)
-                + "_224.ckpt",
-            )
-        )
-    elif "efficientnet" in modeltype:
-        model_path = Path(
-            os.path.join(
-                parent_path,
-                "pose_estimation_tensorflow/models/pretrained/"
-                + modeltype.replace("_", "-"),
-            )
-        )
-    else:
+
+    if modeltype not in MODELTYPE_FILEPATH_MAP.keys():
         print(
             "Currently ResNet (50, 101, 152), MobilenetV2 (1, 0.75, 0.5 and 0.35) and EfficientNet (b0-b6) are supported, please change 'resnet' entry in config.yaml!"
         )
         num_shuffles = -1  # thus the loop below is empty...
         model_path = parent_path
 
+    model_path = parent_path / MODELTYPE_FILEPATH_MAP[modeltype]
+
     if num_shuffles > 0:
         if "efficientnet" in modeltype:
-            if not os.path.isdir(model_path):
-                Downloadweights(modeltype, model_path)
-            model_path = os.path.join(model_path, "model.ckpt")
+            if not model_path.exists():
+                Downloadweights(modeltype, model_path.parent)
         else:
             if not model_path.is_file():
                 Downloadweights(modeltype, model_path)

--- a/deeplabcut/utils/auxfun_models.py
+++ b/deeplabcut/utils/auxfun_models.py
@@ -41,17 +41,16 @@ def Check4weights(modeltype, parent_path, num_shuffles):
         print(
             "Currently ResNet (50, 101, 152), MobilenetV2 (1, 0.75, 0.5 and 0.35) and EfficientNet (b0-b6) are supported, please change 'resnet' entry in config.yaml!"
         )
-        num_shuffles = -1  # thus the loop below is empty...
-        model_path = parent_path
+        # Exit the function early if an unknown modeltype is provided.
+        return parent_path, -1
 
     model_path = parent_path / MODELTYPE_FILEPATH_MAP[modeltype]
 
-    if num_shuffles > 0:
-        if not model_path.exists():
-            if "efficientnet" in modeltype:
-                Downloadweights(modeltype, model_path.parent)
-            else:
-                Downloadweights(modeltype, model_path)
+    if not model_path.exists():
+        if "efficientnet" in modeltype:
+            Downloadweights(modeltype, model_path.parent)
+        else:
+            Downloadweights(modeltype, model_path)
 
     return str(model_path), num_shuffles
 

--- a/deeplabcut/utils/tests/test_auxfun_models.py
+++ b/deeplabcut/utils/tests/test_auxfun_models.py
@@ -23,14 +23,7 @@ class Check4WeightsTestCase(unittest.TestCase):
                 for modeltype, expected_path in MODELTYPE_FILEPATH_MAP.items():
                     actual_path, _ = Check4weights(modeltype, Path(tmpdir), 1)
                 self.assertIn(str(expected_path), actual_path)
-                if "efficientnet" in modeltype:
-                    mocked_download.assert_called_with(
-                        modeltype, tmpdir / expected_path.parent
-                    )
-                else:
-                    mocked_download.assert_called_with(
-                        modeltype, tmpdir / expected_path
-                    )
+                mocked_download.assert_called_with(modeltype)
 
     def test_bad_modeltype(self):
         actual_path, actual_num_shuffles = Check4weights(

--- a/deeplabcut/utils/tests/test_auxfun_models.py
+++ b/deeplabcut/utils/tests/test_auxfun_models.py
@@ -23,7 +23,14 @@ class Check4WeightsTestCase(unittest.TestCase):
                 for modeltype, expected_path in MODELTYPE_FILEPATH_MAP.items():
                     actual_path, _ = Check4weights(modeltype, Path(tmpdir), 1)
                 self.assertIn(str(expected_path), actual_path)
-                mocked_download.assert_called_with(modeltype)
+                if "efficientnet" in modeltype:
+                    mocked_download.assert_called_with(
+                        modeltype, tmpdir / expected_path.parent
+                    )
+                else:
+                    mocked_download.assert_called_with(
+                        modeltype, tmpdir / expected_path
+                    )
 
     def test_bad_modeltype(self):
         actual_path, actual_num_shuffles = Check4weights(

--- a/deeplabcut/utils/tests/test_auxfun_models.py
+++ b/deeplabcut/utils/tests/test_auxfun_models.py
@@ -1,0 +1,33 @@
+"""
+DeepLabCut2.0 Toolbox (deeplabcut.org)
+© A. & M. Mathis Labs
+https://github.com/DeepLabCut/DeepLabCut
+Please see AUTHORS for contributors.
+
+https://github.com/DeepLabCut/DeepLabCut/blob/master/AUTHORS
+Licensed under GNU Lesser General Public License v3.0
+"""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import patch
+
+from deeplabcut.utils.auxfun_models import MODELTYPE_FILEPATH_MAP, Check4weights
+
+
+class Check4WeightsTestCase(unittest.TestCase):
+    def test_filepaths_for_modeltypes(self):
+        with TemporaryDirectory() as tmpdir:
+            with patch("deeplabcut.utils.auxfun_models.Downloadweights") as mocked_download:
+                for modeltype, expected_path in MODELTYPE_FILEPATH_MAP.items():
+                    actual_path, _ = Check4weights(modeltype, Path(tmpdir), 1)
+                self.assertIn(str(expected_path), actual_path)
+                if "efficientnet" in modeltype:
+                    mocked_download.assert_called_with(
+                        modeltype, tmpdir / expected_path.parent
+                    )
+                else:
+                    mocked_download.assert_called_with(
+                        modeltype, tmpdir / expected_path
+                    )

--- a/deeplabcut/utils/tests/test_auxfun_models.py
+++ b/deeplabcut/utils/tests/test_auxfun_models.py
@@ -31,3 +31,10 @@ class Check4WeightsTestCase(unittest.TestCase):
                     mocked_download.assert_called_with(
                         modeltype, tmpdir / expected_path
                     )
+
+    def test_bad_modeltype(self):
+        actual_path, actual_num_shuffles = Check4weights(
+            "dummymodel", "nonexistentpath", 1
+        )
+        self.assertEqual(actual_path, "nonexistentpath")
+        self.assertEqual(actual_num_shuffles, -1)


### PR DESCRIPTION
Contributes towards #1843 

This PR makes two big changes:

- Simplifies the logic in `Check4weights` to use a dictionary constant from the module to figure out the path where the weight files should be for a given model type
- Simplifies the logic in `Downloadweights`. This simplification became possible with the changes introduced to `Check4weights`

The changes made are backed up by tests, which are also added to the codebase in this PR.

Finally, here is a simple example script that a user can run to download model weights for a given model type ahead of time.

```
import sys

from deeplabcut.utils.auxfun_models import MODELTYPE_FILEPATH_MAP, Downloadweights


def main():
    # Multiple model types can be provided separated by spaces.
    modeltypes = sys.argv[1:]
    valid_modeltypes = list(MODELTYPE_FILEPATH_MAP.keys())
    for modeltype in modeltypes:
        if modeltype in valid_modeltypes:
            Downloadweights(modeltype)
        else:
            print(
                f"{modeltype} is not valid. Valid model types are {valid_modeltypes}"
            )


if __name__ == "__main__":
    main()
```

As mentioned earlier, this doesn't fully fix the issue described in #1843 but it simplifies the code, enabling a simple/elegant solution.

Note to reviewer : It might be easy to review this PR one commit at a time.