### PR TITLE
update the lr when switching to adam optimizer

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/core/train.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train.py
@@ -226,6 +226,8 @@ def train(
     if not info["is_cuda_build"]:  # Apple Silicon is not built with CUDA
         warnings.warn("Switching to Adam, as SGD crashes on Apple Silicon.")
         cfg["optimizer"] = "adam"
+        cfg["lr_init"] = 5e-4
+        cfg["multi_step"] = [[1e-4, 7500], [5e-5, 12000], [1e-5, 200000]]
 
     if cfg.get("freezeencoder", False):
         if "efficientnet" in net_type:


### PR DESCRIPTION
When switching to the Adam optimizer on Apple computers (as SGD crashes on Apple Silicon), the learning rate was not updated. This often (almost always) caused the models to diverge.

This PR updates the learning rate, to the same values (and schedule) as the default for multi-animal projects (which use Adam):
```
cfg["multi_step"] = [[1e-4, 7500], [5e-5, 12000], [1e-5, 200000]]
```

This was tested on an M2 MacBook Air, on a dataset which diverge in less than 5 iterations using the previous schedule, and now converges nicely.