### PR TITLE
Niels/pcutoff arg

### DIFF
--- a/deeplabcut/gui/tabs/create_videos.py
+++ b/deeplabcut/gui/tabs/create_videos.py
@@ -146,6 +146,24 @@ class CreateVideos(DefaultTab):
         )
         tmp_layout.addWidget(self.use_filtered_data_checkbox)
 
+        # Selector for p-cutoff
+        pcutoff_widget = QtWidgets.QWidget()
+        pcutoff_layout = _create_horizontal_layout(margins=(0, 0, 0, 0))
+        pcutoff_label = QtWidgets.QLabel("Plotting confidence cutoff (pcutoff)")
+        self.pcutoff_selector = QtWidgets.QDoubleSpinBox()
+        self.pcutoff_selector.setMinimum(0.0)
+        self.pcutoff_selector.setMaximum(1.0)
+        self.pcutoff_selector.setValue(0.6)
+        self.pcutoff_selector.setSingleStep(0.05)
+        pcutoff_layout.addWidget(pcutoff_label)
+        pcutoff_layout.addWidget(self.pcutoff_selector)
+        pcutoff_widget.setLayout(pcutoff_layout)
+        pcutoff_widget.setToolTip(
+            "This value sets the confidence threshold, above which predictions are "
+            "shown in the labeled videos."
+        )
+        tmp_layout.addWidget(pcutoff_widget)
+
         # Plot trajectories
         self.plot_trajectories = QtWidgets.QCheckBox("Plot trajectories")
         self.plot_trajectories.setCheckState(Qt.Unchecked)
@@ -259,20 +277,12 @@ class CreateVideos(DefaultTab):
             shuffle=shuffle,
             filtered=filtered,
             save_frames=self.create_high_quality_video.isChecked(),
+            pcutoff=self.pcutoff_selector.value(),
             displayedbodyparts=bodyparts,
             draw_skeleton=self.draw_skeleton_checkbox.isChecked(),
             trailpoints=trailpoints,
             color_by=color_by,
         )
-        if all(videos_created):
-            self.root.writer.write("Labeled videos created.")
-        else:
-            failed_videos = [
-                video for success, video in zip(videos_created, videos) if not success
-            ]
-            failed_videos_str = ", ".join(failed_videos)
-            self.root.writer.write(f"Failed to create videos from {failed_videos_str}.")
-
         if all(videos_created):
             self.root.writer.write("Labeled videos created.")
         else:
@@ -289,6 +299,7 @@ class CreateVideos(DefaultTab):
                 shuffle=shuffle,
                 filtered=filtered,
                 displayedbodyparts=bodyparts,
+                pcutoff=self.pcutoff_selector.value(),
             )
 
     def build_skeleton(self, *args):

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -20,6 +20,7 @@ Licensed under GNU Lesser General Public License v3.0
 Hao Wu, hwu01@g.harvard.edu contributed the original OpenCV class. Thanks!
 You can find the directory for your ffmpeg bindings by: "find / | grep ffmpeg" and then setting it.
 """
+from __future__ import annotations
 
 import argparse
 import os
@@ -382,7 +383,7 @@ def create_labeled_video(
     init_weights="",
     track_method="",
     superanimal_name="",
-    pcutoff=0.6,
+    pcutoff=None,
     skeleton=[],
     skeleton_color="white",
     dotsize=8,
@@ -501,6 +502,9 @@ def create_labeled_video(
         For multiple animals, must be either 'box', 'skeleton', or 'ellipse' and will
         be taken from the config.yaml file if none is given.
 
+    pcutoff: string, optional, default=None
+        Overrides the pcutoff set in the project configuration to plot the trajectories.
+
     overwrite: bool, optional, default=False
         If ``True`` overwrites existing labeled videos.
 
@@ -560,6 +564,8 @@ def create_labeled_video(
         )
     """
     if config == "":
+        if pcutoff is None:
+            pcutoff = 0.6
         pass
     else:
         cfg = auxiliaryfunctions.read_config(config)
