### PR TITLE
fix drawing of skeleton when displayedbodyparts != all

### DIFF
--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -601,6 +601,8 @@ def create_labeled_video(
     )
     if draw_skeleton:
         bodyparts2connect = cfg["skeleton"]
+        if displayedbodyparts!="all":
+            bodyparts2connect = [pair for pair in bodyparts2connect if all(element in displayedbodyparts for element in pair)]
         skeleton_color = cfg["skeleton_color"]
     else:
         bodyparts2connect = None


### PR DESCRIPTION
Skeleton was drawn for all bodyparts irrespective of displayedbodyparts attribute.