### PR TITLE
slight change to setup (move all TF to TF tag; pin tables, add note that python 3.9 is currently required

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 # [Installation: how to install DeepLabCut](https://deeplabcut.github.io/DeepLabCut/docs/installation.html)
 
 Very quick start: `pip install "deeplabcut[gui,tf]"` that includes all functions plus GUIs, or `pip install deeplabcut[tf]` (headless version with PyTorch and TensorFlow).
-* We recommend using our conda file, see [here](https://github.com/DeepLabCut/DeepLabCut/blob/master/conda-environments/README.md) or the new [`deeplabcut-docker` package](https://github.com/DeepLabCut/DeepLabCut/tree/master/docker).
+* We recommend using our conda file, see [here](https://github.com/DeepLabCut/DeepLabCut/blob/master/conda-environments/README.md) or the new [`deeplabcut-docker` package](https://github.com/DeepLabCut/DeepLabCut/tree/master/docker). Please note that currently we support Python 3.9 (see conda files for guidance).
 
 # [Documentation: The DeepLabCut Process](https://deeplabcut.github.io/DeepLabCut)
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
         "tqdm",
         "pyyaml",
         "Pillow>=7.1",
-        "tables==3.7.0",
+        "tables==3.8.0",
     ],
     extras_require={
         "gui": [

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,12 @@ setuptools.setup(
             "tensorpack>=0.11",
             "tf_slim>=1.1.0",
         ],  # Last supported TF version on Windows Native is 2.10
-        "apple_mchips": ["tensorflow-macos<2.13.0", "tensorflow-metal"],
+        "apple_mchips": [
+            "tensorflow-macos<2.13.0",
+            "tensorflow-metal",
+            "tensorpack>=0.11",
+            "tf_slim>=1.1.0",
+        ],
         "modelzoo": ["huggingface_hub"],
     },
     scripts=["deeplabcut/pose_estimation_tensorflow/models/pretrained/download.sh"],

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setuptools.setup(
         "scikit-learn>=1.0",
         "scipy>=1.9",
         "statsmodels>=0.11",
-        "torch<=1.12",
+        "torch",
         "tqdm",
         "pyyaml",
         "Pillow>=7.1",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open("README.md", encoding="utf-8", errors="replace") as fh:
 setuptools.setup(
     name="deeplabcut",
     version="2.3.9",
-    author="A. & M. Mathis Labs",
+    author="A. & M.W. Mathis Labs",
     author_email="alexander@deeplabcut.org",
     description="Markerless pose-estimation of user-defined features with deep learning",
     long_description=long_description,
@@ -39,13 +39,11 @@ setuptools.setup(
         "scikit-learn>=1.0",
         "scipy>=1.9",
         "statsmodels>=0.11",
-        "tables>=3.7.0",
         "torch<=1.12",
-        "tensorpack>=0.11",
-        "tf_slim>=1.1.0",
         "tqdm",
         "pyyaml",
         "Pillow>=7.1",
+        "tables==3.7.0",
     ],
     extras_require={
         "gui": [
@@ -56,7 +54,9 @@ setuptools.setup(
         "openvino": ["openvino-dev==2022.1.0"],
         "docs": ["numpydoc"],
         "tf": [
-            "tensorflow>=2.0,<=2.10"
+            "tensorflow>=2.0,<=2.10",
+            "tensorpack>=0.11",
+            "tf_slim>=1.1.0",
         ],  # Last supported TF version on Windows Native is 2.10
         "apple_mchips": ["tensorflow-macos<2.13.0", "tensorflow-metal"],
         "modelzoo": ["huggingface_hub"],


### PR DESCRIPTION
**slight change to setup & read me:**
- move all TF items to TF tag
- pin tables to 3.8; if someone uses python > 3.9 it will ty to solve dependency issues and force install DLC 2.3.0!! 
- Add note that python 3.9 is currently required
- unpin torch
- add other TF nicietes for apple install

Tested locally on Intel MacOS system that GUI launches and working (thus far;) 