### PR TITLE
Add in_random_order flag to get_list_of_videos

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -267,6 +267,7 @@ def analyze_videos(
     trainingsetindex=0,
     gputouse=None,
     save_as_csv=False,
+    in_random_order=True,
     destfolder=None,
     batchsize=None,
     cropping=None,
@@ -316,6 +317,10 @@ def analyze_videos(
 
     save_as_csv: bool, optional, default=False
         Saves the predictions in a .csv file.
+
+    in_random_order: bool, optional (default=True)
+        Whether or not to analyze videos in a random order.
+        This is only relevant when specifying a video directory in `videos`.
 
     destfolder: string or None, optional, default=None
         Specifies the destination folder for analysis data. If ``None``, the path of
@@ -604,7 +609,7 @@ def analyze_videos(
     ##################################################
     # Looping over videos
     ##################################################
-    Videos = auxiliaryfunctions.get_list_of_videos(videos, videotype)
+    Videos = auxiliaryfunctions.get_list_of_videos(videos, videotype, in_random_order)
     if len(Videos) > 0:
         if "multi-animal" in dlc_cfg["dataset_type"]:
             from deeplabcut.pose_estimation_tensorflow.predict_multianimal import (

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -322,7 +322,8 @@ def write_pickle(filename, data):
 
 def get_list_of_videos(
     videos: typing.Union[typing.List[str], str],
-    videotype: typing.Union[typing.List[str], str] = ""
+    videotype: typing.Union[typing.List[str], str] = "",
+    in_random_order: bool = True,
 ) -> typing.List[str]:
     """ Returns list of videos of videotype "videotype" in
     folder videos or for list of videos.
@@ -338,6 +339,8 @@ def get_list_of_videos(
 
         videotype (list[str], str): File extension used to filter videos. Optional if ``videos`` is a list of video files,
             and filters with common video extensions if a directory is passed in.
+
+        in_random_order (bool): Whether or not to return a shuffled list of videos.
     """
     if isinstance(videos, str):
         videos = [videos]
@@ -349,15 +352,18 @@ def get_list_of_videos(
         if not videotype:
             videotype = auxfun_videos.SUPPORTED_VIDEOS
 
-        from random import shuffle
-
         print("Analyzing all the videos in the directory...")
         videofolder = videos[0]
 
         # make list of full paths
         videos = [os.path.join(videofolder, fn) for fn in os.listdir(videofolder)]
 
-        shuffle(videos) # this is useful so multiple nets can be used to analyze simultaneously
+        if in_random_order:
+            from random import shuffle
+
+            shuffle(videos) # this is useful so multiple nets can be used to analyze simultaneously
+        else:
+            videos.sort()
 
     if isinstance(videotype, str):
         videotype = [videotype]


### PR DESCRIPTION
Passing `in_random_order=True` to `analyze_videos` now lets users process videos in sorted order.

Fixes #1792.