### PR TITLE
Better handling failures in video creating GUI

### DIFF
--- a/deeplabcut/gui/tabs/create_videos.py
+++ b/deeplabcut/gui/tabs/create_videos.py
@@ -217,7 +217,7 @@ class CreateVideos(DefaultTab):
         ):
             bodyparts = self.bodyparts_to_use
 
-        deeplabcut.create_labeled_video(
+        videos_created = deeplabcut.create_labeled_video(
             config=config,
             videos=videos,
             shuffle=shuffle,
@@ -228,7 +228,16 @@ class CreateVideos(DefaultTab):
             trailpoints=trailpoints,
             color_by=color_by,
         )
-        self.root.writer.write("Labeled videos created.")
+        if all(videos_created):
+            self.root.writer.write("Labeled videos created.")
+        else:
+            failed_videos = [
+                video for success, video in zip(videos_created, videos) if not success
+            ]
+            failed_videos_str = (
+                failed_videos[0] if len(failed_videos) == 1 else ", ".join(failed_videos)
+            )
+            self.root.writer.write(f"Failed to create videos from {failed_videos_str}.")
 
         if self.plot_trajectories.checkState():
             deeplabcut.plot_trajectories(

--- a/deeplabcut/gui/tabs/create_videos.py
+++ b/deeplabcut/gui/tabs/create_videos.py
@@ -234,9 +234,7 @@ class CreateVideos(DefaultTab):
             failed_videos = [
                 video for success, video in zip(videos_created, videos) if not success
             ]
-            failed_videos_str = (
-                failed_videos[0] if len(failed_videos) == 1 else ", ".join(failed_videos)
-            )
+            failed_videos_str = ", ".join(failed_videos)
             self.root.writer.write(f"Failed to create videos from {failed_videos_str}.")
 
         if self.plot_trajectories.checkState():

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -474,7 +474,8 @@ def create_labeled_video(
 
     Returns
     -------
-    None
+        results : list[bool]
+        ``True`` if the video is successfully created for each item in ``videos``.
 
     Examples
     --------
@@ -549,7 +550,7 @@ def create_labeled_video(
     Videos = auxiliaryfunctions.get_list_of_videos(videos, videotype)
 
     if not Videos:
-        return
+        return []
 
     func = partial(
         proc_video,
@@ -577,9 +578,10 @@ def create_labeled_video(
     )
 
     with Pool(min(os.cpu_count(), len(Videos))) as pool:
-        pool.map(func, Videos)
+        results = pool.map(func, Videos)
 
     os.chdir(start_path)
+    return results
 
 
 def proc_video(
@@ -612,6 +614,10 @@ def proc_video(
     ----------
 
 
+    Returns
+    -------
+        result : bool
+        ``True`` if a video is successfully created.
     """
     videofolder = Path(video).parents[0]
     if destfolder is None:
@@ -632,6 +638,7 @@ def proc_video(
 
     if os.path.isfile(videooutname1) or os.path.isfile(videooutname2):
         print("Labeled video {} already created.".format(vname))
+        return True
     else:
         print("Loading {} and data.".format(video))
         try:
@@ -735,9 +742,11 @@ def proc_video(
                     trailpoints=trailpoints,
                     fps=outputframerate,
                 )
+            return True
 
         except FileNotFoundError as e:
             print(e)
+            return False
 
 
 def _create_labeled_video(

--- a/deeplabcut/utils/plotting.py
+++ b/deeplabcut/utils/plotting.py
@@ -334,7 +334,7 @@ def plot_trajectories(
 
     if len(failures) > 0:
         # Some vidoes were not evaluated.
-        failed_videos = failures[0] if len(failures) == 0 else ",".join(failures)
+        failed_videos = ",".join(failures)
         if len(multianimal_errors) > 0:
             verbose_error = ": " + " ".join(multianimal_errors)
         else:


### PR DESCRIPTION
Show errors if video creation fails, like:
![image](https://user-images.githubusercontent.com/16046705/205820819-6d83a931-97d3-433c-ac20-5af3a0d1d1ca.png)

When `prot_trajectry` is checked:
![image](https://user-images.githubusercontent.com/16046705/205820939-2528fee9-79e3-4dcf-86f5-ab34e4648aac.png)


Currently, the message `Labeled videos created.` is shown regardless of the result.
If I check `plot_trajectory`, the exception below is thrown (for a single animal case), which I don't feel very kind.
```
FileNotFoundError: No unfiltered data file found in /home/yuji/Videos/...
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/yuji/Programs/DeepLabCut/deeplabcut/gui/tabs/create_videos.py", line 241, in create_videos
    deeplabcut.plot_trajectories(
  File "/home/yuji/Programs/DeepLabCut/deeplabcut/utils/plotting.py", line 321, in plot_trajectories
    _ = auxiliaryfunctions.load_detection_data(
  File "/home/yuji/Programs/DeepLabCut/deeplabcut/utils/auxiliaryfunctions.py", line 792, in load_detection_data
    raise ValueError(f"Unrecognized track_method={track_method}")
ValueError: Unrecognized track_method=
```