### PR TITLE
Test DLC on Ubuntu & python 3.7

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-11, windows-latest]
-        python-version: [3.8, 3.9, "3.10"] #3.9 only failing for tables on macos and windows; mwm 6302021
+        python-version: [3.7, 3.8, 3.9, "3.10"] #3.9 only failing for tables on macos and windows; mwm 6302021
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip
@@ -22,6 +22,11 @@ jobs:
             path: ~/Library/Caches/pip
           - os: windows-latest
             path: ~\AppData\Local\pip\Cache
+        exclude:
+          - os: macos-11
+            python-version: 3.7
+          - os: windows-latest
+            python-version: 3.7
 
     steps:
       - name: Checkout code

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-11, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"] #3.9 only failing for tables on macos and windows; mwm 6302021
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip


### PR DESCRIPTION
Following #2069, we add back python 3.7 on Ubuntu to GitHub's CI (to test DLC on a setup equivalent to Google Colab).