### PR TITLE
Update the Default frame extraction algorithm.

### DIFF
--- a/deeplabcut/generate_training_dataset/frame_extraction.py
+++ b/deeplabcut/generate_training_dataset/frame_extraction.py
@@ -64,7 +64,7 @@ def select_cropping_area(config, videos=None):
 def extract_frames(
     config,
     mode="automatic",
-    algo="uniform",
+    algo="kmeans",
     crop=False,
     userfeedback=True,
     cluster_step=1,

--- a/deeplabcut/generate_training_dataset/frame_extraction.py
+++ b/deeplabcut/generate_training_dataset/frame_extraction.py
@@ -111,10 +111,10 @@ def extract_frames(
         you to delete the ``collectdata(.h5/.csv)`` files before labeling. Use with
         caution!
 
-    algo : string, Either ``"kmeans"`` or ``"uniform"``, Default: `"uniform"`.
+    algo : string, Either ``"kmeans"`` or ``"uniform"``, Default: `"kmeans"`.
         String specifying the algorithm to use for selecting the frames. Currently,
         deeplabcut supports either ``kmeans`` or ``uniform`` based selection. This flag
-        is only required for ``automatic`` mode and the default is ``uniform``. For
+        is only required for ``automatic`` mode and the default is ``kmeans``. For
         ``"uniform"``, frames are picked in temporally uniform way, ``"kmeans"``
         performs clustering on downsampled frames (see user guide for details).
 

--- a/deeplabcut/generate_training_dataset/frame_extraction.py
+++ b/deeplabcut/generate_training_dataset/frame_extraction.py
@@ -64,7 +64,7 @@ def select_cropping_area(config, videos=None):
 def extract_frames(
     config,
     mode="automatic",
-    algo="kmeans",
+    algo="uniform",
     crop=False,
     userfeedback=True,
     cluster_step=1,


### PR DESCRIPTION
This is an extremely minor fix. The documented default frame extraction method is the ``"uniform"`` distribution algorithm, but the argument default is `"kmeans"`. This minor patch fixes that issue.