### PR TITLE
pin matplotlib version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
         "imgaug>=0.4.0",
         "imageio-ffmpeg",
         "numba>=0.54",
-        "matplotlib>=3.3,,<3.9,!=3.7.0,!=3.7.1",
+        "matplotlib>=3.3,<3.9,!=3.7.0,!=3.7.1",
         "networkx>=2.6",
         "numpy>=1.18.5",
         "pandas>=1.0.1,!=1.5.0",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
         "imgaug>=0.4.0",
         "imageio-ffmpeg",
         "numba>=0.54",
-        "matplotlib>=3.3,!=3.7.0,!=3.7.1",
+        "matplotlib>=3.3,,<3.9,!=3.7.0,!=3.7.1",
         "networkx>=2.6",
         "numpy>=1.18.5",
         "pandas>=1.0.1,!=1.5.0",


### PR DESCRIPTION
Addresses issue #2581. Replicated in Google Colab and locally. We use this method in [many functions](https://github.com/DeepLabCut/DeepLabCut/blob/fbaf36aee285564f18f78384bb94cc20c116297c/deeplabcut/utils/visualization.py#L33)

With `matplotlib==3.8.4`:

```
>>> import matplotlib as mpl
>>> print(mpl.__version__)
3.8.4
>>> import matplotlib.pyplot as plt
>>> plt.cm.get_cmap
<function _get_cmap at 0x11e9f4430>
```

With `matplotlib==3.9.0`:

```
>>> import matplotlib as mpl
>>> print(mpl.__version__)
3.9.0
>>> import matplotlib.pyplot as plt
>>> plt.cm.get_cmap
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'matplotlib.cm' has no attribute 'get_cmap'
```