### PR TITLE
bug fix: empty predictions during video analysis

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/predict_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_multianimal.py
@@ -508,6 +508,8 @@ def GetPoseandCostsS(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes, shelf_pa
                 inputs,
                 outputs,
             )
+            if not dets:
+                continue
             db[key] = dets[0]
             del dets
         elif counter >= nframes:


### PR DESCRIPTION
This PR addresses #2449

During video analysis, we do not check that there are detections for a frame before unpacking them. This PR addresses that in the same way that it's dealt with in the evaluation code