### PR TITLE
update notebooks and COLAB

### DIFF
--- a/examples/COLAB/COLAB_3miceDemo.ipynb
+++ b/examples/COLAB/COLAB_3miceDemo.ipynb
@@ -27,10 +27,10 @@
     "- assemble animals and tracklets.\n",
     "- create quality check plots and video.\n",
     "\n",
-    "### To create a full maDLC pipeline please see our full docs: https://deeplabcut.github.io/DeepLabCut/docs/intro.html \n",
+    "### To create a full maDLC pipeline please see our full docs: https://deeplabcut.github.io/DeepLabCut/README.html\n",
     "- Of interest is a full how-to for maDLC: https://deeplabcut.github.io/DeepLabCut/docs/maDLC_UserGuide.html\n",
     "- a quick guide to maDLC: https://deeplabcut.github.io/DeepLabCut/docs/tutorial.html\n",
-    "- a demo COLAB for how to use maDLC on your own data: https://github.com/DeepLabCut/DeepLabCut/blob/master/examples/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb\n",
+    "- a demo COLAB for how to use maDLC on your own data: https://github.com/DeepLabCut/DeepLabCut/blob/main/examples/COLAB/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb\n",
     "\n",
     "### To get started, please go to \"Runtime\" ->\"change runtime type\"->select \"Python3\", and then select \"GPU\"\n"
    ]

--- a/examples/COLAB/COLAB_YOURDATA_TrainNetwork_VideoAnalysis.ipynb
+++ b/examples/COLAB/COLAB_YOURDATA_TrainNetwork_VideoAnalysis.ipynb
@@ -27,7 +27,7 @@
     "- create simple quality check plots\n",
     "- analyze novel videos!\n",
     "\n",
-    "###This notebook assumes you already have a project folder with labeled data! \n",
+    "### This notebook assumes you already have a project folder with labeled data! \n",
     "\n",
     "This notebook demonstrates the necessary steps to use DeepLabCut for your own project.\n",
     "\n",

--- a/examples/COLAB/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb
+++ b/examples/COLAB/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb
@@ -1,19 +1,4 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "accelerator": "GPU",
-  "colab": {
-   "collapsed_sections": [],
-   "include_colab_link": true,
-   "name": "COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb",
-   "provenance": []
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "name": "python3"
-  }
- },
  "cells": [
   {
    "cell_type": "markdown",
@@ -44,7 +29,7 @@
     "- assemble animals and tracklets\n",
     "- create quality check plots!\n",
     "\n",
-    "###This notebook assumes you already have a DLC project folder with labeled data and you uploaded it to your own Google Drive.\n",
+    "### This notebook assumes you already have a DLC project folder with labeled data and you uploaded it to your own Google Drive.\n",
     "\n",
     "This notebook demonstrates the necessary steps to use DeepLabCut for your own project.\n",
     "\n",
@@ -82,16 +67,16 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "-MVvZ13_FMvP"
    },
+   "outputs": [],
    "source": [
     "#a few colab specific things needed:\n",
     "!pip install --upgrade scikit-image\n",
     "!pip3 install pickle5"
-   ],
-   "execution_count": null,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -106,16 +91,16 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "id": "oTwAcbq2-FZz",
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
+    "id": "oTwAcbq2-FZz",
     "outputId": "9cfd8dcf-a0a8-4801-ed1d-fbcd5ec056af"
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "DLC loaded in light mode; you cannot use any GUI (labeling, relabeling and standalone GUI)\n"
      ]
@@ -501,5 +486,20 @@
     "                                filtered=True)"
    ]
   }
- ]
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [],
+   "include_colab_link": true,
+   "name": "COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/examples/COLAB/COLAB_transformer_reID.ipynb
+++ b/examples/COLAB/COLAB_transformer_reID.ipynb
@@ -27,10 +27,10 @@
     "- use the transformer to do unsupervised ID tracking.\n",
     "- create quality check plots and video.\n",
     "\n",
-    "### To create a full maDLC pipeline please see our full docs: https://deeplabcut.github.io/DeepLabCut/docs/intro.html \n",
+    "### To create a full maDLC pipeline please see our full docs: https://deeplabcut.github.io/DeepLabCut/README.html\n",
     "- Of interest is a full how-to for maDLC: https://deeplabcut.github.io/DeepLabCut/docs/maDLC_UserGuide.html\n",
     "- a quick guide to maDLC: https://deeplabcut.github.io/DeepLabCut/docs/tutorial.html\n",
