### PR TITLE
niels/check_for_duplicate_videos

### DIFF
--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -18,6 +18,7 @@ import warnings
 from functools import lru_cache
 from pathlib import Path
 from PIL import Image
+from typing import List
 
 import numpy as np
 import pandas as pd
@@ -464,7 +465,7 @@ def _robust_path_split(path):
     return parent, filename, ext
 
 
-def parse_video_filenames(videos: list[str]) -> list[str]:
+def parse_video_filenames(videos: List[str]) -> List[str]:
     """Parses the names of all videos listed in a project's ``config.yaml`` file
 
     Goes through the paths all videos listed for a project, and removes entries with a

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -464,6 +464,50 @@ def _robust_path_split(path):
     return parent, filename, ext
 
 
+def parse_video_filenames(videos: list[str]) -> list[str]:
+    """Parses the names of all videos listed in a project's ``config.yaml`` file
+
+    Goes through the paths all videos listed for a project, and removes entries with a
+    duplicate video name (e.g. if a video is listed twice, once with the path
+    ``/data/video-1.mov`` and once with the path ``/my-dlc-project/videos/video-1.mov``,
+    then ``video-1`` will only be returned once). The order of videos listed is
+    preserved.
+
+    This prevents the same labeled-data to be added multiple times when merging
+    annotated datasets.
+
+    Prints a warning for each filename with duplicate video paths.
+
+    Args:
+        videos: the videos listed in the project's config.yaml file
+
+    Returns:
+        the filenames of videos listed in the project's config.yaml file, with duplicate
+        entries removed
+    """
+    filenames = []
+    filename_to_videos = {}
+    for video in videos:
+        _, filename, _ = _robust_path_split(video)
+        videos_with_filename = filename_to_videos.get(filename, [])
+        if len(videos_with_filename) == 0:
+            filenames.append(filename)
+
+        videos_with_filename.append(video)
+        filename_to_videos[filename] = videos_with_filename
+
+    for filename, videos in filename_to_videos.items():
+        if len(videos) > 1:
+            video_str = "\n  * " + "\n  * ".join(videos)
+            logging.warning(
+                f"Found multiple videos with the same filename (``{filename}``). To "
+                f"avoid issues, please edit your project's `config.yaml` file to have "
+                f"each video added only once.\nDuplicate entries: {video_str}"
+            )
+
+    return filenames
+
+
 def merge_annotateddatasets(cfg, trainingsetfolder_full):
     """
     Merges all the h5 files for all labeled-datasets (from individual videos).
@@ -475,8 +519,8 @@ def merge_annotateddatasets(cfg, trainingsetfolder_full):
     AnnotationData = []
     data_path = Path(os.path.join(cfg["project_path"], "labeled-data"))
     videos = cfg["video_sets"].keys()
-    for video in videos:
-        _, filename, _ = _robust_path_split(video)
+    video_filenames = parse_video_filenames(videos)
+    for filename in video_filenames:
         file_path = os.path.join(
             data_path / filename, f'CollectedData_{cfg["scorer"]}.h5'
         )

--- a/tests/test_trainingsetmanipulation.py
+++ b/tests/test_trainingsetmanipulation.py
@@ -113,6 +113,7 @@ def test_format_multianimal_training_data(monkeypatch):
         (["/a/v1.mov", "/a/v2.mp4", "/b/v1.mov"], ["v1", "v2"]),
         (["v1.mov", "v2.mov", "v1.mov"], ["v1", "v2"]),
         (["/a/v1.mp4", "/a/v2.mov", "/b/v2.mov"], ["v1", "v2"]),
+        (["/a/v1.mp4", "/a/v2.mov", "/b/v2.mov", "/b/v3.mp4"], ["v1", "v2", "v3"]),
     ],
 )
 def test_parse_video_filenames(videos: list[str], expected_filenames: list[str]):

--- a/tests/test_trainingsetmanipulation.py
+++ b/tests/test_trainingsetmanipulation.py
@@ -11,6 +11,8 @@
 import numpy as np
 import os
 import pandas as pd
+import pytest
+
 from conftest import TEST_DATA_DIR
 from deeplabcut.generate_training_dataset import (
     read_image_shape_fast,
@@ -19,6 +21,7 @@ from deeplabcut.generate_training_dataset import (
     format_multianimal_training_data,
     trainingsetmanipulation,
     multiple_individuals_trainingsetmanipulation,
+    parse_video_filenames,
 )
 
 from deeplabcut.utils.auxfun_videos import imread
@@ -98,3 +101,20 @@ def test_format_multianimal_training_data(monkeypatch):
         for d in data
         for xy in d["joints"].values()
     )
+
+
+@pytest.mark.parametrize(
+    "videos, expected_filenames",
+    [
+        ([], []),
+        (["/data/my-video.mov"], ["my-video"]),
+        (["/data/my-video.mp4", "/data2/my-video.mov"], ["my-video"]),
+        (["/data/my-video.mov", "/data/video2.mov"], ["my-video", "video2"]),
+        (["/a/v1.mov", "/a/v2.mp4", "/b/v1.mov"], ["v1", "v2"]),
+        (["v1.mov", "v2.mov", "v1.mov"], ["v1", "v2"]),
+        (["/a/v1.mp4", "/a/v2.mov", "/b/v2.mov"], ["v1", "v2"]),
+    ],
+)
+def test_parse_video_filenames(videos: list[str], expected_filenames: list[str]):
+    filenames = parse_video_filenames(videos)
+    assert filenames == expected_filenames

--- a/tests/test_trainingsetmanipulation.py
+++ b/tests/test_trainingsetmanipulation.py
@@ -12,6 +12,7 @@ import numpy as np
 import os
 import pandas as pd
 import pytest
+from typing import List
 
 from conftest import TEST_DATA_DIR
 from deeplabcut.generate_training_dataset import (
@@ -116,6 +117,6 @@ def test_format_multianimal_training_data(monkeypatch):
         (["/a/v1.mp4", "/a/v2.mov", "/b/v2.mov", "/b/v3.mp4"], ["v1", "v2", "v3"]),
     ],
 )
-def test_parse_video_filenames(videos: list[str], expected_filenames: list[str]):
+def test_parse_video_filenames(videos: List[str], expected_filenames: List[str]):
     filenames = parse_video_filenames(videos)
     assert filenames == expected_filenames


### PR DESCRIPTION
Checks that the same videos are not listed multiple times in a project's `config.yaml` file.

If the same video was listed multiple times in the project's `config.yaml` file (e.g. under `/data/videos/openfield.mov` and `/dlc-project-2024-04-14/videos/openfield.mov`), then the labeled data for the video from `/dlc-project-2024-04-14/labeled-data/openfield`) would be added multiple times to the training-data dataframe.

If the same video name is present multiple times, a warning is printed and it is only kept once.