### PR TITLE
Get an empty list if "recent_files" is None

### DIFF
--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -103,7 +103,7 @@ class MainWindow(QMainWindow):
         return QtCore.QSettings()
 
     def load_settings(self):
-        filenames = self.settings.value("recent_files", [])
+        filenames = self.settings.value("recent_files") or []
         for filename in filenames:
             self.add_recent_filename(filename)
 


### PR DESCRIPTION
I could not reproduce the error in #2046, but this one-line fix guarantees that we always get an iterable (an empty list) if "recent_files" evaluates to None.

Fixes #2046