### PR TITLE
Rename functions in "auxfun_models.py"

### DIFF
--- a/deeplabcut/create_project/modelzoo.py
+++ b/deeplabcut/create_project/modelzoo.py
@@ -262,7 +262,7 @@ def create_pretrained_project(
 
         # Download the weights and put then in appropriate directory
         print("Downloading weights...")
-        auxfun_models.DownloadModel(model, train_dir)
+        auxfun_models.download_model(model, train_dir)
 
         pose_cfg = deeplabcut.auxiliaryfunctions.read_plainconfig(path_train_config)
         print(path_train_config)

--- a/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
@@ -269,7 +269,7 @@ def create_multianimaltraining_dataset(
     # Loading the encoder (if necessary downloading from TF)
     dlcparent_path = auxiliaryfunctions.get_deeplabcut_path()
     defaultconfigfile = os.path.join(dlcparent_path, "pose_cfg.yaml")
-    model_path, num_shuffles = auxfun_models.Check4weights(
+    model_path, num_shuffles = auxfun_models.check_for_weights(
         net_type, Path(dlcparent_path), num_shuffles
     )
 

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -906,7 +906,7 @@ def create_training_dataset(
             defaultconfigfile = os.path.join(dlcparent_path, "pose_cfg.yaml")
         elif posecfg_template:
             defaultconfigfile = posecfg_template
-        model_path, num_shuffles = auxfun_models.Check4weights(
+        model_path, num_shuffles = auxfun_models.check_for_weights(
             net_type, Path(dlcparent_path), num_shuffles
         )
 

--- a/deeplabcut/utils/auxfun_models.py
+++ b/deeplabcut/utils/auxfun_models.py
@@ -82,7 +82,7 @@ def download_weights(modeltype, model_path):
         print("Pick one of the following: ", neturls.keys())
 
 
-def DownloadModel(modelname, target_dir):
+def download_model(modelname, target_dir):
     """
     Downloads a DeepLabCut Model Zoo Project
     """
@@ -164,3 +164,4 @@ def download_mpii_weights(wd):
 # Aliases for backwards-compatibility
 Check4Weights = check_for_weights
 Downloadweights = download_weights
+DownloadModel = download_model

--- a/deeplabcut/utils/auxfun_models.py
+++ b/deeplabcut/utils/auxfun_models.py
@@ -48,14 +48,14 @@ def check_for_weights(modeltype, parent_path, num_shuffles):
 
     if not model_path.exists():
         if "efficientnet" in modeltype:
-            Downloadweights(modeltype, model_path.parent)
+            download_weights(modeltype, model_path.parent)
         else:
-            Downloadweights(modeltype, model_path)
+            download_weights(modeltype, model_path)
 
     return str(model_path), num_shuffles
 
 
-def Downloadweights(modeltype, model_path):
+def download_weights(modeltype, model_path):
     """
     Downloads the ImageNet pretrained weights for ResNets, MobileNets et al. from TensorFlow...
     """
@@ -163,3 +163,4 @@ def download_mpii_weights(wd):
 
 # Aliases for backwards-compatibility
 Check4Weights = check_for_weights
+Downloadweights = download_weights

--- a/deeplabcut/utils/auxfun_models.py
+++ b/deeplabcut/utils/auxfun_models.py
@@ -34,7 +34,7 @@ MODELTYPE_FILEPATH_MAP = {
 }
 
 
-def Check4weights(modeltype, parent_path, num_shuffles):
+def check_for_weights(modeltype, parent_path, num_shuffles):
     """ gets local path to network weights and checks if they are present. If not, downloads them from tensorflow.org """
 
     if modeltype not in MODELTYPE_FILEPATH_MAP.keys():
@@ -159,3 +159,7 @@ def download_mpii_weights(wd):
             urllib.request.urlretrieve(i, filename)
 
     return filename
+
+
+# Aliases for backwards-compatibility
+Check4Weights = check_for_weights

--- a/tests/test_auxfun_models.py
+++ b/tests/test_auxfun_models.py
@@ -16,10 +16,10 @@ from unittest.mock import patch
 from deeplabcut.utils.auxfun_models import MODELTYPE_FILEPATH_MAP, check_for_weights
 
 
-class Check4WeightsTestCase(unittest.TestCase):
+class CheckForWeightsTestCase(unittest.TestCase):
     def test_filepaths_for_modeltypes(self):
         with TemporaryDirectory() as tmpdir:
-            with patch("deeplabcut.utils.auxfun_models.Downloadweights") as mocked_download:
+            with patch("deeplabcut.utils.auxfun_models.download_weights") as mocked_download:
                 for modeltype, expected_path in MODELTYPE_FILEPATH_MAP.items():
                     actual_path, _ = check_for_weights(modeltype, Path(tmpdir), 1)
                 self.assertIn(str(expected_path), actual_path)

--- a/tests/test_auxfun_models.py
+++ b/tests/test_auxfun_models.py
@@ -13,7 +13,7 @@ from tempfile import TemporaryDirectory
 import unittest
 from unittest.mock import patch
 
-from deeplabcut.utils.auxfun_models import MODELTYPE_FILEPATH_MAP, Check4weights
+from deeplabcut.utils.auxfun_models import MODELTYPE_FILEPATH_MAP, check_for_weights
 
 
 class Check4WeightsTestCase(unittest.TestCase):
@@ -21,7 +21,7 @@ class Check4WeightsTestCase(unittest.TestCase):
         with TemporaryDirectory() as tmpdir:
             with patch("deeplabcut.utils.auxfun_models.Downloadweights") as mocked_download:
                 for modeltype, expected_path in MODELTYPE_FILEPATH_MAP.items():
-                    actual_path, _ = Check4weights(modeltype, Path(tmpdir), 1)
+                    actual_path, _ = check_for_weights(modeltype, Path(tmpdir), 1)
                 self.assertIn(str(expected_path), actual_path)
                 if "efficientnet" in modeltype:
                     mocked_download.assert_called_with(
@@ -33,7 +33,7 @@ class Check4WeightsTestCase(unittest.TestCase):
                     )
 
     def test_bad_modeltype(self):
-        actual_path, actual_num_shuffles = Check4weights(
+        actual_path, actual_num_shuffles = check_for_weights(
             "dummymodel", "nonexistentpath", 1
         )
         self.assertEqual(actual_path, "nonexistentpath")


### PR DESCRIPTION
Similar to https://github.com/DeepLabCut/DeepLabCut/pull/1913, this PR renames the functions in `deeplabcut.utils.auxfun_models` from CamelCase to under_scores. Each commit renames a single function and updates the usage of the function. Backwards-compatibility aliases have been added like before.