### PR TITLE
Address underlying compatibility issue with scipy 1.11.0

### DIFF
--- a/deeplabcut/refine_training_dataset/stitch.py
+++ b/deeplabcut/refine_training_dataset/stitch.py
@@ -135,7 +135,12 @@ class Tracklet:
     def identity(self):
         """Return the average predicted identity of all Tracklet detections."""
         try:
-            return mode(self.data[..., 3], axis=None, nan_policy="omit")[0][0]
+            return mode(
+                self.data[..., 3],
+                axis=None,
+                nan_policy="omit",
+                keepdims=False,
+            )[0]
         except IndexError:
             return -1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ pandas>=1.0.1,!=1.5.0
 pyyaml
 scikit-image>=0.17
 scikit-learn>=1.0
-scipy>=1.4,<1.11.0
+scipy>=1.9
 statsmodels>=0.11
 tensorflow>=2.0,<2.13.0
 tables==3.7.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
         "pandas>=1.0.1,!=1.5.0",
         "scikit-image>=0.17",
         "scikit-learn>=1.0",
-        "scipy>=1.4,<1.11.0",
+        "scipy>=1.9",
         "statsmodels>=0.11",
         "tables>=3.7.0",
         "torch<=1.12",


### PR DESCRIPTION
See warning in scipy 1.9's documentation.
See warning in https://docs.scipy.org/doc/scipy-1.9.0/reference/generated/scipy.stats.mode.html

The SPEC0 suggests that scipy 1.8 be dropped in 2024, but I think it is OK to drop it a little early.

If you don't want to drop it, we could add a version check for the keyword argument, but that seems a little much.

The keyword argument `keepdims` was added in scipy 1.9

xref: https://github.com/DeepLabCut/DeepLabCut/pull/2290