### PR TITLE
Handle argument errors in undistort_points()

### DIFF
--- a/deeplabcut/pose_estimation_3d/triangulation.py
+++ b/deeplabcut/pose_estimation_3d/triangulation.py
@@ -543,7 +543,7 @@ def undistort_points(config, dataframe, camera_pair):
     """
     if len(dataframe) != 2:
         raise ValueError(
-            f"undistort_points(config, dataframe, camera_pair) needs filenames to two data frames, but got dataframe={dataframe}".
+            f"undistort_points(config, dataframe, camera_pair) needs filenames to two data frames, but got dataframe={dataframe}."
         )
     for filename in dataframe:
         if not os.path.exists(filename):

--- a/deeplabcut/pose_estimation_3d/triangulation.py
+++ b/deeplabcut/pose_estimation_3d/triangulation.py
@@ -541,6 +541,19 @@ def undistort_points(config, dataframe, camera_pair):
         dataFrame_cam2_undistort = pd.read_hdf(os.path.join(path_undistort,filename_cam2 + '_undistort.h5'))
     else:
     """
+    if len(dataframe) != 2:
+        raise ValueError(
+            f"undistort_points(config, dataframe, camera_pair) needs filenames to two data frames, but got dataframe={dataframe}".
+        )
+    for filename in dataframe:
+        if not os.path.exists(filename):
+            raise FileNotFoundError(
+                f"Dataframe path '{filename}' could not be found in the filesystem."
+            )
+    if not os.path.exists(path_camera_matrix):
+        raise FileNotFoundError(
+            f"Camera matrix file '{path_camera_matrix}' could not be found in the filesystem."
+        )
     # Create an empty dataFrame to store the undistorted 2d coordinates and likelihood
     dataframe_cam1 = pd.read_hdf(dataframe[0])
     dataframe_cam2 = pd.read_hdf(dataframe[1])


### PR DESCRIPTION
Right now, argument errors in `undistort_points()` fail with an unexpressive error message. The PR proposes to change this and

- throws a `ValueError` if a wrong number of arguments is given for the filepaths
- throws a `FileNotFoundError` if either the camera matrix or any of the input data frames is not found

Both error messages include the erroneous paths for easier debugging.

---

For comparison, the current error message looks like this:

```
File /usr/local/lib/python3.8/dist-packages/deeplabcut/pose_estimation_3d/triangulation.py:545, in undistort_points(con
fig, dataframe, camera_pair)                                                                                           
    531 """                                                                                                            
    532 path_undistort = destfolder                                                                                    
    533 filename_cam1 = Path(dataframe[0]).stem                                                                        
   (...)                                                                                                               
    542 else:                                                                                                          
    543 """                                                                                                            
    544 # Create an empty dataFrame to store the undistorted 2d coordinates and likelihood                             
--> 545 dataframe_cam1 = pd.read_hdf(dataframe[0])                                                                     
    546 dataframe_cam2 = pd.read_hdf(dataframe[1])                                                                     
    547 path_stereo_file = os.path.join(path_camera_matrix, "stereo_params.pickle")                                    
                                                                                                                       
IndexError: list index out of range                                                                                    
```

and the user would need to manually figure out the value of `dataframe`.