### PR TITLE
Fix failing tests

### DIFF
--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -124,7 +124,7 @@ def CreateVideo(
         nindividuals = len(Dataframe.columns.get_level_values("individuals").unique())
         map2bp = [bplist.index(bp) for bp in all_bpts]
         nbpts_per_ind = (
-            Dataframe.groupby(level="individuals", axis=1).size().values[0] // 3
+            Dataframe.groupby(level="individuals", axis=1).size().values // 3
         )
         map2id = []
         for i, j in enumerate(nbpts_per_ind):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ matplotlib<=3.5.2
 napari-deeplabcut>=0.0.6
 networkx>=2.6
 numpy>=1.18.5
-pandas>=1.0.1
+pandas>=1.0.1,!=1.5.0
 pyyaml
 qdarkstyle==3.1
 scikit-image>=0.17

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
         "matplotlib>=3.3",
         "networkx>=2.6",
         "numpy>=1.18.5",
-        "pandas>=1.0.1",
+        "pandas>=1.0.1,!=1.5.0",
         "scikit-image>=0.17",
         "scikit-learn>=1.0",
         "scipy>=1.4",


### PR DESCRIPTION
pandas 1.5.0 introduced a regression in the groupby behavior—which we fixed with #2007—but just restored the previous behavior in 1.5.1 (see https://pandas.pydata.org/docs/whatsnew/v1.5.1.html#behavior-of-groupby-with-categorical-groupers-gh48645)
We too restore the previous code and avoid installing 1.5.0.
