### PR TITLE
Do not add a new video if it already exists

### DIFF
--- a/deeplabcut/create_project/add.py
+++ b/deeplabcut/create_project/add.py
@@ -80,7 +80,7 @@ def add_new_videos(config, videos, copy_videos=False, coords=None, extract_frame
         print("Attempting to create a symbolic link of the video ...")
         for src, dst in zip(videos, destinations):
             if dst.exists():
-                pass
+                continue
             try:
                 src = str(src)
                 dst = str(dst)

--- a/deeplabcut/create_project/add.py
+++ b/deeplabcut/create_project/add.py
@@ -80,6 +80,7 @@ def add_new_videos(config, videos, copy_videos=False, coords=None, extract_frame
         print("Attempting to create a symbolic link of the video ...")
         for src, dst in zip(videos, destinations):
             if dst.exists():
+                print(f"Video {dst} already exists. Skipping...")
                 continue
             try:
                 src = str(src)


### PR DESCRIPTION
With `pass`,  we'd still attempt to add a new video even if the destination file exists. This is now corrected with `continue`.