### PR TITLE
updated macOS runner to 13

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,17 +13,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-11, windows-latest]
+        os: [ubuntu-latest, macos-13, windows-latest]
         python-version: [3.9, "3.10"]
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip
-          - os: macos-11
+          - os: macos-13
             path: ~/Library/Caches/pip
           - os: windows-latest
             path: ~\AppData\Local\pip\Cache
         exclude:
-          - os: macos-11
+          - os: macos-13
             python-version: 3.7
           - os: windows-latest
             python-version: 3.7


### PR DESCRIPTION
This PR updates the macOS runners to 13 for the github CI/CD as macos-11 now fails to install FFmpeg with Homebrew (Homebrew no longer supports macOS 11).