### PR TITLE
Bug fix: `add_new_videos(..., extract_frames=True)`

### DIFF
--- a/deeplabcut/create_project/add.py
+++ b/deeplabcut/create_project/add.py
@@ -58,6 +58,10 @@ def add_new_videos(
     # Read the config file
     cfg = auxiliaryfunctions.read_config(config)
 
+    # deal with user passing a single video to add
+    if isinstance(videos, str):
+        videos = [videos]
+
     video_path = Path(config).parents[0] / "videos"
     data_path = Path(config).parents[0] / "labeled-data"
     videos = [Path(vp) for vp in videos]

--- a/deeplabcut/create_project/add.py
+++ b/deeplabcut/create_project/add.py
@@ -127,6 +127,7 @@ def add_new_videos(
         else:
             cfg["video_sets_original"].update(params)
     videos_str = [str(video) for video in videos]
+    auxiliaryfunctions.write_config(config, cfg)
     if extract_frames:
         frame_extraction.extract_frames(
             config, userfeedback=False, videos_list=videos_str
@@ -138,4 +139,3 @@ def add_new_videos(
         print(
             "New videos were added to the project! Use the function 'extract_frames' to select frames for labeling."
         )
-    auxiliaryfunctions.write_config(config, cfg)


### PR DESCRIPTION
Addresses issues #2461 and #2463

When running `add_new_videos(..., extract_frames=True)`, the configuration file is written after `extract_frames` is called. So when getting the videos for which to extract new frames, the new videos are not yet in the project configuration:

```python
    # deeplabcut.extract_frames, lines 269-272
    if videos_list is None:
        videos = cfg.get("video_sets_original") or cfg["video_sets"]
    else:  # filter video_list by the ones in the config file
        videos = [v for v in cfg["video_sets"] if v in videos_list]  # none of videos_list are in cfg["video_sets"] yet!
    ...

    has_failed = []
    for video in videos:
        ...

    if all(has_failed):  # True as the list is empty
        print("Frame extraction failed. Video files must be corrupted.")
```

Also deals with the case when users pass a single video to add as a string: wraps it in a list to avoid the annoying issue in #2463.