### PR TITLE
pinned tensorflow to <2.13.0

### DIFF
--- a/conda-environments/DEEPLABCUT_M1.yaml
+++ b/conda-environments/DEEPLABCUT_M1.yaml
@@ -39,6 +39,4 @@ dependencies:
   - ffmpeg
   - apple::tensorflow-deps
   - pip:
-    - tensorflow-macos
-    - tensorflow-metal
-    - -e ../[gui]
+    - -e ../[gui,apple_mchips]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ scikit-image>=0.17
 scikit-learn>=1.0
 scipy>=1.4,<1.11.0
 statsmodels>=0.11
-tensorflow>=2.0
+tensorflow>=2.0,<2.13.0
 tables==3.7.0
 tensorpack==0.11
 tf_slim==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setuptools.setup(
         "openvino": ["openvino-dev==2022.1.0"],
         "docs": ["numpydoc"],
         "tf": ["tensorflow>=2.0,<=2.10"],  # Last supported TF version on Windows Native is 2.10
-        "apple_mchips": ["tensorflow-macos","tensorflow-metal"],
+        "apple_mchips": ["tensorflow-macos<2.13.0","tensorflow-metal"],
         "modelzoo": ["huggingface_hub"],
     },
     scripts=["deeplabcut/pose_estimation_tensorflow/models/pretrained/download.sh"],

--- a/tests/test_trackingutils.py
+++ b/tests/test_trackingutils.py
@@ -33,7 +33,7 @@ def test_ellipse_similarity(ellipse):
 def test_ellipse_fitter():
     fitter = trackingutils.EllipseFitter()
     assert fitter.fit(np.random.rand(2, 2)) is None
-    xy = np.asarray([[-2, 0], [2, 0], [0, 1], [0, -1]], dtype=np.float)
+    xy = np.asarray([[-2, 0], [2, 0], [0, 1], [0, -1]], dtype=float)
     assert fitter.fit(xy) is not None
     fitter.sd = 0
     el = fitter.fit(xy)


### PR DESCRIPTION
Model training fails with `tensorflow==2.13.0` with error:
```
ModuleNotFoundError: No module named ‘keras.legacy_tf_layers’
```