### PR TITLE
Smartly restore pretrained model weights

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/core/train.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train.py
@@ -31,6 +31,7 @@ from deeplabcut.pose_estimation_tensorflow.datasets import (
 )
 from deeplabcut.pose_estimation_tensorflow.nnets import PoseNetFactory
 from deeplabcut.pose_estimation_tensorflow.util.logging import setup_logging
+from deeplabcut.utils import auxfun_models
 
 
 class LearningRate(object):
@@ -243,7 +244,8 @@ def train(
     sess.run(tf.compat.v1.local_variables_initializer())
 
     # Restore variables from disk.
-    restorer.restore(sess, cfg["init_weights"])
+    auxfun_models.smart_restore(restorer, sess, cfg["init_weights"], net_type)
+
     if maxiters is None:
         max_iter = int(cfg["multi_step"][-1][1])
     else:

--- a/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/train_multianimal.py
@@ -28,6 +28,7 @@ from deeplabcut.pose_estimation_tensorflow.core.train import (
     get_optimizer,
     LearningRate,
 )
+from deeplabcut.utils import auxfun_models
 
 
 def train(
@@ -157,7 +158,8 @@ def train(
     sess.run(tf.compat.v1.global_variables_initializer())
     sess.run(tf.compat.v1.local_variables_initializer())
 
-    restorer.restore(sess, cfg["init_weights"])
+    auxfun_models.smart_restore(restorer, sess, cfg["init_weights"], net_type)
+
     if maxiters is None:
         max_iter = int(cfg["multi_step"][-1][1])
     else:


### PR DESCRIPTION
In COLAB, the pretrained model weights are stored on a non-persistent disk, causing training to fail as weights cannot be found (`ValueError: The passed save_path is not a valid checkpoint:...`). This PR introduces a smarter checkpoint restore mechanism to prevent this from happening, silently redownloading the weights.