### PR TITLE
Video analysis on cropped videos: bug fixes for `extract_outlier_frames` and `create_video_with_all_detections`

### DIFF
--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -390,10 +390,20 @@ def extract_outlier_frames(
             df, dataname, _, _ = auxiliaryfunctions.load_analyzed_data(
                 videofolder, vname, DLCscorer, track_method=track_method
             )
+            metadata = auxiliaryfunctions.load_video_metadata(
+                videofolder, vname, DLCscorer
+            )
             nframes = len(df)
             startindex = max([int(np.floor(nframes * cfg["start"])), 0])
             stopindex = min([int(np.ceil(nframes * cfg["stop"])), nframes])
             Index = np.arange(stopindex - startindex) + startindex
+
+            # offset if the data was cropped
+            cropping = metadata["data"]["cropping"]
+            x1, x2, y1, y2 = metadata["data"]["cropping_parameters"]
+            if cropping:
+                df.iloc[:, df.columns.get_level_values(level="coords") == "x"] += x1
+                df.iloc[:, df.columns.get_level_values(level="coords") == "y"] += y1
 
             df = df.iloc[Index]
             mask = df.columns.get_level_values("bodyparts").isin(bodyparts)

--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -399,9 +399,8 @@ def extract_outlier_frames(
             Index = np.arange(stopindex - startindex) + startindex
 
             # offset if the data was cropped
-            cropping = metadata["data"]["cropping"]
-            x1, x2, y1, y2 = metadata["data"]["cropping_parameters"]
-            if cropping:
+            if metadata.get("data", {}).get("cropping"):
+                x1, _, y1, _ = metadata["data"]["cropping_parameters"]
                 df.iloc[:, df.columns.get_level_values(level="coords") == "x"] += x1
                 df.iloc[:, df.columns.get_level_values(level="coords") == "y"] += y1
 

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -1088,10 +1088,16 @@ def create_video_with_all_detections(
             video_name = str(Path(video).stem)
             print("Creating labeled video for ", video_name)
             h5file = full_pickle.replace("_full.pickle", ".h5")
-            data, _ = auxfun_multianimal.LoadFullMultiAnimalData(h5file)
+            data, metadata = auxfun_multianimal.LoadFullMultiAnimalData(h5file)
             data = dict(
                 data
             )  # Cast to dict (making a copy) so items can safely be popped
+
+            x1, y1 = 0, 0
+            if cropping is not None:
+                x1, _, y1, _ = cropping
+            elif metadata.get("data", {}).get("cropping"):
+                x1, _, y1, _ = metadata["data"]["cropping_parameters"]
 
             header = data.pop("metadata")
             all_jointnames = header["all_joints_names"]
@@ -1115,11 +1121,6 @@ def create_video_with_all_detections(
             dotsize = cfg["dotsize"]
             clip = vp(fname=video, sname=outputname, codec="mp4v")
             ny, nx = clip.height(), clip.width()
-
-            x1 = 0
-            y1 = 0
-            if cropping is not None:
-                x1, _, y1, _ = cropping
 
             for n in trange(clip.nframes):
                 frame = clip.load_frame()


### PR DESCRIPTION
When running video analysis with cropping, the predicted poses are stored in the cropped image space. To get the coordinates of the pose in the space of the full video, the data stored in the `_metadata.pickle` can be used.

The `extract_outlier_frames` and `create_video_with_all_detections` did not take these offsets into account, meaning the video with all detections had its keypoints shifted, as did the machine labels.

This PR fixes both of these issues.

As `create_video_with_all_detections` has a `cropping`argument, the behavior is set such that:
1. If `cropping` is given as an argument, that value is used (overriding the value stored in the metadata)
2. If `cropping` is not given then metadata["data"]["cropping"] and metadata["data"]["cropping_parameters"] are used 