### PR TITLE
Allow frame extraction on a video subset in GUI

### DIFF
--- a/deeplabcut/generate_training_dataset/frame_extraction.py
+++ b/deeplabcut/generate_training_dataset/frame_extraction.py
@@ -411,6 +411,7 @@ def extract_frames(
                 output_path = (
                     Path(config).parents[0] / "labeled-data" / Path(video).stem
                 )
+                output_path.mkdir(parents=True, exist_ok=True)
                 is_valid = []
                 if opencv:
                     for index in frames2pick:

--- a/deeplabcut/gui/tabs/extract_frames.py
+++ b/deeplabcut/gui/tabs/extract_frames.py
@@ -16,6 +16,7 @@ from PySide6.QtCore import Qt
 from deeplabcut.gui.dlc_params import DLCParams
 from deeplabcut.gui.components import (
     DefaultTab,
+    VideoSelectionWidget,
     _create_grid_layout,
     _create_label_widget,
 )
@@ -90,6 +91,10 @@ class ExtractFrames(DefaultTab):
         self.layout_attributes = _create_grid_layout(margins=(0, 0, 0, 0))
         self._generate_layout_attributes(self.layout_attributes)
         self.main_layout.addLayout(self.layout_attributes)
+
+        self.main_layout.addWidget(_create_label_widget("Optional: frame extraction from a video subset", "font:bold"))
+        self.video_selection_widget = VideoSelectionWidget(self.root, self)
+        self.main_layout.addWidget(self.video_selection_widget)
 
         self.ok_button = QtWidgets.QPushButton("Extract Frames")
         self.ok_button.clicked.connect(self.extract_frames)
@@ -194,6 +199,7 @@ class ExtractFrames(DefaultTab):
             cluster_color=False,
             slider_width=slider_width,
             userfeedback=False,
+            videos_list=self.video_selection_widget.files or None,
         )
         self.worker, self.thread = move_to_separate_thread(func)
         self.worker.finished.connect(lambda: self.ok_button.setEnabled(True))


### PR DESCRIPTION
Previously, extracted frames from a specific video set (e.g., after adding new videos to the project) was only doable programmatically. One can now select the desired videos from the GUI.