### PR TITLE
pin scipy to less than 1.11.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ dlclibrary
 ipython
 filterpy
 ruamel.yaml>=0.15.0
-intel-openmp
 imageio-ffmpeg
 imgaug==0.4.0
 numba>=0.54.0
@@ -13,9 +12,10 @@ pandas>=1.0.1,!=1.5.0
 pyyaml
 scikit-image>=0.17
 scikit-learn>=1.0
-scipy>=1.4
+scipy>=1.4,<1.11.0
 statsmodels>=0.11
-tensorflow>=2.0
+tensorflow-macos
+tensorflow-metal
 tables==3.7.0
 tensorpack==0.11
 tf_slim==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ dlclibrary
 ipython
 filterpy
 ruamel.yaml>=0.15.0
+intel-openmp
 imageio-ffmpeg
 imgaug==0.4.0
 numba>=0.54.0
@@ -14,8 +15,7 @@ scikit-image>=0.17
 scikit-learn>=1.0
 scipy>=1.4,<1.11.0
 statsmodels>=0.11
-tensorflow-macos
-tensorflow-metal
+tensorflow>=2.0
 tables==3.7.0
 tensorpack==0.11
 tf_slim==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
         "pandas>=1.0.1,!=1.5.0",
         "scikit-image>=0.17",
         "scikit-learn>=1.0",
-        "scipy>=1.4",
+        "scipy>=1.4,<1.11.0",
         "statsmodels>=0.11",
         "tables>=3.7.0",
         "torch<=1.12",


### PR DESCRIPTION
Tracklet stitcher identity tests fail with `scipy>=1.11.0`. Both `test_tracklet` and `test_stitcher_with_identity` fail as the created tracklets have the wrong identities.