### PR TITLE
Rename functions in `auxiliaryfunctions.py` from CamelCase to underscores

### DIFF
--- a/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
@@ -196,7 +196,7 @@ def create_multianimaltraining_dataset(
     scorer = cfg["scorer"]
     project_path = cfg["project_path"]
     # Create path for training sets & store data there
-    trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(cfg)
+    trainingsetfolder = auxiliaryfunctions.get_training_set_folder(cfg)
     full_training_path = Path(project_path, trainingsetfolder)
     auxiliaryfunctions.attempttomakefolder(full_training_path, recursive=True)
 
@@ -527,7 +527,7 @@ def convert_cropped_to_standard_dataset(
 
     datasets_folder = os.path.join(
         project_path,
-        auxiliaryfunctions.GetTrainingSetFolder(cfg),
+        auxiliaryfunctions.get_training_set_folder(cfg),
     )
     df_old = pd.read_hdf(
         os.path.join(datasets_folder, "CollectedData_" + cfg["scorer"] + ".h5"),

--- a/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
@@ -331,7 +331,7 @@ def create_multianimaltraining_dataset(
             (
                 datafilename,
                 metadatafilename,
-            ) = auxiliaryfunctions.GetDataandMetaDataFilenames(
+            ) = auxiliaryfunctions.get_data_and_metadata_filenames(
                 trainingsetfolder, trainFraction, shuffle, cfg
             )
             ################################################################################

--- a/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
@@ -337,7 +337,7 @@ def create_multianimaltraining_dataset(
             ################################################################################
             # Saving metadata and data file (Pickle file)
             ################################################################################
-            auxiliaryfunctions.SaveMetadata(
+            auxiliaryfunctions.save_metadata(
                 os.path.join(project_path, metadatafilename),
                 data,
                 trainIndices,

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -982,7 +982,7 @@ def create_training_dataset(
                 (
                     datafilename,
                     metadatafilename,
-                ) = auxiliaryfunctions.GetDataandMetaDataFilenames(
+                ) = auxiliaryfunctions.get_data_and_metadata_filenames(
                     trainingsetfolder, trainFraction, shuffle, cfg
                 )
 

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -617,7 +617,7 @@ def mergeandsplit(config, trainindex=0, uniform=True):
     scorer = cfg["scorer"]
     project_path = cfg["project_path"]
     # Create path for training sets & store data there
-    trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(
+    trainingsetfolder = auxiliaryfunctions.get_training_set_folder(
         cfg
     )  # Path concatenation OS platform independent
     auxiliaryfunctions.attempttomakefolder(
@@ -847,7 +847,7 @@ def create_training_dataset(
         scorer = cfg["scorer"]
         project_path = cfg["project_path"]
         # Create path for training sets & store data there
-        trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(
+        trainingsetfolder = auxiliaryfunctions.get_training_set_folder(
             cfg
         )  # Path concatenation OS platform independent
         auxiliaryfunctions.attempttomakefolder(

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -999,7 +999,7 @@ def create_training_dataset(
                 ################################################################################
                 # Saving metadata (Pickle file)
                 ################################################################################
-                auxiliaryfunctions.SaveMetadata(
+                auxiliaryfunctions.save_metadata(
                     os.path.join(project_path, metadatafilename),
                     data,
                     trainIndices,

--- a/deeplabcut/gui/refine_tracklets.py
+++ b/deeplabcut/gui/refine_tracklets.py
@@ -302,7 +302,7 @@ class Refine_tracklets(wx.Panel):
         )
 
     def refine_tracklets(self, event):
-        DLCscorer, _ = auxiliaryfunctions.GetScorerName(
+        DLCscorer, _ = auxiliaryfunctions.get_scorer_name(
             self.cfg,
             self.shuffle.GetValue(),
             self.cfg["TrainingFraction"][-1],

--- a/deeplabcut/pose_estimation_3d/triangulation.py
+++ b/deeplabcut/pose_estimation_3d/triangulation.py
@@ -230,7 +230,7 @@ def triangulate(
                             run_triangulate = True
 
                     # Check for scorer names in the pickle file of 3d output
-                    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.GetScorerName(
+                    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.get_scorer_name(
                         cfg, shuffle, trainFraction, trainingsiterations="unknown"
                     )
 

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -77,7 +77,7 @@ def calculatepafdistancebounds(
         ) = auxfun_multianimal.extractindividualsandbodyparts(cfg)
 
         # Loading human annotatated data
-        trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(cfg)
+        trainingsetfolder = auxiliaryfunctions.get_training_set_folder(cfg)
         trainFraction = cfg["TrainingFraction"][trainingsetindex]
         datafn, metadatafn = auxiliaryfunctions.get_data_and_metadata_filenames(
             trainingsetfolder, trainFraction, shuffle, cfg
@@ -271,7 +271,7 @@ def return_evaluate_network_data(
     cfg = auxiliaryfunctions.read_config(config)
 
     # Loading human annotatated data
-    trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(cfg)
+    trainingsetfolder = auxiliaryfunctions.get_training_set_folder(cfg)
     # Data=pd.read_hdf(os.path.join(cfg["project_path"],str(trainingsetfolder),'CollectedData_' + cfg["scorer"] + '.h5'),'df_with_missing')
 
     # Get list of body parts to evaluate network for
@@ -650,7 +650,7 @@ def evaluate_network(
                 )
 
         # Loading human annotatated data
-        trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(cfg)
+        trainingsetfolder = auxiliaryfunctions.get_training_set_folder(cfg)
         Data = pd.read_hdf(
             os.path.join(
                 cfg["project_path"],

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -97,7 +97,7 @@ def calculatepafdistancebounds(
             trainIndices,
             testIndices,
             trainFraction,
-        ) = auxiliaryfunctions.LoadMetadata(
+        ) = auxiliaryfunctions.load_metadata(
             os.path.join(cfg["project_path"], metadatafn)
         )
         Data = pd.read_hdf(
@@ -295,7 +295,7 @@ def return_evaluate_network_data(
     )
     path_test_config = Path(modelfolder) / "test" / "pose_cfg.yaml"
     # Load meta data
-    data, trainIndices, testIndices, trainFraction = auxiliaryfunctions.LoadMetadata(
+    data, trainIndices, testIndices, trainFraction = auxiliaryfunctions.load_metadata(
         os.path.join(cfg["project_path"], metadatafn)
     )
 
@@ -691,7 +691,7 @@ def evaluate_network(
                     trainIndices,
                     testIndices,
                     trainFraction,
-                ) = auxiliaryfunctions.LoadMetadata(
+                ) = auxiliaryfunctions.load_metadata(
                     os.path.join(cfg["project_path"], metadatafn)
                 )
 

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -383,7 +383,7 @@ def return_evaluate_network_data(
         ]  # read how many training siterations that corresponds to.
 
         # name for deeplabcut net (based on its parameters)
-        DLCscorer, DLCscorerlegacy = auxiliaryfunctions.GetScorerName(
+        DLCscorer, DLCscorerlegacy = auxiliaryfunctions.get_scorer_name(
             cfg, shuffle, trainFraction, trainingsiterations, modelprefix=modelprefix
         )
         if not returnjustfns:
@@ -783,7 +783,7 @@ def evaluate_network(
                     ]  # read how many training siterations that corresponds to.
 
                     # Name for deeplabcut net (based on its parameters)
-                    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.GetScorerName(
+                    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.get_scorer_name(
                         cfg,
                         shuffle,
                         trainFraction,

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -275,7 +275,7 @@ def return_evaluate_network_data(
     # Data=pd.read_hdf(os.path.join(cfg["project_path"],str(trainingsetfolder),'CollectedData_' + cfg["scorer"] + '.h5'),'df_with_missing')
 
     # Get list of body parts to evaluate network for
-    comparisonbodyparts = auxiliaryfunctions.IntersectionofBodyPartsandOnesGivenbyUser(
+    comparisonbodyparts = auxiliaryfunctions.intersection_of_body_parts_and_ones_given_by_user(
         cfg, comparisonbodyparts
     )
     ##################################################
@@ -660,7 +660,7 @@ def evaluate_network(
         )
 
         # Get list of body parts to evaluate network for
-        comparisonbodyparts = auxiliaryfunctions.IntersectionofBodyPartsandOnesGivenbyUser(
+        comparisonbodyparts = auxiliaryfunctions.intersection_of_body_parts_and_ones_given_by_user(
             cfg, comparisonbodyparts
         )
         # Make folder for evaluation

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -79,7 +79,7 @@ def calculatepafdistancebounds(
         # Loading human annotatated data
         trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(cfg)
         trainFraction = cfg["TrainingFraction"][trainingsetindex]
-        datafn, metadatafn = auxiliaryfunctions.GetDataandMetaDataFilenames(
+        datafn, metadatafn = auxiliaryfunctions.get_data_and_metadata_filenames(
             trainingsetfolder, trainFraction, shuffle, cfg
         )
         modelfolder = os.path.join(
@@ -282,7 +282,7 @@ def return_evaluate_network_data(
     # Load data...
     ##################################################
     trainFraction = cfg["TrainingFraction"][trainingsetindex]
-    datafn, metadatafn = auxiliaryfunctions.GetDataandMetaDataFilenames(
+    datafn, metadatafn = auxiliaryfunctions.get_data_and_metadata_filenames(
         trainingsetfolder, trainFraction, shuffle, cfg
     )
     modelfolder = os.path.join(
@@ -672,7 +672,7 @@ def evaluate_network(
                 ##################################################
                 # Load and setup CNN part detector
                 ##################################################
-                datafn, metadatafn = auxiliaryfunctions.GetDataandMetaDataFilenames(
+                datafn, metadatafn = auxiliaryfunctions.get_data_and_metadata_filenames(
                     trainingsetfolder, trainFraction, shuffle, cfg
                 )
                 modelfolder = os.path.join(

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -398,7 +398,7 @@ def return_evaluate_network_data(
             notanalyzed,
             resultsfilename,
             DLCscorer,
-        ) = auxiliaryfunctions.CheckifNotEvaluated(
+        ) = auxiliaryfunctions.check_if_not_evaluated(
             str(evaluationfolder), DLCscorer, DLCscorerlegacy, Snapshots[snapindex]
         )
         # resultsfilename=os.path.join(str(evaluationfolder),DLCscorer + '-' + str(Snapshots[snapindex])+  '.h5') # + '-' + str(snapshot)+  ' #'-' + Snapshots[snapindex]+  '.h5')
@@ -800,7 +800,7 @@ def evaluate_network(
                         notanalyzed,
                         resultsfilename,
                         DLCscorer,
-                    ) = auxiliaryfunctions.CheckifNotEvaluated(
+                    ) = auxiliaryfunctions.check_if_not_evaluated(
                         str(evaluationfolder),
                         DLCscorer,
                         DLCscorerlegacy,

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -142,7 +142,7 @@ def evaluate_multianimal_full(
         TrainingFractions = [cfg["TrainingFraction"][trainingsetindex]]
 
     # Loading human annotatated data
-    trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(cfg)
+    trainingsetfolder = auxiliaryfunctions.get_training_set_folder(cfg)
     Data = pd.read_hdf(
         os.path.join(
             cfg["project_path"],

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -153,7 +153,7 @@ def evaluate_multianimal_full(
     conversioncode.guarantee_multiindex_rows(Data)
 
     # Get list of body parts to evaluate network for
-    comparisonbodyparts = auxiliaryfunctions.IntersectionofBodyPartsandOnesGivenbyUser(
+    comparisonbodyparts = auxiliaryfunctions.intersection_of_body_parts_and_ones_given_by_user(
         cfg, comparisonbodyparts
     )
     all_bpts = np.asarray(

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -288,7 +288,7 @@ def evaluate_multianimal_full(
                         notanalyzed,
                         resultsfilename,
                         DLCscorer,
-                    ) = auxiliaryfunctions.CheckifNotEvaluated(
+                    ) = auxiliaryfunctions.check_if_not_evaluated(
                         str(evaluationfolder),
                         DLCscorer,
                         DLCscorerlegacy,

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -271,7 +271,7 @@ def evaluate_multianimal_full(
                     ]  # read how many training siterations that corresponds to.
 
                     # name for deeplabcut net (based on its parameters)
-                    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.GetScorerName(
+                    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.get_scorer_name(
                         cfg,
                         shuffle,
                         trainFraction,

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -169,7 +169,7 @@ def evaluate_multianimal_full(
             ##################################################
             # Load and setup CNN part detector
             ##################################################
-            datafn, metadatafn = auxiliaryfunctions.GetDataandMetaDataFilenames(
+            datafn, metadatafn = auxiliaryfunctions.get_data_and_metadata_filenames(
                 trainingsetfolder, trainFraction, shuffle, cfg
             )
             modelfolder = os.path.join(

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -188,7 +188,7 @@ def evaluate_multianimal_full(
                 trainIndices,
                 testIndices,
                 trainFraction,
-            ) = auxiliaryfunctions.LoadMetadata(
+            ) = auxiliaryfunctions.load_metadata(
                 os.path.join(cfg["project_path"], metadatafn)
             )
 

--- a/deeplabcut/pose_estimation_tensorflow/lib/crossvalutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/crossvalutils.py
@@ -406,7 +406,7 @@ def cross_validate_paf_graphs(
         paf_inds = best_graphs[0]
 
     if calibrate:
-        trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(cfg)
+        trainingsetfolder = auxiliaryfunctions.get_training_set_folder(cfg)
         calibration_file = os.path.join(
             cfg["project_path"],
             str(trainingsetfolder),

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1384,7 +1384,7 @@ def analyze_time_lapse_frames(
         os.chdir(directory)
         framelist = np.sort([fn for fn in os.listdir(os.curdir) if (frametype in fn)])
         vname = Path(directory).stem
-        notanalyzed, dataname, DLCscorer = auxiliaryfunctions.CheckifNotAnalyzed(
+        notanalyzed, dataname, DLCscorer = auxiliaryfunctions.check_if_not_analyzed(
             directory, vname, DLCscorer, DLCscorerlegacy, flag="framestack"
         )
         if notanalyzed:

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1111,7 +1111,7 @@ def AnalyzeVideo(
 
         print(f"Saving results in {destfolder}...")
         dataname = os.path.join(destfolder, vname + DLCscorer + ".h5")
-        auxiliaryfunctions.SaveData(
+        auxiliaryfunctions.save_data(
             PredictedData[:nframes, :],
             metadata,
             dataname,
@@ -1427,7 +1427,7 @@ def analyze_time_lapse_frames(
 
                 print("Saving results in %s..." % (directory))
 
-                auxiliaryfunctions.SaveData(
+                auxiliaryfunctions.save_data(
                     PredictedData[:nframes, :],
                     metadata,
                     dataname,

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -175,7 +175,7 @@ def create_tracking_dataset(
         )
 
     # Name for scorer:
-    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.GetScorerName(
+    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.get_scorer_name(
         cfg,
         shuffle,
         trainFraction,
@@ -562,7 +562,7 @@ def analyze_videos(
         )
 
     # Name for scorer:
-    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.GetScorerName(
+    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.get_scorer_name(
         cfg,
         shuffle,
         trainFraction,
@@ -1347,7 +1347,7 @@ def analyze_time_lapse_frames(
     dlc_cfg["batch_size"] = cfg["batch_size"]
 
     # Name for scorer:
-    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.GetScorerName(
+    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.get_scorer_name(
         cfg,
         shuffle,
         trainFraction,
@@ -1706,7 +1706,7 @@ def convert_detections2tracklets(
     trainingsiterations = (dlc_cfg["init_weights"].split(os.sep)[-1]).split("-")[-1]
 
     # Name for scorer:
-    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.GetScorerName(
+    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.get_scorer_name(
         cfg,
         shuffle,
         trainFraction,

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1492,7 +1492,7 @@ def _convert_detections_to_tracklets(
         min_affinity=inference_cfg.get("pafthreshold", 0.05),
     )
     if calibrate:
-        trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(cfg)
+        trainingsetfolder = auxiliaryfunctions.get_training_set_folder(cfg)
         train_data_file = os.path.join(
             cfg["project_path"],
             str(trainingsetfolder),
@@ -1795,7 +1795,7 @@ def convert_detections2tracklets(
                     identity_only=identity_only,
                 )
                 if calibrate:
-                    trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(cfg)
+                    trainingsetfolder = auxiliaryfunctions.get_training_set_folder(cfg)
                     train_data_file = os.path.join(
                         cfg["project_path"],
                         str(trainingsetfolder),

--- a/deeplabcut/pose_estimation_tensorflow/visualizemaps.py
+++ b/deeplabcut/pose_estimation_tensorflow/visualizemaps.py
@@ -112,7 +112,7 @@ def extract_maps(
         ##################################################
         # Load and setup CNN part detector
         ##################################################
-        datafn, metadatafn = auxiliaryfunctions.GetDataandMetaDataFilenames(
+        datafn, metadatafn = auxiliaryfunctions.get_data_and_metadata_filenames(
             trainingsetfolder, trainFraction, shuffle, cfg
         )
 

--- a/deeplabcut/pose_estimation_tensorflow/visualizemaps.py
+++ b/deeplabcut/pose_estimation_tensorflow/visualizemaps.py
@@ -131,7 +131,7 @@ def extract_maps(
             trainIndices,
             testIndices,
             trainFraction,
-        ) = auxiliaryfunctions.LoadMetadata(
+        ) = auxiliaryfunctions.load_metadata(
             os.path.join(cfg["project_path"], metadatafn)
         )
         try:

--- a/deeplabcut/pose_estimation_tensorflow/visualizemaps.py
+++ b/deeplabcut/pose_estimation_tensorflow/visualizemaps.py
@@ -419,7 +419,7 @@ def extract_save_all_maps(
         read_config,
         attempttomakefolder,
         get_evaluation_folder,
-        IntersectionofBodyPartsandOnesGivenbyUser,
+        intersection_of_body_parts_and_ones_given_by_user,
     )
     from tqdm import tqdm
 
@@ -428,7 +428,7 @@ def extract_save_all_maps(
         config, shuffle, trainingsetindex, gputouse, rescale, Indices, modelprefix
     )
 
-    comparisonbodyparts = IntersectionofBodyPartsandOnesGivenbyUser(
+    comparisonbodyparts = intersection_of_body_parts_and_ones_given_by_user(
         cfg, comparisonbodyparts
     )
 

--- a/deeplabcut/pose_estimation_tensorflow/visualizemaps.py
+++ b/deeplabcut/pose_estimation_tensorflow/visualizemaps.py
@@ -92,7 +92,7 @@ def extract_maps(
             )
 
     # Loading human annotatated data
-    trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(cfg)
+    trainingsetfolder = auxiliaryfunctions.get_training_set_folder(cfg)
     Data = pd.read_hdf(
         os.path.join(
             cfg["project_path"],

--- a/deeplabcut/post_processing/analyze_skeleton.py
+++ b/deeplabcut/post_processing/analyze_skeleton.py
@@ -238,7 +238,7 @@ def analyzeskeleton(
         raise ValueError("No skeleton defined in the config.yaml.")
 
     track_method = auxfun_multianimal.get_track_method(cfg, track_method=track_method)
-    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.GetScorerName(
+    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.get_scorer_name(
         cfg,
         shuffle,
         trainFraction=cfg["TrainingFraction"][trainingsetindex],

--- a/deeplabcut/post_processing/filtering.py
+++ b/deeplabcut/post_processing/filtering.py
@@ -192,7 +192,7 @@ def filterpredictions(
     cfg = auxiliaryfunctions.read_config(config)
     track_method = auxfun_multianimal.get_track_method(cfg, track_method=track_method)
 
-    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.GetScorerName(
+    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.get_scorer_name(
         cfg,
         shuffle,
         trainFraction=cfg["TrainingFraction"][trainingsetindex],

--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -341,7 +341,7 @@ def extract_outlier_frames(
     """
 
     cfg = auxiliaryfunctions.read_config(config)
-    bodyparts = auxiliaryfunctions.IntersectionofBodyPartsandOnesGivenbyUser(
+    bodyparts = auxiliaryfunctions.intersection_of_body_parts_and_ones_given_by_user(
         cfg, comparisonbodyparts
     )
     if not len(bodyparts):
@@ -609,7 +609,7 @@ def ExtractFramesbasedonPreselection(
     start = cfg["start"]
     stop = cfg["stop"]
     numframes2extract = cfg["numframes2pick"]
-    bodyparts = auxiliaryfunctions.IntersectionofBodyPartsandOnesGivenbyUser(cfg, "all")
+    bodyparts = auxiliaryfunctions.intersection_of_body_parts_and_ones_given_by_user(cfg, "all")
 
     videofolder = str(Path(video).parents[0])
     vname = str(Path(video).stem)

--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -349,7 +349,7 @@ def extract_outlier_frames(
 
     track_method = auxfun_multianimal.get_track_method(cfg, track_method=track_method)
 
-    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.GetScorerName(
+    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.get_scorer_name(
         cfg,
         shuffle,
         trainFraction=cfg["TrainingFraction"][trainingsetindex],

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -445,7 +445,7 @@ def GetTrainingSetFolder(cfg):
     )
 
 
-def GetDataandMetaDataFilenames(trainingsetfolder, trainFraction, shuffle, cfg):
+def get_data_and_metadata_filenames(trainingsetfolder, trainFraction, shuffle, cfg):
     # Filename for metadata and data relative to project path for corresponding parameters
     metadatafn = os.path.join(
         str(trainingsetfolder),
@@ -816,6 +816,7 @@ def find_next_unlabeled_folder(config_path, verbose=False):
 
 # aliases for backwards-compatibility.
 SaveData = save_data
+GetDataandMetaDataFilenames = get_data_and_metadata_filenames
 IntersectionofBodyPartsandOnesGivenbyUser = intersection_of_body_parts_and_ones_given_by_user
 GetScorerName = get_scorer_name
 CheckifPostProcessing = check_if_post_processing

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -420,7 +420,7 @@ def grab_files_in_folder(folder, ext="", relative=True):
             yield file if relative else os.path.join(folder, file)
 
 
-def GetVideoList(filename, videopath, videtype):
+def get_video_list(filename, videopath, videtype):
     """ Get list of videos in a path (if filetype == all), otherwise just a specific file."""
     videos = list(grab_files_in_folder(videopath, videtype))
     if filename == "all":
@@ -816,6 +816,7 @@ def find_next_unlabeled_folder(config_path, verbose=False):
 
 # aliases for backwards-compatibility.
 SaveData = save_data
+GetVideoList = get_video_list
 GetTrainingSetFolder = get_training_set_folder
 GetDataandMetaDataFilenames = get_data_and_metadata_filenames
 IntersectionofBodyPartsandOnesGivenbyUser = intersection_of_body_parts_and_ones_given_by_user

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -545,7 +545,7 @@ def form_data_containers(df, bodyparts):
     return df_x, df_y, df_likelihood
 
 
-def GetScorerName(
+def get_scorer_name(
     cfg, shuffle, trainFraction, trainingsiterations="unknown", modelprefix=""
 ):
     """ Extract the scorer/network name for a particular shuffle, training fraction, etc.
@@ -816,6 +816,7 @@ def find_next_unlabeled_folder(config_path, verbose=False):
 
 # aliases for backwards-compatibility.
 SaveData = save_data
+GetScorerName = get_scorer_name
 CheckifPostProcessing = check_if_post_processing
 CheckifNotAnalyzed = check_if_not_analyzed
 CheckifNotEvaluated = check_if_not_evaluated

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -614,7 +614,7 @@ def GetScorerName(
     return scorer, scorer_legacy
 
 
-def CheckifPostProcessing(folder, vname, DLCscorer, DLCscorerlegacy, suffix="filtered"):
+def check_if_post_processing(folder, vname, DLCscorer, DLCscorerlegacy, suffix="filtered"):
     """ Checks if filtered/bone lengths were already calculated. If not, figures
     out if data was already analyzed (either with legacy scorer name or new one!) """
     outdataname = os.path.join(folder, vname + DLCscorer + suffix + ".h5")
@@ -816,5 +816,6 @@ def find_next_unlabeled_folder(config_path, verbose=False):
 
 # aliases for backwards-compatibility.
 SaveData = save_data
+CheckifPostProcessing = check_if_post_processing
 CheckifNotAnalyzed = check_if_not_analyzed
 CheckifNotEvaluated = check_if_not_evaluated

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -387,7 +387,7 @@ def save_data(PredicteData, metadata, dataname, pdindex, imagenames, save_as_csv
         pickle.dump(metadata, f, pickle.HIGHEST_PROTOCOL)
 
 
-def SaveMetadata(metadatafilename, data, trainIndices, testIndices, trainFraction):
+def save_metadata(metadatafilename, data, trainIndices, testIndices, trainFraction):
     with open(metadatafilename, "wb") as f:
         # Pickle the 'labeled-data' dictionary using the highest protocol available.
         pickle.dump(
@@ -816,6 +816,7 @@ def find_next_unlabeled_folder(config_path, verbose=False):
 
 # aliases for backwards-compatibility.
 SaveData = save_data
+SaveMetadata = save_metadata
 LoadMetadata = load_metadata
 GetVideoList = get_video_list
 GetTrainingSetFolder = get_training_set_folder

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -435,7 +435,7 @@ def GetVideoList(filename, videopath, videtype):
 
 
 ## Various functions to get filenames, foldernames etc. based on configuration parameters.
-def GetTrainingSetFolder(cfg):
+def get_training_set_folder(cfg):
     """ Training Set folder for config file based on parameters """
     Task = cfg["Task"]
     date = cfg["date"]
@@ -816,6 +816,7 @@ def find_next_unlabeled_folder(config_path, verbose=False):
 
 # aliases for backwards-compatibility.
 SaveData = save_data
+GetTrainingSetFolder = get_training_set_folder
 GetDataandMetaDataFilenames = get_data_and_metadata_filenames
 IntersectionofBodyPartsandOnesGivenbyUser = intersection_of_body_parts_and_ones_given_by_user
 GetScorerName = get_scorer_name

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -648,7 +648,7 @@ def CheckifPostProcessing(folder, vname, DLCscorer, DLCscorerlegacy, suffix="fil
                 return False, outdataname, sourcedataname, DLCscorer
 
 
-def CheckifNotAnalyzed(destfolder, vname, DLCscorer, DLCscorerlegacy, flag="video"):
+def check_if_not_analyzed(destfolder, vname, DLCscorer, DLCscorerlegacy, flag="video"):
     h5files = list(grab_files_in_folder(destfolder, "h5", relative=False))
     if not len(h5files):
         dataname = os.path.join(destfolder, vname + DLCscorer + ".h5")
@@ -816,4 +816,5 @@ def find_next_unlabeled_folder(config_path, verbose=False):
 
 # aliases for backwards-compatibility.
 SaveData = save_data
+CheckifNotAnalyzed = check_if_not_analyzed
 CheckifNotEvaluated = check_if_not_evaluated

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -395,7 +395,7 @@ def SaveMetadata(metadatafilename, data, trainIndices, testIndices, trainFractio
         )
 
 
-def LoadMetadata(metadatafile):
+def load_metadata(metadatafile):
     with open(metadatafile, "rb") as f:
         [
             trainingdata_details,
@@ -816,6 +816,7 @@ def find_next_unlabeled_folder(config_path, verbose=False):
 
 # aliases for backwards-compatibility.
 SaveData = save_data
+LoadMetadata = load_metadata
 GetVideoList = get_video_list
 GetTrainingSetFolder = get_training_set_folder
 GetDataandMetaDataFilenames = get_data_and_metadata_filenames

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -674,7 +674,7 @@ def CheckifNotAnalyzed(destfolder, vname, DLCscorer, DLCscorerlegacy, flag="vide
     return True, dataname, DLCscorer
 
 
-def CheckifNotEvaluated(folder, DLCscorer, DLCscorerlegacy, snapshot):
+def check_if_not_evaluated(folder, DLCscorer, DLCscorerlegacy, snapshot):
     dataname = os.path.join(folder, DLCscorer + "-" + str(snapshot) + ".h5")
     if os.path.isfile(dataname):
         print("This net has already been evaluated!")
@@ -816,3 +816,4 @@ def find_next_unlabeled_folder(config_path, verbose=False):
 
 # aliases for backwards-compatibility.
 SaveData = save_data
+CheckifNotEvaluated = check_if_not_evaluated

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -515,7 +515,7 @@ def get_deeplabcut_path():
     return os.path.split(importlib.util.find_spec("deeplabcut").origin)[0]
 
 
-def IntersectionofBodyPartsandOnesGivenbyUser(cfg, comparisonbodyparts):
+def intersection_of_body_parts_and_ones_given_by_user(cfg, comparisonbodyparts):
     """ Returns all body parts when comparisonbodyparts=='all', otherwise all bpts that are in the intersection of comparisonbodyparts and the actual bodyparts """
     # if "MULTI!" in allbpts:
     if cfg["multianimalproject"]:
@@ -816,6 +816,7 @@ def find_next_unlabeled_folder(config_path, verbose=False):
 
 # aliases for backwards-compatibility.
 SaveData = save_data
+IntersectionofBodyPartsandOnesGivenbyUser = intersection_of_body_parts_and_ones_given_by_user
 GetScorerName = get_scorer_name
 CheckifPostProcessing = check_if_post_processing
 CheckifNotAnalyzed = check_if_not_analyzed

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -375,7 +375,7 @@ def get_list_of_videos(
     return videos
 
 
-def SaveData(PredicteData, metadata, dataname, pdindex, imagenames, save_as_csv):
+def save_data(PredicteData, metadata, dataname, pdindex, imagenames, save_as_csv):
     """ Save predicted data as h5 file and metadata as pickle file; created by predict_videos.py """
     DataMachine = pd.DataFrame(PredicteData, columns=pdindex, index=imagenames)
     if save_as_csv:
@@ -813,3 +813,6 @@ def find_next_unlabeled_folder(config_path, verbose=False):
                 frac = (~df.isna()).sum().sum() / df.size
                 print(f"{folder.name} | {int(100 * frac)} %")
     return next_folder
+
+# aliases for backwards-compatibility.
+SaveData = save_data

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -521,7 +521,7 @@ def create_labeled_video(
     track_method = auxfun_multianimal.get_track_method(cfg, track_method=track_method)
 
     trainFraction = cfg["TrainingFraction"][trainingsetindex]
-    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.GetScorerName(
+    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.get_scorer_name(
         cfg, shuffle, trainFraction, modelprefix=modelprefix
     )  # automatically loads corresponding model (even training iteration based on snapshot index)
 
@@ -937,7 +937,7 @@ def create_video_with_all_detections(
 
     cfg = auxiliaryfunctions.read_config(config)
     trainFraction = cfg["TrainingFraction"][trainingsetindex]
-    DLCscorername, _ = auxiliaryfunctions.GetScorerName(
+    DLCscorername, _ = auxiliaryfunctions.get_scorer_name(
         cfg, shuffle, trainFraction, modelprefix=modelprefix
     )
 

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -529,7 +529,7 @@ def create_labeled_video(
         fastmode = False  # otherwise one cannot save frames
         keypoints_only = False
 
-    bodyparts = auxiliaryfunctions.IntersectionofBodyPartsandOnesGivenbyUser(
+    bodyparts = auxiliaryfunctions.intersection_of_body_parts_and_ones_given_by_user(
         cfg, displayedbodyparts
     )
     individuals = auxfun_multianimal.IntersectionofIndividualsandOnesGivenbyUser(

--- a/deeplabcut/utils/plotting.py
+++ b/deeplabcut/utils/plotting.py
@@ -261,7 +261,7 @@ def plot_trajectories(
     DLCscorer, DLCscorerlegacy = auxiliaryfunctions.get_scorer_name(
         cfg, shuffle, trainFraction, modelprefix=modelprefix
     )  # automatically loads corresponding model (even training iteration based on snapshot index)
-    bodyparts = auxiliaryfunctions.IntersectionofBodyPartsandOnesGivenbyUser(
+    bodyparts = auxiliaryfunctions.intersection_of_body_parts_and_ones_given_by_user(
         cfg, displayedbodyparts
     )
     individuals = auxfun_multianimal.IntersectionofIndividualsandOnesGivenbyUser(

--- a/deeplabcut/utils/plotting.py
+++ b/deeplabcut/utils/plotting.py
@@ -258,7 +258,7 @@ def plot_trajectories(
     track_method = auxfun_multianimal.get_track_method(cfg, track_method=track_method)
 
     trainFraction = cfg["TrainingFraction"][trainingsetindex]
-    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.GetScorerName(
+    DLCscorer, DLCscorerlegacy = auxiliaryfunctions.get_scorer_name(
         cfg, shuffle, trainFraction, modelprefix=modelprefix
     )  # automatically loads corresponding model (even training iteration based on snapshot index)
     bodyparts = auxiliaryfunctions.IntersectionofBodyPartsandOnesGivenbyUser(

--- a/examples/testscript.py
+++ b/examples/testscript.py
@@ -128,7 +128,7 @@ if __name__ == "__main__":
 
     # Check the training image paths are correctly stored as arrays of strings
     trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(cfg)
-    datafile, _ = auxiliaryfunctions.GetDataandMetaDataFilenames(
+    datafile, _ = auxiliaryfunctions.get_data_and_metadata_filenames(
         trainingsetfolder, 0.8, 1, cfg,
     )
     mlab = sio.loadmat(os.path.join(cfg["project_path"], datafile))["dataset"]

--- a/examples/testscript.py
+++ b/examples/testscript.py
@@ -127,7 +127,7 @@ if __name__ == "__main__":
     )
 
     # Check the training image paths are correctly stored as arrays of strings
-    trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(cfg)
+    trainingsetfolder = auxiliaryfunctions.get_training_set_folder(cfg)
     datafile, _ = auxiliaryfunctions.get_data_and_metadata_filenames(
         trainingsetfolder, 0.8, 1, cfg,
     )

--- a/examples/testscript_multianimal.py
+++ b/examples/testscript_multianimal.py
@@ -168,7 +168,7 @@ if __name__ == "__main__":
     print("Video analyzed.")
 
     print("Create video with all detections...")
-    scorer, _ = auxiliaryfunctions.GetScorerName(cfg, 1, TRAIN_SIZE)
+    scorer, _ = auxiliaryfunctions.get_scorer_name(cfg, 1, TRAIN_SIZE)
 
     deeplabcut.create_video_with_all_detections(
         config_path, [new_video_path], shuffle=1, displayedbodyparts=["bodypart1"]

--- a/examples/testscript_multianimal.py
+++ b/examples/testscript_multianimal.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
     print("Train dataset created.")
 
     # Check the training image paths are correctly stored as arrays of strings
-    trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(cfg)
+    trainingsetfolder = auxiliaryfunctions.get_training_set_folder(cfg)
     datafile, _ = auxiliaryfunctions.get_data_and_metadata_filenames(
         trainingsetfolder, 0.8, 1, cfg,
     )

--- a/examples/testscript_multianimal.py
+++ b/examples/testscript_multianimal.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
 
     # Check the training image paths are correctly stored as arrays of strings
     trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(cfg)
-    datafile, _ = auxiliaryfunctions.GetDataandMetaDataFilenames(
+    datafile, _ = auxiliaryfunctions.get_data_and_metadata_filenames(
         trainingsetfolder, 0.8, 1, cfg,
     )
     datafile = datafile.split(".mat")[0] + ".pickle"

--- a/examples/testscript_transreid.py
+++ b/examples/testscript_transreid.py
@@ -170,7 +170,7 @@ if __name__ == "__main__":
     print("Video analyzed.")
 
     print("Create video with all detections...")
-    scorer, _ = auxiliaryfunctions.GetScorerName(cfg, 1, TRAIN_SIZE)
+    scorer, _ = auxiliaryfunctions.get_scorer_name(cfg, 1, TRAIN_SIZE)
 
     deeplabcut.create_video_with_all_detections(
         config_path, [new_video_path], shuffle=1, displayedbodyparts=["bodypart1"]

--- a/examples/testscript_transreid.py
+++ b/examples/testscript_transreid.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     print("Train dataset created.")
 
     # Check the training image paths are correctly stored as arrays of strings
-    trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(cfg)
+    trainingsetfolder = auxiliaryfunctions.get_training_set_folder(cfg)
     datafile, _ = auxiliaryfunctions.get_data_and_metadata_filenames(
         trainingsetfolder, 0.8, 1, cfg,
     )

--- a/examples/testscript_transreid.py
+++ b/examples/testscript_transreid.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
 
     # Check the training image paths are correctly stored as arrays of strings
     trainingsetfolder = auxiliaryfunctions.GetTrainingSetFolder(cfg)
-    datafile, _ = auxiliaryfunctions.GetDataandMetaDataFilenames(
+    datafile, _ = auxiliaryfunctions.get_data_and_metadata_filenames(
         trainingsetfolder, 0.8, 1, cfg,
     )
     datafile = datafile.split(".mat")[0] + ".pickle"


### PR DESCRIPTION
In this PR, we went through every function in the `deeplabcut.utils.auxiliaryfunctions` and renamed functions from CamelCase to underscores.

Each function was renamed and the function usage updated in a single commit so this PR can easily be reviewed one commit at a time.

Note that CamelCase aliases are added to the end of the module for backwards compatibility. I'm not sure how many people are using `deeplabcut` as a package and importing functions from inside the package. If backwards compatibility isn't a concern and the maintainers are sure that there is no need to maintain the aliases, I can remove them. If necessary, I can add `DeprecationWarning`s when the aliases are being used, if necessary.