### PR TITLE
Fix docstring in video_inference_superanimal

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/predict_supermodel.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_supermodel.py
@@ -36,7 +36,7 @@ def video_inference_superanimal(
         A list of strings containing the full paths to videos for analysis or a path to the directory, where all the videos with same extension are stored.
 
     superanimal_name: str
-        The name of the superanimal model. We currently only support supertopview and superquadruped
+        The name of the superanimal model. We currently only support "superanimal_quadruped" and "superanimal_topviewmouse"
     scale_list: list
         A list of int containing the target height of the multi scale test time augmentation. By default it uses the original size. Users are advised to try a wide range of scale list when the super model does not give reasonable results
 


### PR DESCRIPTION
Running

```python
deeplabcut.video_inference_superanimal(
    ["somevideo_.mp4"],
    "superquadruped"
)
```

currently gives the error

```
[...]
ValueError: `supermodel_name` should be one of: superanimal_quadruped, superanimal_topviewmouse.
```

This PR is a simple fix to update the docstring to point to the correct model names, as listed in the error message.