### PR TITLE
Cap TF version to 2.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setuptools.setup(
         ],
         "openvino": ["openvino-dev==2022.1.0"],
         "docs": ["numpydoc"],
-        "tf": ["tensorflow>=2.0"],
+        "tf": ["tensorflow>=2.0,<=2.10"],  # Last supported TF version on Windows Native
         "apple_mchips": [],
         "modelzoo": ["huggingface_hub"],
     },


### PR DESCRIPTION
As pointed out in #2081, Tensorflow 2.10 will be the last version supported on Native Windows.
Given the recent release of 2.11, pinning TF to <=2.10 avoids failing installations on Windows.

Fixes #2081