### PR TITLE
Avoid creating training dataset with multiple scorers

### DIFF
--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -482,7 +482,7 @@ def merge_annotateddatasets(cfg, trainingsetfolder_full):
             data = pd.read_hdf(file_path)
             conversioncode.guarantee_multiindex_rows(data)
             if data.columns.levels[0][0] != cfg["scorer"]:
-                print(f"{file_path} labeled by a different scorer. This data will not be utilized in trainig dataset creation.")
+                print(f"{file_path} labeled by a different scorer. This data will not be utilized in training dataset creation.")
                 continue
             AnnotationData.append(data)
         except FileNotFoundError:

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -481,6 +481,9 @@ def merge_annotateddatasets(cfg, trainingsetfolder_full):
         try:
             data = pd.read_hdf(file_path)
             conversioncode.guarantee_multiindex_rows(data)
+            if data.columns.levels[0][0] != cfg["scorer"]:
+                print(f"{file_path} labeled by a different scorer. This data will not be utilized in trainig dataset creation.")
+                continue
             AnnotationData.append(data)
         except FileNotFoundError:
             print(file_path, " not found (perhaps not annotated).")

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -482,7 +482,7 @@ def merge_annotateddatasets(cfg, trainingsetfolder_full):
             data = pd.read_hdf(file_path)
             conversioncode.guarantee_multiindex_rows(data)
             if data.columns.levels[0][0] != cfg["scorer"]:
-                print(f"{file_path} labeled by a different scorer. This data will not be utilized in training dataset creation.")
+                print(f"{file_path} labeled by a different scorer. This data will not be utilized in training dataset creation. If you need to merge datasets across scorers, see https://github.com/DeepLabCut/DeepLabCut/wiki/Using-labeled-data-in-DeepLabCut-that-was-annotated-elsewhere-(or-merge-across-labelers)")
                 continue
             AnnotationData.append(data)
         except FileNotFoundError:


### PR DESCRIPTION
This small check will prevent adding data from two different scorers into the training dataset - can happen if one changes the filename to look like proper scorer but leaves the level 0 in the dataframe untouched.