### PR TITLE
Manual outlier_frame_extraction bugfix

### DIFF
--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -669,11 +669,11 @@ def attempt_to_add_video(
 
     try:
         add.add_new_videos(config, videos, coords=coords, copy_videos=copy_videos)
-    except ValueError as err:
+    except:
         # can we make a catch here? - in fact we should drop indices from DataCombined
         # if they are in CollectedData.. [ideal behavior; currently pretty unlikely]
         print(
-            f"AUTOMATIC ADDING OF VIDEO TO CONFIG FILE FAILED WITH {err}! You need to "
+            f"AUTOMATIC ADDING OF VIDEO TO CONFIG FILE FAILED! You need to "
             "do this manually for including it in the config.yaml file!"
         )
         print("Videopath:", video, "Coordinates for cropping:", coords)

--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -15,6 +15,7 @@ import os
 import pickle
 import re
 from pathlib import Path
+from typing import List, Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -424,9 +425,19 @@ def extract_outlier_frames(
                 Indices.extend(ind)
             elif outlieralgorithm == "manual":
                 from deeplabcut.gui.widgets import launch_napari
-
-                _ = launch_napari([video, dataname])
+                added_video = attempt_to_add_video(
+                    config=config,
+                    video=video,
+                    copy_videos=copy_videos,
+                    coords=None,
+                )
+                if added_video:
+                    project_video_path = (
+                        Path(cfg["project_path"]) / "videos" / Path(video).name
+                    )
+                    _ = launch_napari([project_video_path, dataname])
                 return
+
             elif outlieralgorithm == "list":
                 if frames2use is not None:
                     try:
@@ -619,6 +630,57 @@ def compute_deviations(
         return d, o
 
 
+def attempt_to_add_video(
+    config: str,
+    video: str,
+    copy_videos: bool,
+    coords: Optional[List],
+) -> bool:
+    """
+    Add new videos to the config file at any stage of the project.
+
+    Parameters
+    ----------
+    config : string
+        Full path of the config file in the project.
+
+    video : string
+        Full path of the video to add to the project.
+
+    copy_videos : bool, optional
+        If this is set to True, the videos will be copied to the project/videos directory. If False, the symlink of the
+        videos will be copied instead. The default is
+        ``False``; if provided it must be either ``True`` or ``False``.
+
+    coords: list, optional
+        A list containing the list of cropping coordinates of the video. The default is set to None.
+
+    Returns
+    -------
+    True iff the video was successfully added to the project
+    """
+    from deeplabcut.create_project import add
+
+    # make sure coords and videos are a list
+    videos = [video]
+    if coords is not None:
+        coords = [coords]
+
+    try:
+        add.add_new_videos(config, videos, coords=coords, copy_videos=copy_videos)
+    except ValueError as err:
+        # can we make a catch here? - in fact we should drop indices from DataCombined
+        # if they are in CollectedData.. [ideal behavior; currently pretty unlikely]
+        print(
+            f"AUTOMATIC ADDING OF VIDEO TO CONFIG FILE FAILED WITH {err}! You need to "
+            "do this manually for including it in the config.yaml file!"
+        )
+        print("Videopath:", video, "Coordinates for cropping:", coords)
+        return False
+
+    return True
+
+
 def ExtractFramesbasedonPreselection(
     Index,
     extractionalgorithm,
@@ -633,8 +695,6 @@ def ExtractFramesbasedonPreselection(
     with_annotations=True,
     copy_videos=False,
 ):
-    from deeplabcut.create_project import add
-
     start = cfg["start"]
     stop = cfg["stop"]
     numframes2extract = cfg["numframes2pick"]
@@ -772,23 +832,13 @@ def ExtractFramesbasedonPreselection(
 
     # Extract annotations based on DeepLabCut and store in the folder (with name derived from video name) under labeled-data
     if len(frames2pick) > 0:
-        try:
-            if coords is not None:
-                add.add_new_videos(
-                    config,
-                    [video],
-                    coords=[coords],
-                    copy_videos=copy_videos,
-                )  # make sure you pass coords as a list
-            else:
-                add.add_new_videos(
-                    config, [video], coords=None, copy_videos=copy_videos
-                )
-        except:  # can we make a catch here? - in fact we should drop indices from DataCombined if they are in CollectedData.. [ideal behavior; currently this is pretty unlikely]
-            print(
-                "AUTOMATIC ADDING OF VIDEO TO CONFIG FILE FAILED! You need to do this manually for including it in the config.yaml file!"
-            )
-            print("Videopath:", video, "Coordinates for cropping:", coords)
+        added_video = attempt_to_add_video(
+            config=config,
+            video=video,
+            copy_videos=copy_videos,
+            coords=coords,
+        )
+        if not added_video:
             pass
 
         if with_annotations:

--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -425,6 +425,7 @@ def extract_outlier_frames(
                 Indices.extend(ind)
             elif outlieralgorithm == "manual":
                 from deeplabcut.gui.widgets import launch_napari
+
                 added_video = attempt_to_add_video(
                     config=config,
                     video=video,

--- a/tests/test_trackingutils.py
+++ b/tests/test_trackingutils.py
@@ -33,7 +33,7 @@ def test_ellipse_similarity(ellipse):
 def test_ellipse_fitter():
     fitter = trackingutils.EllipseFitter()
     assert fitter.fit(np.random.rand(2, 2)) is None
-    xy = np.asarray([[-2, 0], [2, 0], [0, 1], [0, -1]], dtype=np.float)
+    xy = np.asarray([[-2, 0], [2, 0], [0, 1], [0, -1]], dtype=float)
     assert fitter.fit(xy) is not None
     fitter.sd = 0
     el = fitter.fit(xy)


### PR DESCRIPTION
Addresses issue #2279.

When manually extracting outlier frames from a video (not located in the `{project}/videos/` folder), two issues were occurring:

- the video was not added to the project
- the path to the video was given to `napari-deeplabcut`, instead of the path to alias (or copied video) created in the `{project}/videos/` folder.

There `napari-deeplabcut` tried to extract the frames to a `labeled-images` folder located in the parent folder of the analyzed video (which logically did not exist). This pull request fixes these issues.