@@ -567,6 +573,8 @@ def create_labeled_video(
         track_method = auxfun_multianimal.get_track_method(
             cfg, track_method=track_method
         )
+        if pcutoff is None:
+            pcutoff = cfg["pcutoff"]
 
     if init_weights == "":
         DLCscorer, DLCscorerlegacy = auxiliaryfunctions.get_scorer_name(
@@ -659,6 +667,7 @@ def create_labeled_video(
         keypoints_only,
         overwrite,
         init_weights=init_weights,
+        pcutoff=pcutoff,
         confidence_to_alpha=confidence_to_alpha,
     )
 
@@ -699,6 +708,7 @@ def proc_video(
     overwrite,
     video,
     init_weights="",
+    pcutoff: float | None = None,
     confidence_to_alpha: Optional[Callable[[float], float]] = None,
 ):
     """Helper function for create_videos
@@ -715,6 +725,9 @@ def proc_video(
     videofolder = Path(video).parents[0]
     if destfolder is None:
         destfolder = videofolder  # where your folder with videos is.
+
+    if pcutoff is None:
+        pcutoff = cfg["pcutoff"]
 
     auxiliaryfunctions.attempt_to_make_folder(destfolder)
 
@@ -751,7 +764,10 @@ def proc_video(
                 s = "_id" if color_by == "individual" else "_bp"
             else:
                 s = ""
-            videooutname = filepath.replace(".h5", f"{s}_labeled.mp4")
+
+            videooutname = filepath.replace(
+                ".h5", f"{s}_p{int(100 * pcutoff)}_labeled.mp4"
+            )
             if os.path.isfile(videooutname) and not overwrite:
                 print("Labeled video already created. Skipping...")
                 return
@@ -779,7 +795,7 @@ def proc_video(
                     df,
                     videooutname,
                     inds,
-                    cfg["pcutoff"],
+                    pcutoff,
                     cfg["dotsize"],
                     cfg["alphavalue"],
                     skeleton_color=skeleton_color,
@@ -801,7 +817,7 @@ def proc_video(
                     cfg["dotsize"],
                     cfg["colormap"],
                     cfg["alphavalue"],
-                    cfg["pcutoff"],
+                    pcutoff,
                     trailpoints,
                     cropping,
                     x1,
@@ -828,7 +844,7 @@ def proc_video(
                     bbox=(x1, x2, y1, y2),
                     codec=codec,
                     output_path=videooutname,
-                    pcutoff=cfg["pcutoff"],
+                    pcutoff=pcutoff,
                     dotsize=cfg["dotsize"],
                     cmap=cfg["colormap"],
                     color_by=color_by,

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -566,7 +566,6 @@ def create_labeled_video(
     if config == "":
         if pcutoff is None:
             pcutoff = 0.6
-        pass
     else:
         cfg = auxiliaryfunctions.read_config(config)
         trainFraction = cfg["TrainingFraction"][trainingsetindex]

--- a/deeplabcut/utils/plotting.py
+++ b/deeplabcut/utils/plotting.py
@@ -17,6 +17,7 @@ Please see AUTHORS for contributors.
 https://github.com/DeepLabCut/DeepLabCut/blob/master/AUTHORS
 Licensed under GNU Lesser General Public License v3.0
 """
+from __future__ import annotations
 
 import argparse
 import os
@@ -187,6 +188,7 @@ def plot_trajectories(
     resolution=100,
     linewidth=1.0,
     track_method="",
+    pcutoff: float | None = None,
 ):
     """Plots the trajectories of various bodyparts across the video.
 
@@ -251,6 +253,9 @@ def plot_trajectories(
          For multiple animals, must be either 'box', 'skeleton', or 'ellipse' and will
          be taken from the config.yaml file if none is given.
 
+    pcutoff: string, optional, default=None
+        Overrides the pcutoff set in the project configuration to plot the trajectories.
+
     Returns
     -------
     None
@@ -266,6 +271,10 @@ def plot_trajectories(
         )
     """
     cfg = auxiliaryfunctions.read_config(config)
+
+    if pcutoff is None:
+        pcutoff = cfg["pcutoff"]
+
     track_method = auxfun_multianimal.get_track_method(cfg, track_method=track_method)
 
     trainFraction = cfg["TrainingFraction"][trainingsetindex]
@@ -308,7 +317,7 @@ def plot_trajectories(
                 linewidth,
                 cfg["colormap"],
                 cfg["alphavalue"],
-                cfg["pcutoff"],
+                pcutoff,
                 suffix,
                 imagetype,
                 tmpfolder,


### PR DESCRIPTION
# DeepLabCut GUI - Add a `pcutoff` selector when creating labeled videos

## Changes

- adds a `pcutoff` parameter to the GUI when creating labeled videos
- fix the `create_labeled_videos` code to always use the `pcutoff` given as an argument (overriding the value set in the project configuration), with the default value being None (== use the `pcutoff` in the project config)
- add the `pcutoff` used for a video to its filename: `{video}_DLC{scorer}_p{pcutoff used}_labeled.mp4`

## Demo

https://github.com/DeepLabCut/DeepLabCut/assets/45132115/21314de4-92ba-4133-8565-6d6ab77bdeae

