### PR TITLE
upper bound to matplotlib version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
         "imgaug>=0.4.0",
         "imageio-ffmpeg",
         "numba>=0.54",
-        "matplotlib>=3.3",
+        "matplotlib>=3.3, <=3.6.1",
         "networkx>=2.6",
         "numpy>=1.18.5",
         "pandas>=1.0.1,!=1.5.0",


### PR DESCRIPTION
With 3.7.1 switching ID in tracklet refinement GUI doesn't work (at least on Windows)