### PR TITLE
MacOS CI Fix - FFMpeg Installation

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -48,7 +48,7 @@ jobs:
             sudo apt-get update
             sudo apt-get install ffmpeg
           elif [ "$RUNNER_OS" == "macOS" ]; then
-            brew install ffmpeg
+            brew install ffmpeg || true
           else
             choco install ffmpeg
           fi


### PR DESCRIPTION
Fixes the installation of FFmpeg in the MacOS runner. The installation on was failing because the Homebrew installation did not complete successfully because of the following error:

```bash
==> Installing libass dependency: python@3.12
==> Downloading https://ghcr.io/v2/homebrew/core/python/3.12/manifests/3.12.3
Already downloaded: /Users/runner/Library/Caches/Homebrew/downloads/5065c4d76c933aad4e13bd77c1bf37f0afe78f4608261edd170e331cb36c8a0d--python@3.12-3.12.3.bottle_manifest.json
==> Pouring python@3.12--3.12.3.ventura.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3
Target /usr/local/bin/2to3
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3'

To force the link and overwrite all conflicting files:
  brew link --overwrite python@3.12

To list all files that would be deleted:
  brew link --overwrite python@3.12 --dry-run

Possible conflicting files are:
/usr/local/bin/2to3 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/2to3
/usr/local/bin/2to3-3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/2to3-3.12
/usr/local/bin/idle3 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/idle3
/usr/local/bin/idle3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/idle3.12
/usr/local/bin/pydoc3 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/pydoc3
/usr/local/bin/pydoc3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/pydoc3.12
/usr/local/bin/python3 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/python3
/usr/local/bin/python3-config -> /Library/Frameworks/Python.framework/Versions/3.12/bin/python3-config
/usr/local/bin/python3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12
/usr/local/bin/python3.12-config -> /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12-config
```

Basically, one of the dependencies for FFmpeg is `libass`, which requires `python@3.12`. But due to the existing installation of `python` on the runner, it fails to create one of the symlinks. I believe this error can be ignored, as described [here](https://github.com/actions/runner-images/issues/8500#issuecomment-1754435532). It also says that we could then run `brew link --overwrite python@3.12`, but this does not seem to be necessary to run the tests. I also would not want the default python version to be updated to 3.12 (instead of 3.9 or 3.10), so I think we can ignore that step.

So just updating the CI to ignore Homebrew's return code is enough to fix the issue. One issue with this fix is that in the future, if something else with homebrew fails, it might break something further down in the CI/CD pipeline. I still think this is the best way to go.