### PR TITLE
Remove two dead ends from triangulate()

### DIFF
--- a/deeplabcut/pose_estimation_3d/triangulation.py
+++ b/deeplabcut/pose_estimation_3d/triangulation.py
@@ -134,7 +134,12 @@ def triangulate(
     for i in range(len(video_list)):
         dataname = []
         for j in range(len(video_list[i])):  # looping over cameras
-            if cam_names[j] in video_list[i][j]:
+            if cam_names[j] not in video_list[i][j]:
+                raise ValueError(
+                    f"Camera name '{cam_names[j]}' "
+                    f"not found in video list '{video_list[i][j]}'."
+                )
+            else:
                 print(
                     "Analyzing video %s using %s"
                     % (video_list[i][j], str("config_file_" + cam_names[j]))
@@ -298,6 +303,7 @@ def triangulate(
                     scorer_name[cam_names[j]] = DLCscorer
                     run_triangulate = True
                     print(destfolder, vname, DLCscorer)
+                    suffix = tr_method_suffix
                     if filterpredictions:
                         filtering.filterpredictions(
                             config_2d,
@@ -308,11 +314,12 @@ def triangulate(
                             filtertype=filtertype,
                             destfolder=destfolder,
                         )
-                        dataname.append(
-                            os.path.join(
-                                destfolder, vname + DLCscorer + tr_method_suffix + "_filtered.h5"
-                            )
+                        suffix += "_filtered"
+                    dataname.append(
+                        os.path.join(
+                            destfolder, vname + DLCscorer + suffix + ".h5"
                         )
+                    )
 
         if run_triangulate:
             #        if len(dataname)>0:


### PR DESCRIPTION
The [triangulate function](https://github.com/DeepLabCut/DeepLabCut/blob/a576225efae540e0f02221b4cd9fafbf8e6501c2/deeplabcut/pose_estimation_3d/triangulation.py#L26-L36) has two dead ends:

[This `if` statement](
https://github.com/DeepLabCut/DeepLabCut/blob/a576225efae540e0f02221b4cd9fafbf8e6501c2/deeplabcut/pose_estimation_3d/triangulation.py#L137) will silently fail to add to `dataname`. The PR adds a `ValueError()` in case the camera name does not match the video.

[This second `if` statement](https://github.com/DeepLabCut/DeepLabCut/blob/a576225efae540e0f02221b4cd9fafbf8e6501c2/deeplabcut/pose_estimation_3d/triangulation.py#L301-L315) will also silently fail in case `filterpredictions` is `False`. The PR includes a solution similar to the one used [here](https://github.com/DeepLabCut/DeepLabCut/blob/a576225efae540e0f02221b4cd9fafbf8e6501c2/deeplabcut/pose_estimation_3d/triangulation.py#L270-L286). It would be good to check this for any potential unwanted side effects before merging.