### PR TITLE
Fix `interp` kwarg in `imresize` function.

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/util/visualize.py
+++ b/deeplabcut/pose_estimation_tensorflow/util/visualize.py
@@ -91,7 +91,7 @@ def show_heatmaps(cfg, img, scmap, pose, cmap="jet"):
         plot_j = (pidx + 1) // subplot_width
         plot_i = (pidx + 1) % subplot_width
         scmap_part = np.sum(scmap[:, :, part], axis=2)
-        scmap_part = imresize(scmap_part, 8.0, interp="bicubic")
+        scmap_part = imresize(scmap_part, 8.0, interpolationmethod="bicubic")
         scmap_part = np.lib.pad(scmap_part, ((4, 0), (4, 0)), "minimum")
         curr_plot = axarr[plot_j, plot_i]
         curr_plot.set_title(all_joints_names[pidx])

--- a/deeplabcut/pose_estimation_tensorflow/util/visualize.py
+++ b/deeplabcut/pose_estimation_tensorflow/util/visualize.py
@@ -20,6 +20,7 @@ import math
 
 import matplotlib.pyplot as plt
 import numpy as np
+import cv2
 
 from deeplabcut.utils.auxfun_videos import imresize
 
@@ -91,7 +92,7 @@ def show_heatmaps(cfg, img, scmap, pose, cmap="jet"):
         plot_j = (pidx + 1) // subplot_width
         plot_i = (pidx + 1) % subplot_width
         scmap_part = np.sum(scmap[:, :, part], axis=2)
-        scmap_part = imresize(scmap_part, 8.0, interpolationmethod="bicubic")
+        scmap_part = imresize(scmap_part, 8.0, interpolationmethod=cv2.INTER_CUBIC)
         scmap_part = np.lib.pad(scmap_part, ((4, 0), (4, 0)), "minimum")
         curr_plot = axarr[plot_j, plot_i]
         curr_plot.set_title(all_joints_names[pidx])

--- a/deeplabcut/pose_estimation_tensorflow/vis_dataset.py
+++ b/deeplabcut/pose_estimation_tensorflow/vis_dataset.py
@@ -17,6 +17,8 @@ import logging
 
 import matplotlib.pyplot as plt
 import numpy as np
+import cv2
+
 
 from deeplabcut.pose_estimation_tensorflow.config import load_config
 from deeplabcut.pose_estimation_tensorflow.datasets import (
@@ -65,7 +67,7 @@ def display_dataset():
                     continue
 
                 scmap_part = scmap[:, :, j]
-                scmap_part = imresize(scmap_part, 8.0, interpolationmethod="nearest")
+                scmap_part = imresize(scmap_part, 8.0, interpolationmethod=cv2.INTER_NEAREST)
                 scmap_part = np.lib.pad(scmap_part, ((4, 0), (4, 0)), "minimum")
 
                 curr_plot.set_title("{}".format(j + 1))

--- a/deeplabcut/pose_estimation_tensorflow/vis_dataset.py
+++ b/deeplabcut/pose_estimation_tensorflow/vis_dataset.py
@@ -65,7 +65,7 @@ def display_dataset():
                     continue
 
                 scmap_part = scmap[:, :, j]
-                scmap_part = imresize(scmap_part, 8.0, interp="nearest")
+                scmap_part = imresize(scmap_part, 8.0, interpolationmethod="nearest")
                 scmap_part = np.lib.pad(scmap_part, ((4, 0), (4, 0)), "minimum")
 
                 curr_plot.set_title("{}".format(j + 1))


### PR DESCRIPTION
I noticed the `imresize` function had usages that referred to the kwarg `interp` but the actual definition of the function had a different name `interpolationmethod`. 

I then noticed that the args were provided as strings but the underlying [OpenCV method actually takes an enum](https://docs.opencv.org/3.4/da/d54/group__imgproc__transform.html#ga5bb5a1fea74ea38e1a5445ca803ff121).

I applied the necessary corrections although I have not tested the scripts myself. I was interested in visualizing the augmentations without actively training but I wrote my own script for that. 