### PR TITLE
Unpin statsmodels

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pyyaml
 scikit-image>=0.17,<1.0.0
 scikit-learn>=1.0
 scipy>=1.4
-statsmodels>=0.11,<=0.13.1
+statsmodels>=0.11
 tensorflow>=2.0
 tables==3.7.0
 tensorpack==0.11

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
         "scikit-image>=0.17,<=1.0.0",
         "scikit-learn>=1.0",
         "scipy>=1.4",
-        "statsmodels>=0.11,!=0.13.2",
+        "statsmodels>=0.11",
         "tables>=3.7.0",
         "tensorflow>=2.0",
         "tensorpack>=0.11",


### PR DESCRIPTION
We had pinned statsmodels a while ago, as v0.13.2 caused Colab to freeze when installing DLC (#1679). I found that this is no longer the case, so I'd suggest removing the pin.

Fixes #1870 