### PR TITLE
Auto default to ellipse in create_labeled_video for multi-animal projects

### DIFF
--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -552,8 +552,6 @@ def create_labeled_video(
     else:
         cfg = auxiliaryfunctions.read_config(config)
         trainFraction = cfg["TrainingFraction"][trainingsetindex]
-    if track_method != "":
-        # will otherwise always return ellipse
         track_method = auxfun_multianimal.get_track_method(
             cfg, track_method=track_method
         )


### PR DESCRIPTION
`auxfun_multianimal.get_track_method` smartly returns the right tracker based on the project type, and thus should be called anyway (#2186 made me realize it)