### PR TITLE
Use QFrame.Shape.StyledPanel instead of QFrame.StyledPanel

### DIFF
--- a/deeplabcut/gui/tabs/create_project.py
+++ b/deeplabcut/gui/tabs/create_project.py
@@ -43,7 +43,7 @@ class ProjectCreator(QtWidgets.QDialog):
 
     def lay_out_user_frame(self):
         user_frame = QtWidgets.QFrame(self)
-        user_frame.setFrameShape(user_frame.StyledPanel)
+        user_frame.setFrameShape(user_frame.Shape.StyledPanel)
         user_frame.setLineWidth(0.5)
 
         proj_label = QtWidgets.QLabel("Project:", user_frame)
@@ -193,7 +193,7 @@ class ProjectCreator(QtWidgets.QDialog):
                     child.setDisabled(True)
                 else:
                     child.setDisabled(False)
-    
+
     def update_project_name(self, text):
         self.proj_default = text
         self.update_project_location()

--- a/deeplabcut/gui/tabs/create_project.py
+++ b/deeplabcut/gui/tabs/create_project.py
@@ -44,7 +44,7 @@ class ProjectCreator(QtWidgets.QDialog):
     def lay_out_user_frame(self):
         user_frame = QtWidgets.QFrame(self)
         user_frame.setFrameShape(user_frame.Shape.StyledPanel)
-        user_frame.setLineWidth(0.5)
+        user_frame.setLineWidth(0)
 
         proj_label = QtWidgets.QLabel("Project:", user_frame)
         self.proj_line = QtWidgets.QLineEdit(self.proj_default, user_frame)

--- a/deeplabcut/gui/tabs/open_project.py
+++ b/deeplabcut/gui/tabs/open_project.py
@@ -36,7 +36,7 @@ class OpenProject(QtWidgets.QDialog):
 
     def layout_open(self):
         self.open_frame = QtWidgets.QFrame(self)
-        self.open_frame.setFrameShape(self.open_frame.StyledPanel)
+        self.open_frame.setFrameShape(self.open_frame.Shape.StyledPanel)
         self.open_frame.setLineWidth(0.5)
         self.open_frame.setMinimumWidth(600)
 

--- a/deeplabcut/gui/tabs/open_project.py
+++ b/deeplabcut/gui/tabs/open_project.py
@@ -37,7 +37,7 @@ class OpenProject(QtWidgets.QDialog):
     def layout_open(self):
         self.open_frame = QtWidgets.QFrame(self)
         self.open_frame.setFrameShape(self.open_frame.Shape.StyledPanel)
-        self.open_frame.setLineWidth(0.5)
+        self.open_frame.setLineWidth(0)
         self.open_frame.setMinimumWidth(600)
 
         open_label = QtWidgets.QLabel("Select the config file:", self.open_frame)

--- a/deeplabcut/gui/widgets.py
+++ b/deeplabcut/gui/widgets.py
@@ -128,7 +128,7 @@ class DragDropListView(QtWidgets.QListView):
 class ItemSelectionFrame(QtWidgets.QFrame):
     def __init__(self, items, parent=None):
         super(ItemSelectionFrame, self).__init__(parent)
-        self.setFrameShape(self.StyledPanel)
+        self.setFrameShape(self.Shape.StyledPanel)
         self.setLineWidth(0.5)
 
         self.select_box = QtWidgets.QCheckBox("Files")

--- a/deeplabcut/gui/widgets.py
+++ b/deeplabcut/gui/widgets.py
@@ -129,7 +129,7 @@ class ItemSelectionFrame(QtWidgets.QFrame):
     def __init__(self, items, parent=None):
         super(ItemSelectionFrame, self).__init__(parent)
         self.setFrameShape(self.Shape.StyledPanel)
-        self.setLineWidth(0.5)
+        self.setLineWidth(0)
 
         self.select_box = QtWidgets.QCheckBox("Files")
         self.select_box.setChecked(True)


### PR DESCRIPTION
I think this helps with qtpy which doesn't provide a few of the "conveniences" of PySide6.

I understand if you might not care, but I do think this helps provide a bit of compatibility with a few other environments.

Thank you for considering this