### PR TITLE
prevents replotting of existing plots during model evaluation

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -275,8 +275,10 @@ def return_evaluate_network_data(
     # Data=pd.read_hdf(os.path.join(cfg["project_path"],str(trainingsetfolder),'CollectedData_' + cfg["scorer"] + '.h5'),'df_with_missing')
 
     # Get list of body parts to evaluate network for
-    comparisonbodyparts = auxiliaryfunctions.intersection_of_body_parts_and_ones_given_by_user(
-        cfg, comparisonbodyparts
+    comparisonbodyparts = (
+        auxiliaryfunctions.intersection_of_body_parts_and_ones_given_by_user(
+            cfg, comparisonbodyparts
+        )
     )
     ##################################################
     # Load data...
@@ -660,8 +662,10 @@ def evaluate_network(
         )
 
         # Get list of body parts to evaluate network for
-        comparisonbodyparts = auxiliaryfunctions.intersection_of_body_parts_and_ones_given_by_user(
-            cfg, comparisonbodyparts
+        comparisonbodyparts = (
+            auxiliaryfunctions.intersection_of_body_parts_and_ones_given_by_user(
+                cfg, comparisonbodyparts
+            )
         )
         # Make folder for evaluation
         auxiliaryfunctions.attempttomakefolder(
@@ -954,9 +958,6 @@ def evaluate_network(
                             DataCombined = pd.concat(
                                 [Data.T, DataMachine.T], axis=0, sort=False
                             ).T
-                            print(
-                                "Plotting...(attention scale might be inconsistent in comparison to when data was analyzed; i.e. if you used rescale)"
-                            )
                             foldername = os.path.join(
                                 str(evaluationfolder),
                                 "LabeledImages_"
@@ -964,15 +965,23 @@ def evaluate_network(
                                 + "_"
                                 + Snapshots[snapindex],
                             )
-                            auxiliaryfunctions.attempttomakefolder(foldername)
-                            Plotting(
-                                cfg,
-                                comparisonbodyparts,
-                                DLCscorer,
-                                trainIndices,
-                                DataCombined * 1.0 / scale,
-                                foldername,
-                            )
+                            if not os.path.exists(foldername):
+                                print(
+                                    "Plotting...(attention scale might be inconsistent in comparison to when data was analyzed; i.e. if you used rescale)"
+                                )
+                                auxiliaryfunctions.attempttomakefolder(foldername)
+                                Plotting(
+                                    cfg,
+                                    comparisonbodyparts,
+                                    DLCscorer,
+                                    trainIndices,
+                                    DataCombined * 1.0 / scale,
+                                    foldername,
+                                )
+                            else:
+                                print(
+                                    "Plots already exist for this snapshot... Skipping to the next one."
+                                )
 
                 if len(final_result) > 0:  # Only append if results were calculated
                     make_results_file(final_result, evaluationfolder, DLCscorer)

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -1019,7 +1019,7 @@ def make_results_file(final_result, evaluationfolder, DLCscorer):
     output_path = os.path.join(str(evaluationfolder), DLCscorer + "-results.csv")
     if os.path.exists(output_path):
         temp = pd.read_csv(output_path, index_col=0)
-        df = pd.concat((df, temp)).reset_index(drop=True)
+        df = pd.concat((temp, df)).reset_index(drop=True)
 
     df.to_csv(output_path)
 
@@ -1031,7 +1031,7 @@ def make_results_file(final_result, evaluationfolder, DLCscorer):
     )
     if os.path.exists(output_path):
         temp = pd.read_csv(output_path, index_col=0)
-        df = pd.concat((df, temp)).reset_index(drop=True)
+        df = pd.concat((temp, df)).reset_index(drop=True)
 
     df.to_csv(output_path)
 


### PR DESCRIPTION
Hi team DLC!

Here's my use case and the optimization I propose in this PR: I trained a DLC model on 200k iterations, saving snapshots every 10k iterations; I evaluated all iterations with plotting=True; when I looked at the train/test error curves, I realize my model needed more iterations (best snapshot was at 190k iterations, so it didn't plateaued yet); I restarted training from init_weight snapshot #200k for 500k more iterations; once training finished, I relaunched evaluate_network (still with plotting=True), and even though the 20 first snapshots had already been evaluated and were correctly detected as such ("This net has already been evaluated!" output), the plotting step re-occurred, adding about 1min per snapshot to unnecessarily recreate existing plots.

In this PR, I simply updated evaluate.py around l955 (case when `notanalyzed` is False) to skip the Plotting call if folder already exists (it could be cleaner to check if all frames within folder exist, but to me this is good enough). That way, I just saved myself 20 min. Could also have specified snapshotindex in config.yaml, but it wasn't immediately clear how to set this parameter (besides -1, all or an int).

As it's my first PR in this repo, I would like to take a second and thank you for providing to the community such an amazing toolbox!

Best,
Ludovic