### PR TITLE
Avoid assembling if already done and overwrite == False

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
@@ -813,9 +813,8 @@ class Assembler:
     def from_pickle(self, pickle_path):
         with open(pickle_path, "rb") as file:
             data = pickle.load(file)
-        
-        self.assemblies = {key: value for key, value in data.items() if key != "single"}
-        self.unique = data["single"] if "single" in data.keys() else dict()
+        self.unique = data.pop('single', {})
+        self.assemblies = data
         
     @staticmethod
     def parse_metadata(data):

--- a/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
@@ -813,7 +813,7 @@ class Assembler:
     def from_pickle(self, pickle_path):
         with open(pickle_path, "rb") as file:
             data = pickle.load(file)
-        self.unique = data.pop('single', {})
+        self.unique = data.pop("single", {})
         self.assemblies = data
         
     @staticmethod

--- a/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
@@ -809,7 +809,14 @@ class Assembler:
                         if unique is not None:
                             self.unique[i] = unique
                         pbar.update()
-
+    
+    def from_pickle(self, pickle_path):
+        with open(pickle_path, "rb") as file:
+            data = pickle.load(file)
+        
+        self.assemblies = {key: value for key, value in data.items() if key != "single"}
+        self.unique = data["single"] if "single" in data.keys() else dict()
+        
     @staticmethod
     def parse_metadata(data):
         params = dict()

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1821,7 +1821,8 @@ def convert_detections2tracklets(
                     ass.assemble()
                     ass.to_pickle(dataname.split(".h5")[0] + "_assemblies.pickle")
                 else:
-                    print(f"Loading assemblies from {dataname.split(".h5")[0] + "_assemblies.pickle"}")
+                    ass_filename = dataname.split(".h5")[0] + "_assemblies.pickle"
+                    print(f"Loading assemblies from {ass_filename}")
                     ass = pd.read_pickle(dataname.split(".h5")[0] + "_assemblies.pickle")
                 try:
                     data.close()

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1872,7 +1872,7 @@ def convert_detections2tracklets(
                                 xy = animals[:, keep_inds, :2]
                             trackers = mot_tracker.track(xy)
                         elif isinstance(ass, dict) and identity_only:
-                            #identity assignement if read from _assemblies.pickle
+                            #identity assignment if read from _assemblies.pickle
                             mat = np.zeros(
                                 (len(assemblies), inferencecfg["topktoretain"])
                             )

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1821,6 +1821,7 @@ def convert_detections2tracklets(
                     ass.assemble()
                     ass.to_pickle(dataname.split(".h5")[0] + "_assemblies.pickle")
                 else:
+                    print(f"Loading assemblies from {dataname.split(".h5")[0] + "_assemblies.pickle"}")
                     ass = pd.read_pickle(dataname.split(".h5")[0] + "_assemblies.pickle")
                 try:
                     data.close()

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1495,7 +1495,7 @@ def _convert_detections_to_tracklets(
         )
     tracklets = {}
 
-    ass = inferenceutils.Assembler(
+    assembly_builder = inferenceutils.Assembler(
         data,
         max_n_individuals=inference_cfg["topktoretain"],
         n_multibodyparts=len(cfg["multianimalbodyparts"]),
@@ -1512,22 +1512,22 @@ def _convert_detections_to_tracklets(
             str(trainingsetfolder),
             "CollectedData_" + cfg["scorer"] + ".h5",
         )
-        ass.calibrate(train_data_file)
-    ass.assemble()
+        assembly_builder.calibrate(train_data_file)
+    assembly_builder.assemble()
 
     output_path, _ = os.path.splitext(output_path)
     output_path += ".pickle"
-    ass.to_pickle(output_path.replace(".pickle", "_assemblies.pickle"))
+    assembly_builder.to_pickle(output_path.replace(".pickle", "_assemblies.pickle"))
 
     if cfg["uniquebodyparts"]:
         tracklets["single"] = {}
-        tracklets["single"].update(ass.unique)
+        tracklets["single"].update(assembly_builder.unique)
 
-    for i, imname in tqdm(enumerate(ass.metadata["imnames"])):
-        assemblies = ass.assemblies.get(i)
+    for i, imname in tqdm(enumerate(assembly_builder.metadata["imnames"])):
+        assemblies = assembly_builder.assemblies.get(i)
         if assemblies is None:
             continue
-        animals = np.stack([ass.data[:, :3] for ass in assemblies])
+        animals = np.stack([assembly_builder.data[:, :3] for assembly_builder in assemblies])
         if track_method == "box":
             xy = trackingutils.calc_bboxes_from_keypoints(
                 animals, inference_cfg.get("boundingboxslack", 0)
@@ -1798,7 +1798,7 @@ def convert_detections2tracklets(
                     )
                 tracklets = {}
                 multi_bpts = cfg["multianimalbodyparts"]
-                ass = inferenceutils.Assembler(
+                assembly_builder = inferenceutils.Assembler(
                     data,
                     max_n_individuals=inferencecfg["topktoretain"],
                     n_multibodyparts=len(multi_bpts),
@@ -1808,7 +1808,8 @@ def convert_detections2tracklets(
                     window_size=window_size,
                     identity_only=identity_only,
                 )
-                if not os.path.exists(dataname.split(".h5")[0] + "_assemblies.pickle") or overwrite:
+                assemblies_filename = dataname.split(".h5")[0] + "_assemblies.pickle"
+                if not os.path.exists(assemblies_filename) or overwrite:
                     if calibrate:
                         trainingsetfolder = auxiliaryfunctions.get_training_set_folder(cfg)
                         train_data_file = os.path.join(
@@ -1816,12 +1817,11 @@ def convert_detections2tracklets(
                             str(trainingsetfolder),
                             "CollectedData_" + cfg["scorer"] + ".h5",
                         )
-                        ass.calibrate(train_data_file)
-                    ass.assemble()
-                    ass.to_pickle(dataname.split(".h5")[0] + "_assemblies.pickle")
+                        assembly_builder.calibrate(train_data_file)
+                    assembly_builder.assemble()
+                    assembly_builder.to_pickle(assemblies_filename)
                 else:
-                    ass_filename = dataname.split(".h5")[0] + "_assemblies.pickle"
-                    ass.from_pickle(ass_filename)
+                    assembly_builder.from_pickle(assemblies_filename)
                     print(f"Loading assemblies from {ass_filename}")
                 try:
                     data.close()
@@ -1834,7 +1834,7 @@ def convert_detections2tracklets(
                     tracklets["single"] = {}
                     _single = {}
                     for index, imname in enumerate(imnames):
-                        single_detection = ass.unique.get(index)
+                        single_detection = assembly_builder.unique.get(index)
                         if single_detection is None:
                             continue
                         imindex = int(re.findall(r"\d+", imname)[0])
@@ -1844,7 +1844,7 @@ def convert_detections2tracklets(
                 if inferencecfg["topktoretain"] == 1:
                     tracklets[0] = {}
                     for index, imname in tqdm(enumerate(imnames)):
-                        assemblies = ass.assemblies.get(index)
+                        assemblies = assembly_builder.assemblies.get(index)
                         if assemblies is None:
                             continue
                         tracklets[0][imname] = assemblies[0].data
@@ -1852,10 +1852,10 @@ def convert_detections2tracklets(
                     keep = set(multi_bpts).difference(ignore_bodyparts or [])
                     keep_inds = sorted(multi_bpts.index(bpt) for bpt in keep)
                     for index, imname in tqdm(enumerate(imnames)):
-                        assemblies = ass.assemblies.get(index)
+                        assemblies = assembly_builder.assemblies.get(index)
                         if assemblies is None:
                             continue
-                        animals = np.stack([ass.data for ass in assemblies])
+                        animals = np.stack([assembly_builder.data for assembly_builder in assemblies])
                         if not identity_only:
                             if track_method == "box":
                                 xy = trackingutils.calc_bboxes_from_keypoints(

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1797,19 +1797,19 @@ def convert_detections2tracklets(
                         inferencecfg.get("min_hits", 1),
                         inferencecfg.get("iou_threshold", 0.6),
                     )
-                tracklets = {}
+                                tracklets = {}
                 multi_bpts = cfg["multianimalbodyparts"]
+                ass = inferenceutils.Assembler(
+                    data,
+                    max_n_individuals=inferencecfg["topktoretain"],
+                    n_multibodyparts=len(multi_bpts),
+                    greedy=greedy,
+                    pcutoff=inferencecfg.get("pcutoff", 0.1),
+                    min_affinity=inferencecfg.get("pafthreshold", 0.05),
+                    window_size=window_size,
+                    identity_only=identity_only,
+                )
                 if not os.path.exists(dataname.split(".h5")[0] + "_assemblies.pickle") or overwrite:
-                    ass = inferenceutils.Assembler(
-                        data,
-                        max_n_individuals=inferencecfg["topktoretain"],
-                        n_multibodyparts=len(multi_bpts),
-                        greedy=greedy,
-                        pcutoff=inferencecfg.get("pcutoff", 0.1),
-                        min_affinity=inferencecfg.get("pafthreshold", 0.05),
-                        window_size=window_size,
-                        identity_only=identity_only,
-                    )
                     if calibrate:
                         trainingsetfolder = auxiliaryfunctions.get_training_set_folder(cfg)
                         train_data_file = os.path.join(
@@ -1822,8 +1822,8 @@ def convert_detections2tracklets(
                     ass.to_pickle(dataname.split(".h5")[0] + "_assemblies.pickle")
                 else:
                     ass_filename = dataname.split(".h5")[0] + "_assemblies.pickle"
+                    ass.from_pickle(ass_filename)
                     print(f"Loading assemblies from {ass_filename}")
-                    ass = pd.read_pickle(dataname.split(".h5")[0] + "_assemblies.pickle")
                 try:
                     data.close()
                 except AttributeError:
@@ -1853,12 +1853,7 @@ def convert_detections2tracklets(
                     keep = set(multi_bpts).difference(ignore_bodyparts or [])
                     keep_inds = sorted(multi_bpts.index(bpt) for bpt in keep)
                     for index, imname in tqdm(enumerate(imnames)):
-                        if isinstance(ass, dict):
-                            assemblies = ass.get(index)
-                            animals = np.stack([ass for ass in assemblies])
-                        else:
-                            assemblies = ass.assemblies.get(index)
-                            animals = np.stack([ass.data for ass in assemblies])
+                        assemblies = ass.assemblies.get(index)
                         if assemblies is None:
                             continue
                         animals = np.stack([ass.data for ass in assemblies])
@@ -1871,21 +1866,6 @@ def convert_detections2tracklets(
                             else:
                                 xy = animals[:, keep_inds, :2]
                             trackers = mot_tracker.track(xy)
-                        elif isinstance(ass, dict) and identity_only:
-                            #identity assignment if read from _assemblies.pickle
-                            mat = np.zeros(
-                                (len(assemblies), inferencecfg["topktoretain"])
-                            )
-                            for nrow, assembly in enumerate(assemblies):
-                                assembly = assembly[~np.isnan(assembly).any(axis=1)]
-                                unq, idx, cnt = np.unique(assembly[:, 3], return_inverse=True, return_counts=True)
-                                avg = np.bincount(idx, weights=assembly[:, 2]) / cnt
-                                soft = softmax(avg)
-                                vote_output = dict(zip(unq.astype(int), soft))
-                                for k, v in vote_output.items():
-                                    mat[nrow, k] = v
-                            inds = linear_sum_assignment(mat, maximize=True)
-                            trackers = np.c_[inds][:, ::-1]
                         else:
                             # Optimal identity assignment based on soft voting
                             mat = np.zeros(

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -28,7 +28,6 @@ import numpy as np
 import pandas as pd
 import tensorflow as tf
 from scipy.optimize import linear_sum_assignment
-from scipy.special import softmax
 from skimage.util import img_as_ubyte
 from tqdm import tqdm
 

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -28,6 +28,7 @@ import numpy as np
 import pandas as pd
 import tensorflow as tf
 from scipy.optimize import linear_sum_assignment
+from scipy.special import softmax
 from skimage.util import img_as_ubyte
 from tqdm import tqdm
 

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1796,7 +1796,7 @@ def convert_detections2tracklets(
                         inferencecfg.get("min_hits", 1),
                         inferencecfg.get("iou_threshold", 0.6),
                     )
-                                tracklets = {}
+                tracklets = {}
                 multi_bpts = cfg["multianimalbodyparts"]
                 ass = inferenceutils.Assembler(
                     data,


### PR DESCRIPTION
This QoL significantly reduces time needed for testing different inference parameters by reading assemblies from an existing file (if already run once). Works for both identity True and False.