### PR TITLE
Fix TypeError for create_training_dataset when training videos are named by number

### DIFF
--- a/deeplabcut/utils/conversioncode.py
+++ b/deeplabcut/utils/conversioncode.py
@@ -74,7 +74,6 @@ def convertcsv2h5(config, userfeedback=True, scorer=None):
                 else:
                     index_col = 0
                 data = pd.read_csv(fn, index_col=index_col, header=header)
-                data.index = data.index.set_levels(data.index.levels[1].astype(str), level=1)
                 data.columns = data.columns.set_levels([scorer], level="scorer")
                 guarantee_multiindex_rows(data)
                 data.to_hdf(fn.replace(".csv", ".h5"), key="df_with_missing", mode="w")
@@ -241,6 +240,8 @@ def guarantee_multiindex_rows(df):
             df.index = pd.MultiIndex.from_tuples(splits)
         except TypeError:  #  Ignore numerical index of frame indices
             pass
+    
+    df.index = df.index.set_levels(df.index.levels[1].astype(str), level=1)  # set folder name to str
 
 
 def robust_split_path(s):

--- a/deeplabcut/utils/conversioncode.py
+++ b/deeplabcut/utils/conversioncode.py
@@ -241,7 +241,11 @@ def guarantee_multiindex_rows(df):
         except TypeError:  #  Ignore numerical index of frame indices
             pass
     
-    df.index = df.index.set_levels(df.index.levels[1].astype(str), level=1)  # set folder name to str
+    # Ensure folder names are strings
+    try:
+        df.index = df.index.set_levels(df.index.levels[1].astype(str), level=1)
+    except AttributeError:
+        pass
 
 
 def robust_split_path(s):

--- a/deeplabcut/utils/conversioncode.py
+++ b/deeplabcut/utils/conversioncode.py
@@ -74,6 +74,7 @@ def convertcsv2h5(config, userfeedback=True, scorer=None):
                 else:
                     index_col = 0
                 data = pd.read_csv(fn, index_col=index_col, header=header)
+                data.index = data.index.set_levels(data.index.levels[1].astype(str), level=1)
                 data.columns = data.columns.set_levels([scorer], level="scorer")
                 guarantee_multiindex_rows(data)
                 data.to_hdf(fn.replace(".csv", ".h5"), key="df_with_missing", mode="w")


### PR DESCRIPTION
Hi DeepLabCut team,

My training videos are named '1.mp4', '2.mp4' etc., which caused their filename/dirname to be interpreted as integers in the create_training_dataset function. (multi-animal version 2.2.1)
![TypeError](https://user-images.githubusercontent.com/82919281/173996318-adb75f45-303c-478c-afe0-f847e6eca4b7.PNG)

So I added a simple type conversion to ensure they are read as strings and fixed it in my attempt.