### PR TITLE
Update pose_cfg.yaml template

### DIFF
--- a/deeplabcut/pose_cfg.yaml
+++ b/deeplabcut/pose_cfg.yaml
@@ -77,20 +77,22 @@ mirror: False #imgaug & tensorpack do not consider mirror symmetric joints now,
 # set True to use with default parameters, otherwise give a dictionary for keyword arguments
 # If no ratio value is given, set to 0.4 by default
 
-# contrast:
-clahe: True
-claheratio: 0.1
-histeq: True
-histeqratio: 0.1
-#
-# convolution:
-sharpen: False
-sharpenratio: 0.3
-edge: False
-emboss:
-   alpha: [0.0, 1.0]
-   strength: [0.5, 1.5]
-   embossratio: 0.1
+# dictionary with contrast parameters
+contrast:
+   clahe: True
+   claheratio: 0.1
+   histeq: True
+   histeqratio: 0.1
+   
+# dictionary with convolution parameters
+convolution:
+   sharpen: False
+   sharpenratio: 0.3
+   edge: False
+   emboss:
+      alpha: [0.0, 1.0]
+      strength: [0.5, 1.5]
+      embossratio: 0.1
 
 ##############################################################################
 #### Augmentation type: scalecrop + tensorpack variables

--- a/deeplabcut/pose_cfg.yaml
+++ b/deeplabcut/pose_cfg.yaml
@@ -92,7 +92,7 @@ convolution:
    emboss:
       alpha: [0.0, 1.0]
       strength: [0.5, 1.5]
-      embossratio: 0.1
+   embossratio: 0.1
 
 ##############################################################################
 #### Augmentation type: scalecrop + tensorpack variables


### PR DESCRIPTION
We (@sabrinabenas and I) think there might be a bug in how the pose_config template is read for the contrast and convolution parameters for data augmentation. With the template as default, the contrast and convolution methods are always evaluated as False and not added to the pipeline (see pose_imgaug.py)
