### PR TITLE
add validation for fps when fps*1000 overflow 65535(max of 16bit)

### DIFF
--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -88,8 +88,9 @@ def CreateVideo(
         ny, nx = clip.height(), clip.width()
 
     fps = clip.fps()
-    if fps*1000 > 65535:
-        fps = round(fps)
+    if isinstance(fps, float):
+        if fps*1000 > 65535:
+            fps = round(fps)
     nframes = clip.nframes
     duration = nframes / fps
 

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -88,6 +88,8 @@ def CreateVideo(
         ny, nx = clip.height(), clip.width()
 
     fps = clip.fps()
+    if fps*1000 > 65535:
+        fps = round(fps)
     nframes = clip.nframes
     duration = nframes / fps
 


### PR DESCRIPTION
Thank you for the great dlc programs.

I applied
> deeplabcut.create_labeled_video(config_path, [video_path])

After dlc added points to all frames, dlc cannot save the data as mp4 with following message.
> [mpeg4 @ 000001eb3d342700] timebase 1000/66667 not supported by MPEG 4 standard, the maximum admitted value for the timebase denominator is 65535

To solve the problem, I added 2 rows.
Please confirm it works well.

Best regards,