### PR TITLE
Bug fixes VideoWriter: video names with spaces

### DIFF
--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -55,7 +55,7 @@ class VideoReader:
 
     def check_integrity(self):
         dest = os.path.join(self.directory, f"{self.name}.log")
-        command = f"ffmpeg -v error -i {self.video_path} -f null - 2>{dest}"
+        command = f'ffmpeg -v error -i "{self.video_path}" -f null - 2>"{dest}"'
         subprocess.call(command, shell=True)
         if os.path.getsize(dest) != 0:
             warnings.warn(f'Video contains errors. See "{dest}" for a detailed report.')
@@ -333,8 +333,8 @@ class VideoWriter(VideoReader):
     ):
         output_path = self.make_output_path(suffix, dest_folder)
         command = (
-            f"ffmpeg -n -i {self.video_path} -filter:v "
-            f'"scale={width}:{height}{{}}" -c:a copy {output_path}'
+            f'ffmpeg -n -i "{self.video_path}" -filter:v '
+            f'"scale={width}:{height}{{}}" -c:a copy "{output_path}"'
         )
         # Rotate, see: https://stackoverflow.com/questions/3937387/rotating-videos-with-ffmpeg
         # interesting option to just update metadata.

--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -267,8 +267,8 @@ class VideoWriter(VideoReader):
 
         output_path = self.make_output_path(suffix, dest_folder)
         command = (
-            f"ffmpeg -n -i {self.video_path} -ss {start} -to {end} "
-            f"-c:a copy {output_path}"
+            f'ffmpeg -n -i "{self.video_path}" -ss {start} -to {end} '
+            f'-c:a copy "{output_path}"'
         )
         subprocess.call(command, shell=True)
         return output_path


### PR DESCRIPTION
Fixed a few bugs in VideoWriter: the subcommands used did not wrap the video name in quotation marks (neither input nor output), which led to FFmpeg failing to parse the input/output names.

This affected the `check_integrity`, `rescale` and `shorten` methods.