### PR TITLE
Fix rectangle selector

### DIFF
--- a/deeplabcut/gui/widgets.py
+++ b/deeplabcut/gui/widgets.py
@@ -514,7 +514,6 @@ class FrameCropper(QtWidgets.QDialog):
         self.rs = RectangleSelector(
             self.ax,
             self.line_select_callback,
-            drawtype="box",
             minspanx=5,
             minspany=5,
             interactive=True,

--- a/deeplabcut/gui/widgets.py
+++ b/deeplabcut/gui/widgets.py
@@ -518,7 +518,6 @@ class FrameCropper(QtWidgets.QDialog):
             minspany=5,
             interactive=True,
             spancoords="pixels",
-            rectprops=dict(facecolor="red", edgecolor="black", alpha=0.3, fill=True),
         )
         self.show()
         self.fig.canvas.start_event_loop(timeout=-1)

--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -597,7 +597,6 @@ def draw_bbox(video):
     rs = RectangleSelector(
         ax,
         line_select_callback,
-        drawtype="box",
         minspanx=5,
         minspany=5,
         interactive=True,

--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -601,7 +601,6 @@ def draw_bbox(video):
         minspany=5,
         interactive=True,
         spancoords="pixels",
-        rectprops=dict(facecolor="red", edgecolor="black", alpha=0.3, fill=True),
     )
     plt.show()
 


### PR DESCRIPTION
In [release 3.7.0](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.7.0.html#rectangleselector-and-ellipseselector), matplotlib removed the `drawtype` attribute from the `RectangleSelector`. The `rectprops` attribute was changed to `props` (starting from [release 3.5.0](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.5.0.html#unification-and-cleanup-of-selector-widget-api)).

To be compatible with this & future releases, they must also be removed from DLC.

This should not affect users on older matplotlib releases, as the default value was already `"box"` (as shown here in [release 3.3](https://matplotlib.org/3.3.4/api/widgets_api.html#matplotlib.widgets.RectangleSelector)).

The `rectprops=dict(facecolor='red', edgecolor='black', alpha=0.3, fill=True)` argument was removed to be compatible with both matplotlib < 3.5 and matplotlib >= 3.7, so the default will be used (`dict(facecolor='red', edgecolor='black', alpha=0.2, fill=True)`). From my test there is no noticeable difference.