### PR TITLE
"deeplabcut.filterpredictions" and "deeplabcut.analyze_skeleton" return mappings

### DIFF
--- a/deeplabcut/post_processing/analyze_skeleton.py
+++ b/deeplabcut/post_processing/analyze_skeleton.py
@@ -177,6 +177,7 @@ def analyzeskeleton(
     destfolder=None,
     modelprefix="",
     track_method="",
+    return_data=False,
 ):
     """Extracts length and orientation of each "bone" of the skeleton.
 
@@ -227,6 +228,9 @@ def analyzeskeleton(
         Empty by default (corresponding to a single animal project).
         For multiple animals, must be either 'box', 'skeleton', or 'ellipse' and will
         be taken from the config.yaml file if none is given.
+
+    return_data: bool, optional, default=False
+        If True, returns a dictionary of the filtered data keyed by video names.
 
     Returns
     -------
@@ -292,7 +296,9 @@ def analyzeskeleton(
         skeleton.to_hdf(output_name, "df_with_missing", format="table", mode="w")
         if save_as_csv:
             skeleton.to_csv(output_name.replace(".h5", ".csv"))
-    return video_to_skeleton_df
+
+    if return_data:
+        return video_to_skeleton_df
 
 
 if __name__ == "__main__":

--- a/deeplabcut/post_processing/analyze_skeleton.py
+++ b/deeplabcut/post_processing/analyze_skeleton.py
@@ -256,32 +256,32 @@ def analyzeskeleton(
             df, filepath, scorer, _ = auxiliaryfunctions.load_analyzed_data(
                 destfolder, vname, DLCscorer, filtered, track_method
             )
-            output_name = filepath.replace(".h5", f"_skeleton.h5")
-            if os.path.isfile(output_name):
-                print(f"Skeleton in video {vname} already processed. Skipping...")
-                continue
-
-            bones = {}
-            if "individuals" in df.columns.names:
-                for animal_name, df_ in df.groupby(level="individuals", axis=1):
-                    temp = df_.droplevel(["scorer", "individuals"], axis=1)
-                    if animal_name != "single":
-                        for bp1, bp2 in cfg["skeleton"]:
-                            name = "{}_{}_{}".format(animal_name, bp1, bp2)
-                            bones[name] = analyzebone(temp[bp1], temp[bp2])
-            else:
-                for bp1, bp2 in cfg["skeleton"]:
-                    name = "{}_{}".format(bp1, bp2)
-                    bones[name] = analyzebone(df[scorer][bp1], df[scorer][bp2])
-
-            skeleton = pd.concat(bones, axis=1)
-            skeleton.to_hdf(output_name, "df_with_missing", format="table", mode="w")
-            if save_as_csv:
-                skeleton.to_csv(output_name.replace(".h5", ".csv"))
-
         except FileNotFoundError as e:
             print(e)
             continue
+
+        output_name = filepath.replace(".h5", f"_skeleton.h5")
+        if os.path.isfile(output_name):
+            print(f"Skeleton in video {vname} already processed. Skipping...")
+            continue
+
+        bones = {}
+        if "individuals" in df.columns.names:
+            for animal_name, df_ in df.groupby(level="individuals", axis=1):
+                temp = df_.droplevel(["scorer", "individuals"], axis=1)
+                if animal_name != "single":
+                    for bp1, bp2 in cfg["skeleton"]:
+                        name = "{}_{}_{}".format(animal_name, bp1, bp2)
+                        bones[name] = analyzebone(temp[bp1], temp[bp2])
+        else:
+            for bp1, bp2 in cfg["skeleton"]:
+                name = "{}_{}".format(bp1, bp2)
+                bones[name] = analyzebone(df[scorer][bp1], df[scorer][bp2])
+
+        skeleton = pd.concat(bones, axis=1)
+        skeleton.to_hdf(output_name, "df_with_missing", format="table", mode="w")
+        if save_as_csv:
+            skeleton.to_csv(output_name.replace(".h5", ".csv"))
 
 
 if __name__ == "__main__":

--- a/deeplabcut/post_processing/filtering.py
+++ b/deeplabcut/post_processing/filtering.py
@@ -80,6 +80,7 @@ def filterpredictions(
     destfolder=None,
     modelprefix="",
     track_method="",
+    return_data=False,
 ):
     """Fits frame-by-frame pose predictions.
 
