### PR TITLE
Fix various typos

### DIFF
--- a/deeplabcut/gui/create_new_project.py
+++ b/deeplabcut/gui/create_new_project.py
@@ -366,7 +366,7 @@ class Create_new_project(wx.Panel):
                 )
             else:
                 wx.MessageBox(
-                    "Some of the enteries are missing.\n\nMake sure that the task and experimenter name are specified and videos are selected!",
+                    "Some of the entries are missing.\n\nMake sure that the task and experimenter name are specified and videos are selected!",
                     "Error",
                     wx.OK | wx.ICON_ERROR,
                 )

--- a/deeplabcut/gui/outlier_frame_extraction_toolbox.py
+++ b/deeplabcut/gui/outlier_frame_extraction_toolbox.py
@@ -209,7 +209,7 @@ class MainFrame(BaseFrame):
         self.firstFrame = 0
         self.Colorscheme = []
 
-        # Read confing file
+        # Read config file
         self.cfg = auxiliaryfunctions.read_config(config)
         self.Task = self.cfg["Task"]
         self.start = self.cfg["start"]

--- a/deeplabcut/pose_estimation_tensorflow/training.py
+++ b/deeplabcut/pose_estimation_tensorflow/training.py
@@ -78,7 +78,7 @@ def train_network(
 
     max_snapshots_to_keep: int or None
         Sets how many snapshots are kept, i.e. states of the trained network. Every
-        saving interation many times a snapshot is stored, however only the last
+        saving iteration many times a snapshot is stored, however only the last
         ``max_snapshots_to_keep`` many are kept! If you change this to None, then all
         are kept.
         See: https://github.com/DeepLabCut/DeepLabCut/issues/8#issuecomment-387404835

--- a/deeplabcut/pose_tracking_pytorch/model/backbones/vit_pytorch.py
+++ b/deeplabcut/pose_tracking_pytorch/model/backbones/vit_pytorch.py
@@ -335,7 +335,7 @@ class DLCTransReID(nn.Module):
                 )
 
 
-def resize_pos_embed(posemb, posemb_new, hight, width):
+def resize_pos_embed(posemb, posemb_new, height, width):
     # Rescale the grid of position embeddings when loading from state_dict. Adapted from
     # https://github.com/google-research/vision_transformer/blob/00883dd691c63a6830751563748663526e811cee/vit_jax/checkpoint.py#L224
     ntok_new = posemb_new.shape[1]
@@ -346,12 +346,12 @@ def resize_pos_embed(posemb, posemb_new, hight, width):
     gs_old = int(math.sqrt(len(posemb_grid)))
     print(
         "Resized position embedding from size:{} to size: {} with height:{} width: {}".format(
-            posemb.shape, posemb_new.shape, hight, width
+            posemb.shape, posemb_new.shape, height, width
         )
     )
     posemb_grid = posemb_grid.reshape(1, gs_old, gs_old, -1).permute(0, 3, 1, 2)
-    posemb_grid = F.interpolate(posemb_grid, size=(hight, width), mode="bilinear")
-    posemb_grid = posemb_grid.permute(0, 2, 3, 1).reshape(1, hight * width, -1)
+    posemb_grid = F.interpolate(posemb_grid, size=(height, width), mode="bilinear")
+    posemb_grid = posemb_grid.permute(0, 2, 3, 1).reshape(1, height * width, -1)
     posemb = torch.cat([posemb_token, posemb_grid], dim=1)
     return posemb
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -51,7 +51,7 @@ To get the location right, a cool trick is to drag the folder and drop it into T
      - Ubuntu/MacOS: ``source/conda activate nameoftheenv`` (i.e. on your Mac: ``conda activate DEEPLABCUT``)
      - Windows: ``activate nameoftheenv`` (i.e. ``activate DEEPLABCUT``)
 
-Now you should see (`nameofenv`) on the left of your teminal screen, i.e. ``(DEEPLABCUT) YourName-MacBook...``
+Now you should see (`nameofenv`) on the left of your terminal screen, i.e. ``(DEEPLABCUT) YourName-MacBook...``
 NOTE: no need to run pip install deeplabcut, as it is already installed!!! :)
 
 **Great, that's it! DeepLabCut is installed!**


### PR DESCRIPTION
Found via `codespell -q 3 -L interm,mot,nd,ro,sie,sur,tthe,warmup`