### PR TITLE
Fix 'allow_growth'

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/training.py
+++ b/deeplabcut/pose_estimation_tensorflow/training.py
@@ -143,6 +143,9 @@ def train_network(
             keepdeconvweights=True,
         )
     """
+    if allow_growth:
+        os.environ['TF_FORCE_GPU_ALLOW_GROWTH'] = 'true'
+
     import tensorflow as tf
 
     # reload logger.


### PR DESCRIPTION
In order to run multiple processes on a given GPU, it seemed necessary to have this addition. 