@@ -146,6 +147,9 @@ def filterpredictions(
         For multiple animals, must be either 'box', 'skeleton', or 'ellipse' and will
         be taken from the config.yaml file if none is given.
 
+    return_data: bool, optional, default=False
+        If True, returns a dictionary of the filtered data keyed by video names.
+
     Returns
     -------
     video_to_filtered_df
@@ -209,7 +213,8 @@ def filterpredictions(
 
     if not len(Videos):
         print("No video(s) were found. Please check your paths and/or 'videotype'.")
-        return video_to_filtered_df
+        if return_data:
+            return video_to_filtered_df
 
     for video in Videos:
         if destfolder is None:
@@ -292,7 +297,9 @@ def filterpredictions(
         if save_as_csv:
             print("Saving filtered csv poses!")
             data.to_csv(outdataname.split(".h5")[0] + ".csv")
-    return video_to_filtered_df
+
+    if return_data:
+        return video_to_filtered_df
 
 
 if __name__ == "__main__":

--- a/deeplabcut/post_processing/filtering.py
+++ b/deeplabcut/post_processing/filtering.py
@@ -226,60 +226,61 @@ def filterpredictions(
             df, filepath, _, _ = auxiliaryfunctions.load_analyzed_data(
                 destfolder, vname, DLCscorer, track_method=track_method
             )
-            nrows = df.shape[0]
-            if filtertype == "arima":
-                temp = df.values.reshape((nrows, -1, 3))
-                placeholder = np.empty_like(temp)
-                for i in range(temp.shape[1]):
-                    x, y, p = temp[:, i].T
-                    meanx, _ = FitSARIMAXModel(
-                        x, p, p_bound, alpha, ARdegree, MAdegree, False
-                    )
-                    meany, _ = FitSARIMAXModel(
-                        y, p, p_bound, alpha, ARdegree, MAdegree, False
-                    )
-                    meanx[0] = x[0]
-                    meany[0] = y[0]
-                    placeholder[:, i] = np.c_[meanx, meany, p]
-                data = pd.DataFrame(
-                    placeholder.reshape((nrows, -1)),
-                    columns=df.columns,
-                    index=df.index,
-                )
-            elif filtertype == "median":
-                data = df.copy()
-                mask = data.columns.get_level_values("coords") != "likelihood"
-                data.loc[:, mask] = df.loc[:, mask].apply(
-                    signal.medfilt, args=(windowlength,), axis=0
-                )
-            elif filtertype == "spline":
-                data = df.copy()
-                mask_data = data.columns.get_level_values("coords").isin(("x", "y"))
-                xy = data.loc[:, mask_data].values
-                prob = data.loc[:, ~mask_data].values
-                missing = np.isnan(xy)
-                xy_filled = columnwise_spline_interp(xy, windowlength)
-                filled = ~np.isnan(xy_filled)
-                xy[filled] = xy_filled[filled]
-                inds = np.argwhere(missing & filled)
-                if inds.size:
-                    # Retrieve original individual label indices
-                    inds[:, 1] //= 2
-                    inds = np.unique(inds, axis=0)
-                    prob[inds[:, 0], inds[:, 1]] = 0.01
-                    data.loc[:, ~mask_data] = prob
-                data.loc[:, mask_data] = xy
-            else:
-                raise ValueError(f"Unknown filter type {filtertype}")
-
-            outdataname = filepath.replace(".h5", "_filtered.h5")
-            data.to_hdf(outdataname, "df_with_missing", format="table", mode="w")
-            if save_as_csv:
-                print("Saving filtered csv poses!")
-                data.to_csv(outdataname.split(".h5")[0] + ".csv")
         except FileNotFoundError as e:
             print(e)
             continue
+
+        nrows = df.shape[0]
+        if filtertype == "arima":
+            temp = df.values.reshape((nrows, -1, 3))
+            placeholder = np.empty_like(temp)
+            for i in range(temp.shape[1]):
+                x, y, p = temp[:, i].T
+                meanx, _ = FitSARIMAXModel(
+                    x, p, p_bound, alpha, ARdegree, MAdegree, False
+                )
+                meany, _ = FitSARIMAXModel(
+                    y, p, p_bound, alpha, ARdegree, MAdegree, False
+                )
+                meanx[0] = x[0]
+                meany[0] = y[0]
+                placeholder[:, i] = np.c_[meanx, meany, p]
+            data = pd.DataFrame(
+                placeholder.reshape((nrows, -1)),
+                columns=df.columns,
+                index=df.index,
+            )
+        elif filtertype == "median":
+            data = df.copy()
+            mask = data.columns.get_level_values("coords") != "likelihood"
+            data.loc[:, mask] = df.loc[:, mask].apply(
+                signal.medfilt, args=(windowlength,), axis=0
+            )
+        elif filtertype == "spline":
+            data = df.copy()
+            mask_data = data.columns.get_level_values("coords").isin(("x", "y"))
+            xy = data.loc[:, mask_data].values
+            prob = data.loc[:, ~mask_data].values
+            missing = np.isnan(xy)
+            xy_filled = columnwise_spline_interp(xy, windowlength)
+            filled = ~np.isnan(xy_filled)
+            xy[filled] = xy_filled[filled]
+            inds = np.argwhere(missing & filled)
+            if inds.size:
+                # Retrieve original individual label indices
+                inds[:, 1] //= 2
+                inds = np.unique(inds, axis=0)
+                prob[inds[:, 0], inds[:, 1]] = 0.01
+                data.loc[:, ~mask_data] = prob
+            data.loc[:, mask_data] = xy
+        else:
+            raise ValueError(f"Unknown filter type {filtertype}")
+
+        outdataname = filepath.replace(".h5", "_filtered.h5")
+        data.to_hdf(outdataname, "df_with_missing", format="table", mode="w")
+        if save_as_csv:
+            print("Saving filtered csv poses!")
+            data.to_csv(outdataname.split(".h5")[0] + ".csv")
 
 
 if __name__ == "__main__":

--- a/deeplabcut/post_processing/filtering.py
+++ b/deeplabcut/post_processing/filtering.py
@@ -292,6 +292,7 @@ def filterpredictions(
         if save_as_csv:
             print("Saving filtered csv poses!")
             data.to_csv(outdataname.split(".h5")[0] + ".csv")
+    return video_to_filtered_df
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`deeplabcut.filterpredictions` at the moment returns `None`. Internally, there are two `try/except` blocks. The first try/except block looks for existing filtered data. The second try/except block looks for analyzed data to filter.

This PR does the following - 

* In the first commit, the second/inner try/except block is pulled out of the first try/except block. The first try/except block continues to the next video in the for loop if filtered data is found.
* In the second commit, the scope of the second try/except block is narrowed. Instead of finding and filtering the analyzed data in the try block, the try block only looks for the analyzed data now and the filtering happens outside.
* In the third and final commit, the PR stores the mapping between video filename and the corresponding filtered data. If no videos are found, an empty dictionary is returned and if analyzed data isnt found, `None` is returned for the corresponding video filename.

Similarly, `deeplabcut.analyze_skeleton` at the moment returns `None`.

Similar to change in `deeplabcut.filterpredictions` earlier, the scope of the `try/except` is also reduced - now the skeleton calculations are performed outside the try/except block. And `deeplabcut.analyze_skeleton` returns a mapping from the video filename to the corresponding skeleton data. If analyzed data isn't found for a given video filename, `None` will be used and if a pre-existing skeleton data file is found, a dataframe will be loaded from the file.

This addresses one of the points mentioned in #1895 - `deeplabcut` functions returning information instead of returning `None`.

Note to reviewer : It might be easier to review this PR one-commit-at-a-time.