### PR TITLE
Fixed draw_bbox when pyplot is in non-interactive mode

### DIFF
--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -586,7 +586,7 @@ def draw_bbox(video):
 
     fig = plt.figure()
     ax = fig.add_subplot(111)
-    ax.imshow(frame[:, :, ::-1])
+    ax.imshow(frame)
     ax_help = fig.add_axes([0.9, 0.2, 0.1, 0.1])
     ax_save = fig.add_axes([0.9, 0.1, 0.1, 0.1])
     crop_button = Button(ax_save, "Crop")
@@ -602,7 +602,7 @@ def draw_bbox(video):
         interactive=True,
         spancoords="pixels",
     )
-    plt.show()
+    plt.show(block=False)
 
     # import platform
     # if platform.system() == "Darwin":  # for OSX use WXAgg


### PR DESCRIPTION
Addresses issue #2283. As documented in [Matplotlib's interactive guide](https://matplotlib.org/stable/users/explain/interactive_guide.html#blocking-the-prompt), show needs to be called without blocking the thread. When run in non-interactive mode, the [default behavior](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.show.html#matplotlib.pyplot.show) of `show()` is to block the loop until all windows are closed.

Also fixes the frames being shown with the color channels in the incorrect order (`VideoReader` returns RGB frames, `imshow` expects RGB frames, and the channels were being swapped as if the frames were BGR).

This fix was tested on OS X.