### PR TITLE
Fix ArtistList's AttributeError

### DIFF
--- a/deeplabcut/gui/tracklet_toolbox.py
+++ b/deeplabcut/gui/tracklet_toolbox.py
@@ -592,7 +592,8 @@ class TrackletVisualizer:
                     ] = ~self.manager.tracklet_swaps[self.picked_pair][self.cuts]
                     self.fill_shaded_areas()
                     self.cuts = []
-                    self.ax_slider.lines.clear()
+                    for line in self.ax_slider.lines:
+                        line.remove()
         elif event.key == "backspace":
             if not self.dps:  # Last flag deletion
                 try:
@@ -684,7 +685,8 @@ class TrackletVisualizer:
                 if len(self.cuts) > 1:
                     mask[self.cuts[-2] : self.cuts[-1] + 1] = True
                     self.cuts = []
-                    self.ax_slider.lines.clear()
+                    for line in self.ax_slider.lines:
+                        line.remove()
                     self.clean_collections()
                 else:
                     return
@@ -869,7 +871,7 @@ class TrackletVisualizer:
 
         df = df.groupby(level="bodyparts", axis=1, group_keys=False).apply(filter_low_prob, prob=pcutoff)
         df.index = pd.MultiIndex.from_tuples(index)
-        
+
         machinefile = os.path.join(
             tmpfolder, "machinelabels-iter" + str(self.manager.cfg["iteration"]) + ".h5"
         )


### PR DESCRIPTION
matplotlib's ArtistLists were made immutable in [3.7.0](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.7.0.html#modification-of-axes-children-sublists), causing an AttributeError when calling the `.clear` method (https://github.com/DeepLabCut/DeepLabCut/pull/2203#issuecomment-1511142283). Artists are now removed as recommended in matplotlib's docs (note that this is backward-compatible with prior versions of matplotlib).  
