### PR TITLE
Fix windows video selection for extraction in the GUI

### DIFF
--- a/deeplabcut/gui/components.py
+++ b/deeplabcut/gui/components.py
@@ -8,6 +8,8 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
+import os
+
 from PySide6 import QtWidgets
 from PySide6.QtCore import Qt
 from deeplabcut.gui.dlc_params import DLCParams
@@ -162,7 +164,7 @@ class VideoSelectionWidget(QtWidgets.QWidget):
 
         if filenames[0]:
             # Qt returns a tuple (list of files, filetype)
-            self.root.video_files = filenames[0]
+            self.root.video_files = [os.path.abspath(vid) for vid in filenames[0]]
 
     def clear_selected_videos(self):
         self.root.video_files = set()


### PR DESCRIPTION
`QtWidgets.QFileDialog.getOpenFileNames` outputs unix formated paths which on Windows leads to wrong reading and uninformative output "Video file corrupted" which isn't true. This fix normalizes the path according to `os`