### PR TITLE
Catch ValueError when tracklet dict is empty

### DIFF
--- a/deeplabcut/refine_training_dataset/stitch.py
+++ b/deeplabcut/refine_training_dataset/stitch.py
@@ -538,7 +538,10 @@ class TrackletStitcher:
         header = dict_of_dict.pop("header", None)
         single = None
         for k, dict_ in dict_of_dict.items():
-            inds, data = zip(*[(cls.get_frame_ind(k), v) for k, v in dict_.items()])
+            try:
+                inds, data = zip(*[(cls.get_frame_ind(k), v) for k, v in dict_.items()])
+            except ValueError:
+                continue
             inds = np.asarray(inds)
             data = np.asarray(data)
             try:


### PR DESCRIPTION
Fixes #2146 