### PR TITLE
Update python-package.yml

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-11, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10"]
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip

--- a/deeplabcut/utils/auxiliaryfunctions_3d.py
+++ b/deeplabcut/utils/auxiliaryfunctions_3d.py
@@ -215,7 +215,7 @@ def Get_list_of_triangulated_and_videoFiles(
             videofolder = str(Path(filepath[0]).parents[0])
         video_list = get_camerawise_videos(videofolder, cam_names, videotype)
 
-    # Get the filename of the triangulated file excluing the scorer name and remove any '-' or _ from it
+    # Get the filename of the triangulated file excluding the scorer name and remove any '-' or _ from it
     filename = [i.split(string_to_search)[0] for i in triangulated_file_list]
     for i in range(len(filename)):
         if filename[i][-1] == "_" or filename[i][-1] == "-":

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -73,7 +73,7 @@ You can (on Windows) hold SHIFT and right-click > Copy as path, or (on Mac) righ
 
 ``conda env create -f DEEPLABCUT_M1.yaml``
 
-- You can now use this environment from anywhere on your comptuer (i.e., no need to go back into the conda- folder). Just enter your environment by running:
+- You can now use this environment from anywhere on your computer (i.e., no need to go back into the conda- folder). Just enter your environment by running:
      - Ubuntu/MacOS: ``source/conda activate nameoftheenv`` (i.e. on your Mac: ``conda activate DEEPLABCUT`` or ``conda activate DEEPLABCUT_M1``)
      - Windows: ``activate nameoftheenv`` (i.e. ``activate DEEPLABCUT``)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,7 +14,7 @@
 **General NN Improvements:**
 - [X] EfficientNet backbones added (currently SOTA on ImageNet). https://openaccess.thecvf.com/content/WACV2021/html/Mathis_Pretraining_Boosts_Out-of-Domain_Robustness_for_Pose_Estimation_WACV_2021_paper.html https://github.com/DeepLabCut/DeepLabCut/commit/96da2cacf837a9b84ecdeafb50dfb4a93b402f33
 - [X] New multi-fusion multi-scale networks; DLCRNet_ms5
-- [ ] BUCTD integration, see ICCV 2023 paper at https://arxiv.org/abs/2306.07879
+- [ ] BUCTD Integration, see ICCV 2023 paper at https://arxiv.org/abs/2306.07879
 
 **deeplabcut 2.2: multi-animal pose estimation and tracking with DeepLabCut**
 - [X] alpha testing complete (early May 2020)
@@ -29,7 +29,7 @@
 
 **real-time module with DEMO for how to set up on your camera system, integration with our [Camera Control Software]**(https://github.com/AdaptiveMotorControlLab/Camera_Control)
 - [X] Integration with Bonsai completed! See: https://github.com/bonsai-rx/deeplabcut
-- [X] Integreation with Auto-pi-lot. See: https://auto-pi-lot.com/
+- [X] Integration with Auto-pi-lot. See: https://auto-pi-lot.com/
 - [X] DeepLabCut-live! released Aug 5th, 2020: preprint & code: https://www.biorxiv.org/content/10.1101/2020.08.04.236422v1
 - [X] DeepLabCut-live! published in eLife
 

--- a/examples/JUPYTER/Demo_napari.ipynb
+++ b/examples/JUPYTER/Demo_napari.ipynb
@@ -177,7 +177,7 @@
     "# Attention: If you have not installed the napari-dlc plugin, do so now by running this cell:\n",
     "!pip install napari-deeplabcut\n",
     "\n",
-    "#if the plugin does not appear upon launch, consider running in the ternimal the above command \n",
+    "#if the plugin does not appear upon launch, consider running in the termimal the above command \n",
     "#within the same conda env and then re-starting kernel in your notebook (Kernel > restart)."
    ]
   },

--- a/examples/JUPYTER/Demo_napari.ipynb
+++ b/examples/JUPYTER/Demo_napari.ipynb
@@ -177,7 +177,7 @@
     "# Attention: If you have not installed the napari-dlc plugin, do so now by running this cell:\n",
     "!pip install napari-deeplabcut\n",
     "\n",
-    "#if the plugin does not appear upon launch, consider running in the termimal the above command \n",
+    "#if the plugin does not appear upon launch, consider running in the terminal the above command \n",
     "#within the same conda env and then re-starting kernel in your notebook (Kernel > restart)."
    ]
   },


### PR DESCRIPTION
Keeping up with the times. Here, I propose to drop 3.7 and 3.8 testing, see also PR #2290 vs. #2396 where this is needed to keep up with our core dependency, scipy!

- minor spelling errors fixed.