### PR TITLE
GUI - Fix config YAML edition (start list indexing at 0)

### DIFF
--- a/deeplabcut/gui/widgets.py
+++ b/deeplabcut/gui/widgets.py
@@ -432,7 +432,7 @@ class DictViewer(QtWidgets.QWidget):
             for key, val in data.items():
                 self.add_row(key, val, tree_widget)
         elif isinstance(data, list):
-            for i, val in enumerate(data, start=1):
+            for i, val in enumerate(data):
                 self.add_row(str(i), val, tree_widget)
         else:
             print("This should never be reached!")


### PR DESCRIPTION
Populates the config dictionary with keys starting at 0 for lists, as starting keys at 1 led to errors when editing the YAML (e.g., in `pose_cfg.yaml` changing `multi_step` item 0 would change `multi_step` item 1).