### PR TITLE
add new way to visualize low-likelihood pose estimates

### DIFF
--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -389,7 +389,6 @@ def create_labeled_video(
     superanimal_name="",
     skeleton=[],
     skeleton_color="white",
-    dotsize=8,
     colormap="rainbow",
     alphavalue=0.5,
     overwrite=False,

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -69,7 +69,6 @@ def get_segment_indices(bodyparts2connect, all_bpts):
 def CreateVideo(
     clip,
     Dataframe,
-    pcutoff_mode,
     pcutoff,
     dotsize,
     colormap,
@@ -85,6 +84,7 @@ def CreateVideo(
     draw_skeleton,
     displaycropped,
     color_by,
+    pcutoff_mode="hide",
 ):
     """Creating individual frames with labeled body parts and making a video"""
     bpts = Dataframe.columns.get_level_values("bodyparts")
@@ -206,7 +206,6 @@ def CreateVideoSlow(
     dotsize,
     colormap,
     alphavalue,
-    pcutoff_mode,
     pcutoff,
     trailpoints,
     cropping,
@@ -223,6 +222,7 @@ def CreateVideoSlow(
     draw_skeleton,
     displaycropped,
     color_by,
+    pcutoff_mode="hide",
 ):
     """Creating individual frames with labeled body parts and making a video"""
     # scorer=np.unique(Dataframe.columns.get_level_values(0))[0]
@@ -383,15 +383,15 @@ def create_labeled_video(
     modelprefix="",
     init_weights="",
     track_method="",
-    pcutoff_mode="hide",
-    pcutoff=None,
-    dotsize=None,
     superanimal_name="",
+    pcutoff=0.6,
     skeleton=[],
     skeleton_color="white",
+    dotsize=None,
     colormap="rainbow",
     alphavalue=0.5,
     overwrite=False,
+    pcutoff_mode="hide",
 ):
     """Labels the bodyparts in a video.
 
@@ -810,7 +810,6 @@ def proc_video(
                     cfg["dotsize"],
                     cfg["colormap"],
                     cfg["alphavalue"],
-                    cfg["pcutoff_mode"],
                     cfg["pcutoff"],
                     trailpoints,
                     cropping,
@@ -827,6 +826,7 @@ def proc_video(
                     draw_skeleton,
                     displaycropped,
                     color_by,
+                    pcutoff_mode=cfg["pcutoff_mode"],
                 )
                 clip.close()
             else:
@@ -912,7 +912,6 @@ def _create_labeled_video(
     CreateVideo(
         clip,
         df,
-        pcutoff_mode,
         pcutoff,
         dotsize,
         cmap,
@@ -928,6 +927,7 @@ def _create_labeled_video(
         bool(skeleton_edges),
         display_cropped,
         color_by,
+        pcutoff_mode=pcutoff_mode,
     )
 
 

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -387,7 +387,6 @@ def create_labeled_video(
     pcutoff=None,
     dotsize=None,
     superanimal_name="",
-    pcutoff=0.6,
     skeleton=[],
     skeleton_color="white",
     dotsize=8,


### PR DESCRIPTION
Hi team DLC!

During a recent project (I work at Inscopix, by the way =)) a colleague was wondering where low-likelihood labels would be placed if we could see them, which made me realize I couldn't find any existing way to visualize that: by default labels with likelihood <= pcutoff are not plotted when creating a labelled video; we can sure drop pcutoff to 0 but then all frames are labeled and there is no way to differentiate between above and below pcutoff labels.

Here is a simple PR keeping the default mode ("hide"), so it won't go in the way of existing scripts, and adding a "darken" mode when label colors are darkened when body part likelihood gets at or below pcutoff.

Also added a way to override pcutoff and dotsize values from config.yaml directly in the function call, so that these parameters could be changed more conveniently and, more importantly, by users without writing access to config.yaml but still wanting to use the related trained model.

Looking forward to discussing these features with you, and again, thank you for putting out there such a great package!
Have a beautiful weekend,
Ludovic