### PR TITLE
Update use of .Directory for PySide6.5.0

### DIFF
--- a/deeplabcut/gui/tabs/label_frames.py
+++ b/deeplabcut/gui/tabs/label_frames.py
@@ -38,8 +38,8 @@ class LabelFrames(DefaultTab):
 
     def label_frames(self):
         dialog = QtWidgets.QFileDialog(self)
-        dialog.setFileMode(dialog.Directory)
-        dialog.setViewMode(dialog.Detail)
+        dialog.setFileMode(QtWidgets.QFileDialog.Directory)
+        dialog.setViewMode(QtWidgets.QFileDialog.Detail)
         dialog.setDirectory(
             os.path.join(os.path.dirname(self.root.config), "labeled-data")
         )


### PR DESCRIPTION
It seems to be getting removed

See: https://wiki.qt.io/Qt_for_Python_Development_Notes

old Enums are being removed, and the startup time will improve a bit (still in progress)