### PR TITLE
Bump version of `tables` installed during CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ scikit-learn>=1.0
 scipy>=1.9
 statsmodels>=0.11
 tensorflow>=2.0,<2.13.0
-tables==3.7.0
+tables==3.8.0
 tensorpack==0.11
 tf_slim==1.1.0
 torch==1.12


### PR DESCRIPTION
Fixes unit tests failing with `ImportError: Pandas requires version '3.8.0' or newer of 'tables' (version '3.7.0' currently installed)`.