### PR TITLE
fix broken gputouse

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -84,7 +84,9 @@ def create_tracking_dataset(
         del os.environ["TF_CUDNN_USE_AUTOTUNE"]  # was potentially set during training
 
     if gputouse is not None:  # gpu selection
-        os.environ["CUDA_VISIBLE_DEVICES"] = str(gputouse)
+        physical_devices = tf.config.list_physical_devices('GPU')
+        assert gputouse < len(physical_devices), f"There are {len(physical_devices)} available GPUs: {physical_devices}\nPlease choose gputouse in {np.arange(len(physical_devices))}"
+        tf.config.set_visible_devices(physical_devices[gputouse], 'GPU')
 
     tf.compat.v1.reset_default_graph()
     start_path = os.getcwd()  # record cwd to return to this directory in the end
@@ -479,7 +481,9 @@ def analyze_videos(
         del os.environ["TF_CUDNN_USE_AUTOTUNE"]  # was potentially set during training
 
     if gputouse is not None:  # gpu selection
-        os.environ["CUDA_VISIBLE_DEVICES"] = str(gputouse)
+        physical_devices = tf.config.list_physical_devices('GPU')
+        assert gputouse < len(physical_devices), f"There are {len(physical_devices)} available GPUs: {physical_devices}\nPlease choose gputouse in {np.arange(len(physical_devices))}"
+        tf.config.set_visible_devices(physical_devices[gputouse], 'GPU')
 
     tf.compat.v1.reset_default_graph()
     start_path = os.getcwd()  # record cwd to return to this directory in the end
@@ -1290,7 +1294,9 @@ def analyze_time_lapse_frames(
         del os.environ["TF_CUDNN_USE_AUTOTUNE"]  # was potentially set during training
 
     if gputouse is not None:  # gpu selection
-        os.environ["CUDA_VISIBLE_DEVICES"] = str(gputouse)
+        physical_devices = tf.config.list_physical_devices('GPU')
+        assert gputouse < len(physical_devices), f"There are {len(physical_devices)} available GPUs: {physical_devices}\nPlease choose gputouse in {np.arange(len(physical_devices))}"
+        tf.config.set_visible_devices(physical_devices[gputouse], 'GPU')
 
     tf.compat.v1.reset_default_graph()
     start_path = os.getcwd()  # record cwd to return to this directory in the end
@@ -1378,7 +1384,9 @@ def analyze_time_lapse_frames(
     )
 
     if gputouse is not None:  # gpu selectinon
-        os.environ["CUDA_VISIBLE_DEVICES"] = str(gputouse)
+        physical_devices = tf.config.list_physical_devices('GPU')
+        assert gputouse < len(physical_devices), f"There are {len(physical_devices)} available GPUs: {physical_devices}\nPlease choose gputouse in {np.arange(len(physical_devices))}"
+        tf.config.set_visible_devices(physical_devices[gputouse], 'GPU')
 
     ##################################################
     # Loading the images

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -36,7 +36,7 @@ from deeplabcut.pose_estimation_tensorflow.core import predict
 from deeplabcut.pose_estimation_tensorflow.lib import inferenceutils, trackingutils
 
 from deeplabcut.refine_training_dataset.stitch import stitch_tracklets
-from deeplabcut.utils import auxiliaryfunctions, auxfun_multianimal
+from deeplabcut.utils import auxiliaryfunctions, auxfun_multianimal, auxfun_models
 from deeplabcut.pose_estimation_tensorflow.core.openvino.session import (
     GetPoseF_OV,
     is_openvino_available,
@@ -84,9 +84,7 @@ def create_tracking_dataset(
         del os.environ["TF_CUDNN_USE_AUTOTUNE"]  # was potentially set during training
 
     if gputouse is not None:  # gpu selection
-        physical_devices = tf.config.list_physical_devices('GPU')
-        assert gputouse < len(physical_devices), f"There are {len(physical_devices)} available GPUs: {physical_devices}\nPlease choose gputouse in {np.arange(len(physical_devices))}"
-        tf.config.set_visible_devices(physical_devices[gputouse], 'GPU')
+        auxfun_models.set_visible_devices(gputouse)
 
     tf.compat.v1.reset_default_graph()
     start_path = os.getcwd()  # record cwd to return to this directory in the end
@@ -481,9 +479,7 @@ def analyze_videos(
         del os.environ["TF_CUDNN_USE_AUTOTUNE"]  # was potentially set during training
 
     if gputouse is not None:  # gpu selection
-        physical_devices = tf.config.list_physical_devices('GPU')
-        assert gputouse < len(physical_devices), f"There are {len(physical_devices)} available GPUs: {physical_devices}\nPlease choose gputouse in {np.arange(len(physical_devices))}"
-        tf.config.set_visible_devices(physical_devices[gputouse], 'GPU')
+        auxfun_models.set_visible_devices(gputouse)
 
     tf.compat.v1.reset_default_graph()
     start_path = os.getcwd()  # record cwd to return to this directory in the end
@@ -1294,9 +1290,7 @@ def analyze_time_lapse_frames(
         del os.environ["TF_CUDNN_USE_AUTOTUNE"]  # was potentially set during training
 
     if gputouse is not None:  # gpu selection
-        physical_devices = tf.config.list_physical_devices('GPU')
-        assert gputouse < len(physical_devices), f"There are {len(physical_devices)} available GPUs: {physical_devices}\nPlease choose gputouse in {np.arange(len(physical_devices))}"
-        tf.config.set_visible_devices(physical_devices[gputouse], 'GPU')
+        auxfun_models.set_visible_devices(gputouse)
 
     tf.compat.v1.reset_default_graph()
     start_path = os.getcwd()  # record cwd to return to this directory in the end
@@ -1384,9 +1378,7 @@ def analyze_time_lapse_frames(
     )
 
     if gputouse is not None:  # gpu selectinon
-        physical_devices = tf.config.list_physical_devices('GPU')
-        assert gputouse < len(physical_devices), f"There are {len(physical_devices)} available GPUs: {physical_devices}\nPlease choose gputouse in {np.arange(len(physical_devices))}"
-        tf.config.set_visible_devices(physical_devices[gputouse], 'GPU')
+        auxfun_models.set_visible_devices(gputouse)
 
     ##################################################
     # Loading the images

--- a/deeplabcut/utils/auxfun_models.py
+++ b/deeplabcut/utils/auxfun_models.py
@@ -19,6 +19,7 @@ Licensed under GNU Lesser General Public License v3.0
 """
 
 import os
+import tensorflow as tf
 from pathlib import Path
 from deeplabcut.utils import auxiliaryfunctions
 
@@ -155,6 +156,16 @@ def download_model(modelname, target_dir):
         ]
         print("Model does not exist: ", modelname)
         print("Pick one of the following: ", models)
+
+
+def set_visible_devices(gputouse: int):
+    physical_devices = tf.config.list_physical_devices("GPU")
+    n_devices = len(physical_devices)
+    if gputouse >= n_devices:
+        raise ValueError(
+            f"There are {n_devices} available GPUs: {physical_devices}\nPlease choose `gputouse` in {list(range(n_devices))}."
+        )
+    tf.config.set_visible_devices(physical_devices[gputouse], "GPU")
 
 
 # Aliases for backwards-compatibility


### PR DESCRIPTION
Hi @n-poulsen and team DLC!

Here is a PR solving #2312: after TF import (or first call if lazy loading is enabled), `os.environ['CUDA_VISIBLE_DEVICES']` has no effect anymore, so I replaced it by `tf.config.set_visible_devices()` (the TensorFlow equivalent of `torch.cuda.set_device()` ; hat tip to [this message](https://github.com/pytorch/pytorch/issues/9158#issuecomment-1198489462)). Also added an explicit error message if `gputouse` is out of the range of available GPUs.

Made this replacement for all four `if gputouse is not None:` statements in `predict_videos.py`, although I only (explicitly) use `analyze_videos()` (which I just tried, and it worked perfectly!).

Best,
Ludovic