### PR TITLE
do not write when frame is None

### DIFF
--- a/deeplabcut/utils/video_processor.py
+++ b/deeplabcut/utils/video_processor.py
@@ -146,7 +146,8 @@ class VideoProcessorCV(VideoProcessor):
         return np.flip(frame, 2)
 
     def save_frame(self, frame):
-        self.svid.write(np.flip(frame, 2))
+        if frame is not None:
+            self.svid.write(np.flip(frame, 2))
 
     def close(self):
         if hasattr(self, "svid") and self.svid is not None:


### PR DESCRIPTION
When creating a labeled video with a bad frame, save_frame() fails. This is just to add a sanity check for the argument frame.