### PR TITLE
Label video when num_outputs > 1 (and overwriting flag)

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -275,8 +275,10 @@ def return_evaluate_network_data(
     # Data=pd.read_hdf(os.path.join(cfg["project_path"],str(trainingsetfolder),'CollectedData_' + cfg["scorer"] + '.h5'),'df_with_missing')
 
     # Get list of body parts to evaluate network for
-    comparisonbodyparts = auxiliaryfunctions.intersection_of_body_parts_and_ones_given_by_user(
-        cfg, comparisonbodyparts
+    comparisonbodyparts = (
+        auxiliaryfunctions.intersection_of_body_parts_and_ones_given_by_user(
+            cfg, comparisonbodyparts
+        )
     )
     ##################################################
     # Load data...
@@ -660,8 +662,10 @@ def evaluate_network(
         )
 
         # Get list of body parts to evaluate network for
-        comparisonbodyparts = auxiliaryfunctions.intersection_of_body_parts_and_ones_given_by_user(
-            cfg, comparisonbodyparts
+        comparisonbodyparts = (
+            auxiliaryfunctions.intersection_of_body_parts_and_ones_given_by_user(
+                cfg, comparisonbodyparts
+            )
         )
         # Make folder for evaluation
         auxiliaryfunctions.attempttomakefolder(
@@ -954,9 +958,6 @@ def evaluate_network(
                             DataCombined = pd.concat(
                                 [Data.T, DataMachine.T], axis=0, sort=False
                             ).T
-                            print(
-                                "Plotting...(attention scale might be inconsistent in comparison to when data was analyzed; i.e. if you used rescale)"
-                            )
                             foldername = os.path.join(
                                 str(evaluationfolder),
                                 "LabeledImages_"
@@ -964,15 +965,23 @@ def evaluate_network(
                                 + "_"
                                 + Snapshots[snapindex],
                             )
-                            auxiliaryfunctions.attempttomakefolder(foldername)
-                            Plotting(
-                                cfg,
-                                comparisonbodyparts,
-                                DLCscorer,
-                                trainIndices,
-                                DataCombined * 1.0 / scale,
-                                foldername,
-                            )
+                            if not os.path.exists(foldername):
+                                print(
+                                    "Plotting...(attention scale might be inconsistent in comparison to when data was analyzed; i.e. if you used rescale)"
+                                )
+                                auxiliaryfunctions.attempttomakefolder(foldername)
+                                Plotting(
+                                    cfg,
+                                    comparisonbodyparts,
+                                    DLCscorer,
+                                    trainIndices,
+                                    DataCombined * 1.0 / scale,
+                                    foldername,
+                                )
+                            else:
+                                print(
+                                    "Plots already exist for this snapshot... Skipping to the next one."
+                                )
 
                 if len(final_result) > 0:  # Only append if results were calculated
                     make_results_file(final_result, evaluationfolder, DLCscorer)

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -1019,7 +1019,7 @@ def make_results_file(final_result, evaluationfolder, DLCscorer):
     output_path = os.path.join(str(evaluationfolder), DLCscorer + "-results.csv")
     if os.path.exists(output_path):
         temp = pd.read_csv(output_path, index_col=0)
-        df = pd.concat((df, temp)).reset_index(drop=True)
+        df = pd.concat((temp, df)).reset_index(drop=True)
 
     df.to_csv(output_path)
 
@@ -1031,7 +1031,7 @@ def make_results_file(final_result, evaluationfolder, DLCscorer):
     )
     if os.path.exists(output_path):
         temp = pd.read_csv(output_path, index_col=0)
-        df = pd.concat((df, temp)).reset_index(drop=True)
+        df = pd.concat((temp, df)).reset_index(drop=True)
 
     df.to_csv(output_path)
 


### PR DESCRIPTION
Hi DLC team!

Based on a reply of @MMathisLab on an [unrelated PR](https://github.com/DeepLabCut/DeepLabCut/issues/2094#issuecomment-1361688793), I went ahead and added `num_outputs: 2` in the `config.yaml` file of a model trained from frames/videos of a single animal, but which I wanted to use to analyze videos containing two animals. Calling `analyze_video` worked fine, and the resulting HDF file contained for each body part two sets of x,y,likelihood (namely, 'x', 'y', 'likelihood', 'x2', 'y2', 'likelihood2'). However, calling `create_labeled_video` resulted in an indexing error ("IndexError: index N is out of bounds for axis 0 with size N", N being the number of body parts), and it came from the fact that while I had 2N sets of estimates (two per body part), there were only N colors (one per body part; further details in the code).

This PR fixes the bug described above by taking into account situations where num_outputs>1 in single animal models, in a parsimonious approach (i.e., by replacing existing lines of code so that output using num_outputs=1 doesn't change at all, and output using num_outputs>1 is now valid, as opposed to adding a new situation).

Also, while doing this debugging I constantly had to manually delete the created movie, so I implemented an overwriting flag in `create_labeled_video` that defaults at False. Turning it to True forces overwriting.

(besides, here's the bottom line of my attempt at estimating poses for the two animals: while the video did show two labels per body part after debugging, on many frames my animal of interest had two labels on it for the same body part, so it looks like a dead end for this strategy in my use case, and I'll have to rely on masking!)

Please don't hesitate if you need further information!
Best,
Ludovic