### PR TITLE
Plot keypoint confidence as alpha value

### DIFF
--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -1047,7 +1047,7 @@ def create_video_with_all_detections(
         If False, all keypoints will be plot with alpha=1. Otherwise, this can be
         defined as a function f: [0, 1] -> [0, 1] such that the alpha value for a
         keypoint will be set as a function of its score: alpha = f(score). The default
-        function used when True is f(x) = max(0, (x - pcutoff)/(1 - pcutoff)).
+        function used when True is f(x) = x.
     """
     from deeplabcut.pose_estimation_tensorflow.lib.inferenceutils import Assembler
     import re

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -618,8 +618,12 @@ def create_labeled_video(
     )
     if draw_skeleton:
         bodyparts2connect = cfg["skeleton"]
-        if displayedbodyparts!="all":
-            bodyparts2connect = [pair for pair in bodyparts2connect if all(element in displayedbodyparts for element in pair)]
+        if displayedbodyparts != "all":
+            bodyparts2connect = [
+                pair
+                for pair in bodyparts2connect
+                if all(element in displayedbodyparts for element in pair)
+            ]
         skeleton_color = cfg["skeleton_color"]
     else:
         bodyparts2connect = None
@@ -1222,7 +1226,6 @@ def _get_default_conf_to_alpha(
         return np.clip((x - pcutoff) / (1 - pcutoff), 0, 1)
 
     return default_confidence_to_alpha
-
 
 
 if __name__ == "__main__":

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -1195,9 +1195,7 @@ def create_video_from_pickled_tracks(
 
 
 if __name__ == "__main__":
-    root = Path("/Users/niels/Documents/upamathis/datasets/")
-    project = "dev-ma-pen-2023-06-14"
-    create_video_with_all_detections(
-        config=str(root / project / "config.yaml"),
-        videos=[str(root / project / "videos" / "multipen.mov")],
-    )
+    parser = argparse.ArgumentParser()
+    parser.add_argument("config")
+    parser.add_argument("videos")
+    cli_args = parser.parse_args()


### PR DESCRIPTION
Adds the ability to use the confidence scores for keypoints for the alpha values for disks when creating labeled videos.