### PR TITLE
Fix broken link in Demo_3D_DeepLabCut.ipynb

### DIFF
--- a/examples/JUPYTER/Demo_3D_DeepLabCut.ipynb
+++ b/examples/JUPYTER/Demo_3D_DeepLabCut.ipynb
@@ -275,9 +275,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:DLC2]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-DLC2-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -289,7 +289,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/examples/JUPYTER/Demo_3D_DeepLabCut.ipynb
+++ b/examples/JUPYTER/Demo_3D_DeepLabCut.ipynb
@@ -120,7 +120,7 @@
     "     \n",
     "#### DEMO images:\n",
     " \n",
-    "Here, we used a standard set along with this notebook. These images are a part of the Camera Calibration ToolBox for Matlab; specifically example 5: http://www.vision.caltech.edu/bouguetj/calib_doc/htmls/example5.html \n",
+    "Here, we used a standard set along with this notebook. These images are a part of the Camera Calibration ToolBox for Matlab; specifically example 5. The images can be downloaded at: https://data.caltech.edu/records/20164. After downloading, the calibration images can be found at ../calib_doc/htmls/calib_example.zip\n",
     "\n",
     "\n",
     "If you wish to run this DEMO notebook, download the files and place inside the **calibration_images** directory. (To note, pairs 1 and 6 are not detected correctly, so please delete these images!). \n",
@@ -275,9 +275,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:DLC2]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-DLC2-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -289,7 +289,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Current link for calibration demo images is broken.

**Changes**

- Update link to download calibration demo images to the more permanent Caltech Research Data Repository site. https://data.caltech.edu/records/20164

- Verified they are the same images as shown in DeepLabCut 3D demo video at 0:50 of https://www.youtube.com/watch?v=Eh6oIGE4dwI