### PR TITLE
Explicitely use QRegularExpression instead of implicit string conversion

### DIFF
--- a/deeplabcut/gui/tabs/modelzoo.py
+++ b/deeplabcut/gui/tabs/modelzoo.py
@@ -10,7 +10,7 @@
 #
 import deeplabcut
 from PySide6 import QtWidgets
-from PySide6.QtCore import Qt, Signal, QTimer
+from PySide6.QtCore import Qt, Signal, QTimer, QRegularExpression
 from PySide6.QtGui import QRegularExpressionValidator
 from deeplabcut.gui.components import (
     DefaultTab,
@@ -33,7 +33,7 @@ class RegExpValidator(QRegularExpressionValidator):
 class ModelZoo(DefaultTab):
     def __init__(self, root, parent, h1_description):
         super().__init__(root, parent, h1_description)
-        self._val_pattern = "(\d{3,5},\s*)+\d{3,5}"
+        self._val_pattern = QRegularExpression(r"(\d{3,5},\s*)+\d{3,5}")
         self._set_page()
 
     @property


### PR DESCRIPTION
Two things here:

- The use of the r-string, or raw string helps ensures that the `\d` is preserved.
- I think that qtpy or conda-forge's PySide6 will throw an error if the regular expression isn't a Qt Regular Expression

Thank you for considering small improvements to compatibility.

Best,

Mark

xref: https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals