### PR TITLE
Avoid sampling of NaN center location

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/datasets/augmentation.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/augmentation.py
@@ -92,6 +92,7 @@ class KeypointAwareCropToFixedSize(iaa.CropToFixedSize):
             else:
                 h, w = batch.images[n].shape[:2]
                 kpts = batch.keypoints[n].to_xy_array()
+                kpts = kpts[~np.isnan(kpts).all(axis=1)]
                 n_kpts = kpts.shape[0]
                 inds = np.arange(n_kpts)
                 if sampling == "density":


### PR DESCRIPTION
In #1946, np.full(..., np.nan) is required in order for FlipLR to work when keypoints are hidden. Occasionally though, a NaN point can be sampled as crop center https://github.com/DeepLabCut/DeepLabCut/blob/ecbb85818e49c6575597f1808a1c3e224d58ca8f/deeplabcut/pose_estimation_tensorflow/datasets/augmentation.py#L94-L107 causing imgaug errors.
This one-liner addresses this bug.