### PR TITLE
GUI fixes

### DIFF
--- a/deeplabcut/generate_training_dataset/frame_extraction.py
+++ b/deeplabcut/generate_training_dataset/frame_extraction.py
@@ -263,11 +263,9 @@ def extract_frames(
     from deeplabcut.utils import auxiliaryfunctions
 
     if mode == "manual":
-        wd = Path(config).resolve().parents[0]
-        os.chdir(str(wd))
-        from deeplabcut.gui import frame_extraction_toolbox
-
-        frame_extraction_toolbox.show(config, slider_width)
+        from deeplabcut.gui.widgets import launch_napari
+        _ = launch_napari()
+        return
 
     elif mode == "automatic":
         config_file = Path(config).resolve()

--- a/deeplabcut/gui/tabs/analyze_videos.py
+++ b/deeplabcut/gui/tabs/analyze_videos.py
@@ -258,8 +258,6 @@ class AnalyzeVideos(DefaultTab):
 
         videos = list(self.files)
         save_as_csv = self.save_as_csv.checkState() == Qt.Checked
-        save_as_nwb = self.save_as_nwb.checkState() == Qt.Checked
-        filter_data = self.filter_predictions.checkState() == Qt.Checked
         videotype = self.video_selection_widget.videotype_widget.currentText()
 
         if self.root.is_multianimal:
@@ -272,14 +270,10 @@ class AnalyzeVideos(DefaultTab):
             track_method = self.tracker_type_widget.currentText()
             edit_config(self.root.config, {"default_track_method": track_method})
             num_animals_in_videos = self.num_animals_in_videos.value()
-            create_video_all_detections = (
-                self.create_detections_video_checkbox.checkState() == Qt.Checked
-            )
         else:
             calibrate_assembly = False
             num_animals_in_videos = None
             assemble_with_ID_only = False
-            create_video_all_detections = False
 
         cropping = None
 
@@ -316,10 +310,23 @@ class AnalyzeVideos(DefaultTab):
         self.worker, self.thread = move_to_separate_thread(func)
         self.worker.finished.connect(lambda: self.analyze_videos_btn.setEnabled(True))
         self.worker.finished.connect(lambda: self.root._progress_bar.hide())
+        self.worker.finished.connect(lambda: self.run_enabled())
         self.thread.start()
         self.analyze_videos_btn.setEnabled(False)
         self.root._progress_bar.show()
 
+    def run_enabled(self):
+        config = self.root.config
+        shuffle = self.root.shuffle_value
+
+        videos = list(self.files)
+        save_as_csv = self.save_as_csv.checkState() == Qt.Checked
+        save_as_nwb = self.save_as_nwb.checkState() == Qt.Checked
+        filter_data = self.filter_predictions.checkState() == Qt.Checked
+        videotype = self.video_selection_widget.videotype_widget.currentText()
+        create_video_all_detections = (
+                self.create_detections_video_checkbox.checkState() == Qt.Checked
+            )
         if create_video_all_detections:
             deeplabcut.create_video_with_all_detections(
                 config,
@@ -331,7 +338,7 @@ class AnalyzeVideos(DefaultTab):
         if filter_data:
             deeplabcut.filterpredictions(
                 config,
-                videos=videos,
+                video=videos,
                 videotype=videotype,
                 shuffle=shuffle,
                 filtertype="median",
@@ -341,7 +348,7 @@ class AnalyzeVideos(DefaultTab):
 
         if self.plot_trajectories.checkState() == Qt.Checked:
             bdpts = self.bodyparts_list_widget.selected_bodyparts
-            self.logger.debug(f"Selected body parts for plot_trajectories: {bdpts}")
+            self.root.logger.debug(f"Selected body parts for plot_trajectories: {bdpts}")
             showfig = self.show_trajectory_plots.checkState() == Qt.Checked
             deeplabcut.plot_trajectories(
                 config,

--- a/deeplabcut/gui/tabs/create_project.py
+++ b/deeplabcut/gui/tabs/create_project.py
@@ -58,6 +58,7 @@ class ProjectCreator(QtWidgets.QDialog):
         loc_label = ClickableLabel("Location:", parent=user_frame)
         loc_label.signal.connect(self.on_click)
         self.loc_line = QtWidgets.QLineEdit(self.loc_default, user_frame)
+        self.loc_line.textEdited.connect(self.on_text)
 
         vbox = QtWidgets.QVBoxLayout(user_frame)
         grid = QtWidgets.QGridLayout()
@@ -193,7 +194,11 @@ class ProjectCreator(QtWidgets.QDialog):
                     child.setDisabled(True)
                 else:
                     child.setDisabled(False)
-
+    
+    def on_text(self, text): #can this be done recursively?
+        self.loc_default = text
+        self.update_project_location()
+    
     def update_project_name(self, text):
         self.proj_default = text
         self.update_project_location()

--- a/deeplabcut/gui/tabs/create_project.py
+++ b/deeplabcut/gui/tabs/create_project.py
@@ -58,7 +58,6 @@ class ProjectCreator(QtWidgets.QDialog):
         loc_label = ClickableLabel("Location:", parent=user_frame)
         loc_label.signal.connect(self.on_click)
         self.loc_line = QtWidgets.QLineEdit(self.loc_default, user_frame)
-        self.loc_line.textEdited.connect(self.on_text)
 
         vbox = QtWidgets.QVBoxLayout(user_frame)
         grid = QtWidgets.QGridLayout()
@@ -194,10 +193,6 @@ class ProjectCreator(QtWidgets.QDialog):
                     child.setDisabled(True)
                 else:
                     child.setDisabled(False)
-    
-    def on_text(self, text): #can this be done recursively?
-        self.loc_default = text
-        self.update_project_location()
     
     def update_project_name(self, text):
         self.proj_default = text

--- a/deeplabcut/gui/tabs/extract_outlier_frames.py
+++ b/deeplabcut/gui/tabs/extract_outlier_frames.py
@@ -60,7 +60,7 @@ class ExtractOutlierFrames(DefaultTab):
         self.extract_outlierframes_button.setMinimumWidth(150)
 
         self.label_outliers_button = QtWidgets.QPushButton("Labeling GUI")
-        self.label_outliers_button.setEnabled(False)
+        self.label_outliers_button.setEnabled(True)
         self.label_outliers_button.clicked.connect(self.launch_refinement_gui)
         self.label_outliers_button.setMinimumWidth(150)
 
@@ -115,7 +115,6 @@ class ExtractOutlierFrames(DefaultTab):
         )
 
     def extract_outlier_frames(self):
-        self.label_outliers_button.setEnabled(True)
 
         config = self.root.config
         shuffle = self.root.shuffle_value

--- a/deeplabcut/gui/tabs/refine_tracklets.py
+++ b/deeplabcut/gui/tabs/refine_tracklets.py
@@ -222,7 +222,7 @@ class RefineTracklets(DefaultTab):
         msg.setStandardButtons(QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No)
         result = msg.exec_()
         if result == QtWidgets.QMessageBox.Yes:
-            deeplabcut.merge_datasets(self.config, forceiterate=None)
+            deeplabcut.merge_datasets(self.root.config, forceiterate=None)
 
     def refine_tracks(self):
         cfg = self.root.cfg

--- a/deeplabcut/gui/tabs/refine_tracklets.py
+++ b/deeplabcut/gui/tabs/refine_tracklets.py
@@ -222,6 +222,7 @@ class RefineTracklets(DefaultTab):
         result = msg.exec_()
         if result == QtWidgets.QMessageBox.Yes:
             deeplabcut.merge_datasets(self.root.config, forceiterate=None)
+            self.root.viz.export_to_training_data()
 
     def refine_tracks(self):
         cfg = self.root.cfg

--- a/deeplabcut/gui/tabs/refine_tracklets.py
+++ b/deeplabcut/gui/tabs/refine_tracklets.py
@@ -218,7 +218,6 @@ class RefineTracklets(DefaultTab):
             "Make sure that you have refined all the labels before merging the dataset.If you merge the dataset, you need to re-create the training dataset before you start the training. Are you ready to merge the dataset?"
         )
         msg.setWindowTitle("Warning")
-        msg.setWindowIcon(QtWidgets.QMessageBox.Warning)
         msg.setStandardButtons(QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No)
         result = msg.exec_()
         if result == QtWidgets.QMessageBox.Yes:

--- a/deeplabcut/gui/tracklet_toolbox.py
+++ b/deeplabcut/gui/tracklet_toolbox.py
@@ -836,7 +836,7 @@ class TrackletVisualizer:
             imagename = os.path.join(
                 tmpfolder, "img" + str(ind).zfill(strwidth) + ".png"
             )
-            index.append(os.path.join(*imagename.rsplit(os.path.sep, 3)[-3:]))
+            index.append(tuple((os.path.join(*imagename.rsplit(os.path.sep, 3)[-3:])).split("\\")))
             if not os.path.isfile(imagename):
                 self.video.set_to_frame(ind)
                 frame = self.video.read_frame()
@@ -861,8 +861,9 @@ class TrackletVisualizer:
             cols.loc[mask] = np.nan
             return cols
 
-        df = df.groupby(level="bodyparts", axis=1).apply(filter_low_prob, prob=pcutoff)
-        df.index = index
+        df = df.groupby(level="bodyparts", axis=1, group_keys=False).apply(filter_low_prob, prob=pcutoff)
+        df.index = pd.MultiIndex.from_tuples([ind
+                        for ind in index])
         machinefile = os.path.join(
             tmpfolder, "machinelabels-iter" + str(self.manager.cfg["iteration"]) + ".h5"
         )

--- a/deeplabcut/gui/tracklet_toolbox.py
+++ b/deeplabcut/gui/tracklet_toolbox.py
@@ -93,10 +93,10 @@ class DraggablePoint:
             if self.likelihood is not None:
                 message += " You cannot undo this step!"
             msg = QMessageBox()
+            msg.setWindowTitle("Warning!")
             msg.setText(message)
             msg.setStandardButtons(msg.Yes | msg.No)
-            msg.exec()
-            if msg.Yes:
+            if msg.exec() == msg.Yes:
                 self.delete_data()
 
     def delete_data(self):

--- a/deeplabcut/gui/tracklet_toolbox.py
+++ b/deeplabcut/gui/tracklet_toolbox.py
@@ -878,8 +878,8 @@ class TrackletVisualizer:
             df.to_csv(os.path.join(tmpfolder, "machinelabels.csv"))
 
         # Merge with the already existing annotated data
-        df.columns.set_levels(
-            [self.manager.cfg["scorer"]], level="scorer", inplace=True
+        df.columns = df.columns.set_levels(
+            [self.manager.cfg["scorer"]], level="scorer"
         )
         df.drop("likelihood", level="coords", axis=1, inplace=True)
         output_path = os.path.join(

--- a/deeplabcut/gui/tracklet_toolbox.py
+++ b/deeplabcut/gui/tracklet_toolbox.py
@@ -92,12 +92,11 @@ class DraggablePoint:
             message = f"Do you want to remove the label {self.bodyParts}?"
             if self.likelihood is not None:
                 message += " You cannot undo this step!"
-            msg = QMessageBox(
-                title="Remove!",
-                text=message,
-            )
+            msg = QMessageBox()
+            msg.setText(message)
             msg.setStandardButtons(msg.Yes | msg.No)
-            if msg == 2:
+            msg.exec()
+            if msg.Yes:
                 self.delete_data()
 
     def delete_data(self):

--- a/deeplabcut/gui/tracklet_toolbox.py
+++ b/deeplabcut/gui/tracklet_toolbox.py
@@ -862,8 +862,8 @@ class TrackletVisualizer:
             return cols
 
         df = df.groupby(level="bodyparts", axis=1, group_keys=False).apply(filter_low_prob, prob=pcutoff)
-        df.index = pd.MultiIndex.from_tuples([ind
-                        for ind in index])
+        df.index = pd.MultiIndex.from_tuples(index)
+        
         machinefile = os.path.join(
             tmpfolder, "machinelabels-iter" + str(self.manager.cfg["iteration"]) + ".h5"
         )


### PR DESCRIPTION
I'm currently testing the GUI and trying to fix reported issues. One is more design improvement, i.e. being able to change the working dir also via textbox, not only by clicking the `Location` text (I think maybe it should stand out somehow - it doesn't indicate in any way that it's a button unless you hover over it)

Another thing I noticed was that label removal wasn't working in the tracklet toolbox, so also fixed that. Seems to work now.

Some other reported things that I didn't know if should be changed: 

- `Labelling GUI` button disabled by defualt in Extract Outlier Frames tab - what if you extracted before and are going back to refining?
- Manual extraction of frames still points to old GUI when called via `deeplabcut.extract_frames()`