### PR TITLE
Fix circular imports on python3.7

### DIFF
--- a/deeplabcut/refine_training_dataset/tracklets.py
+++ b/deeplabcut/refine_training_dataset/tracklets.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pickle
 import re
 from deeplabcut.post_processing import columnwise_spline_interp
-from deeplabcut.utils.auxiliaryfunctions import read_config
+from deeplabcut.utils import auxiliaryfunctions
 from tqdm import trange
 
 
@@ -36,7 +36,7 @@ class TrackletManager:
         manager.find_swapping_bodypart_pairs()
         """
         self.config = config
-        self.cfg = read_config(config)
+        self.cfg = auxiliaryfunctions.read_config(config)
         self.min_swap_len = min_swap_len
         self.min_tracklet_len = min_tracklet_len
         self.max_gap = max_gap

--- a/deeplabcut/utils/visualization.py
+++ b/deeplabcut/utils/visualization.py
@@ -17,7 +17,7 @@ from matplotlib.collections import LineCollection
 from skimage import io, color
 from tqdm import trange
 
-from deeplabcut.utils.auxiliaryfunctions import attempttomakefolder
+from deeplabcut.utils import auxiliaryfunctions
 
 
 def get_cmap(n, name="hsv"):
@@ -301,7 +301,7 @@ def make_labeled_images_from_dataframe(
     if not destfolder:
         destfolder = os.path.dirname(images_list[0])
     tmpfolder = destfolder + "_labeled"
-    attempttomakefolder(tmpfolder)
+    auxiliaryfunctions.attempttomakefolder(tmpfolder)
     ic = io.imread_collection(images_list)
 
     h, w = ic[0].shape[:2]


### PR DESCRIPTION
DeepLabCut mysteriously fails to import on python3.7 since 2.3rc2. This is fixed with these minor edits, though I'd suggest adding py3.7 back in CI since this is the version Colab uses.