-    "- a demo COLAB for how to use maDLC on your own data: https://github.com/DeepLabCut/DeepLabCut/blob/master/examples/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb\n",
+    "- a demo COLAB for how to use maDLC on your own data: https://github.com/DeepLabCut/DeepLabCut/blob/main/examples/COLAB/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb\n",
     "\n",
     "### To get started, please go to \"Runtime\" ->\"change runtime type\"->select \"Python3\", and then select \"GPU\"\n"
    ]

--- a/examples/JUPYTER/Demo_labeledexample_Openfield.ipynb
+++ b/examples/JUPYTER/Demo_labeledexample_Openfield.ipynb
@@ -528,7 +528,7 @@
    },
    "outputs": [],
    "source": [
-    "%gui wx\n",
+    "%gui qt6\n",
     "deeplabcut.refine_labels(path_config_file)"
    ]
   },

--- a/examples/JUPYTER/Demo_napari.ipynb
+++ b/examples/JUPYTER/Demo_napari.ipynb
@@ -192,7 +192,7 @@
    "outputs": [],
    "source": [
     "# napari will pop up! Please go to plugin > deeplabcut to start:\n",
-    "%gui qt5\n",
+    "%gui qt6\n",
     "import napari\n",
     "napari.Viewer()"
    ]
@@ -400,7 +400,7 @@
    "source": [
     "#now you can edit the \"machine-labeled file\" within napari; \n",
     "#just again drop the file and images into the workspace after you load the plugin\n",
-    "%gui qt5\n",
+    "%gui qt6\n",
     "import napari\n",
     "napari.Viewer()"
    ]

--- a/examples/JUPYTER/Demo_yourowndata.ipynb
+++ b/examples/JUPYTER/Demo_yourowndata.ipynb
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -129,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -152,7 +152,7 @@
    "source": [
     "#AND/OR:\n",
     "#SELECT RARE EVENTS MANUALLY:\n",
-    "%gui wx\n",
+    "%gui qt5\n",
     "deeplabcut.extract_frames(path_config_file,'manual')"
    ]
   },
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -178,7 +178,7 @@
    },
    "outputs": [],
    "source": [
-    "%gui wx\n",
+    "%gui qt5\n",
     "deeplabcut.label_frames(path_config_file)"
    ]
   },
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -264,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -289,7 +289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -315,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -351,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -375,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -383,7 +383,7 @@
    },
    "outputs": [],
    "source": [
-    "%gui wx\n",
+    "%gui qt5\n",
     "deeplabcut.refine_labels(path_config_file)"
    ]
   },
@@ -406,7 +406,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -432,7 +432,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -471,7 +471,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -495,7 +495,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "colab": {},
     "colab_type": "code",

--- a/examples/JUPYTER/Demo_yourowndata.ipynb
+++ b/examples/JUPYTER/Demo_yourowndata.ipynb
@@ -145,18 +145,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#AND/OR:\n",
-    "#SELECT RARE EVENTS MANUALLY:\n",
-    "%gui qt5\n",
-    "deeplabcut.extract_frames(path_config_file,'manual')"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
@@ -178,8 +166,14 @@
    },
    "outputs": [],
    "source": [
-    "%gui qt5\n",
-    "deeplabcut.label_frames(path_config_file)"
+    "# napari will pop up!\n",
+    "# Please go to plugin > deeplabcut to start\n",
+    "# then, drag-and-drop the project configuration file into the viewer (the value of path_config_file)\n",
+    "# finally, drop the folder containing the images (in 'labeled-data') in the viewer\n",
+    "\n",
+    "%gui qt6\n",
+    "import napari\n",
+    "napari.Viewer()"
    ]
   },
   {
@@ -383,7 +377,7 @@
    },
    "outputs": [],
    "source": [
-    "%gui qt5\n",
+    "%gui qt6\n",
     "deeplabcut.refine_labels(path_config_file)"
    ]
   },


### PR DESCRIPTION
made the following changes:
- fixed some broken links
- updated the GUI from QT5 to QT6 in the notebooks
- fixed the `examples/JUPYTER/Demo_yourowndata.ipynb` notebook to use the new GUI (tested on an M2 MacBook)
- removed the option to extract frames manually in `examples/JUPYTER/Demo_yourowndata.ipynb`, as that was causing issues in the notebook (failure to open GUI)