### PR TITLE
fixed file dialog not showing uppercase file extension video files

### DIFF
--- a/deeplabcut/gui/components.py
+++ b/deeplabcut/gui/components.py
@@ -158,8 +158,8 @@ class VideoSelectionWidget(QtWidgets.QWidget):
 
         # Create a filter string with both lowercase and uppercase extensions
 
-        video_types = [f"*.{ext.lower()}" for ext in DLCParams.VIDEOTYPES] + [
-            f"*.{ext.upper()}" for ext in DLCParams.VIDEOTYPES
+        video_types = [f"*.{ext.lower()}" for ext in DLCParams.VIDEOTYPES[1:]] + [
+            f"*.{ext.upper()}" for ext in DLCParams.VIDEOTYPES[1:]
         ]
         video_files = f"Videos ({' '.join(video_types)})"
 

--- a/deeplabcut/gui/components.py
+++ b/deeplabcut/gui/components.py
@@ -201,12 +201,6 @@ class ShuffleSpinBox(QtWidgets.QSpinBox):
         self.setMaximum(10_000)
         self.setValue(self.root.shuffle_value)
         self.valueChanged.connect(self.root.update_shuffle)
-        self.root.shuffle_change.connect(self.update_shuffle)
-
-    @Slot(int)
-    def update_shuffle(self, new_shuffle: int):
-        if new_shuffle != self.value():
-            self.setValue(new_shuffle)
 
 
 class DefaultTab(QtWidgets.QWidget):


### PR DESCRIPTION
- I added a fix to component.py in the gui to fix the file dialog not showing videos with uppercase file extension. E.g. .MP4 files, when selecting .mp4 in the GUI.
- I updated the DOCSTRING.
- Included screenshot of the GUI after the fix:
![deeplabcutfix](https://github.com/DeepLabCut/DeepLabCut/assets/58895710/2984efa3-c348-483f-aa58-2d564caa208a)

Tested on Linux.
