### PR TITLE
Fix typo in refine_tracklets.py

### DIFF
--- a/deeplabcut/gui/tabs/refine_tracklets.py
+++ b/deeplabcut/gui/tabs/refine_tracklets.py
@@ -222,7 +222,7 @@ class RefineTracklets(DefaultTab):
         result = msg.exec_()
         if result == QtWidgets.QMessageBox.Yes:
             deeplabcut.merge_datasets(self.root.config, forceiterate=None)
-            self.root.viz.export_to_training_data()
+            self.viz.export_to_training_data()
 
     def refine_tracks(self):
         cfg = self.root.cfg


### PR DESCRIPTION
Noticed self.root.viz.export_to_training_data() on line 255 was throwing an attribute error when refining tracklets. Merging refined tracklets into training data now seems to work.