### PR TITLE
Update train.py: avoids error on 'unique_bodyparts'

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/runners/train.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/train.py
@@ -418,10 +418,15 @@ class PoseTrainingRunner(TrainingRunner[PoseModel]):
             for batch_id in range(len(ground_truth)):
                 # keypoints (num_kpts, 3)
                 keypoints = ground_truth[batch_id]
-                for kpts in keypoints:
-                    vis = kpts[-1]
+                if name == 'unique_bodyparts':
+                    vis = keypoints[-1]
                     if vis < 0:
-                        kpts[-1] = 0
+                        keypoints[-1] = 0
+                else:
+                    for kpts in keypoints:
+                        vis = kpts[-1]
+                        if vis < 0:
+                            kpts[-1] = 0
 
             # rescale to the full image for TD or CTD
             gt_with_vis[..., :2] = (gt_with_vis[..., :2] * scale) + offset


### PR DESCRIPTION
- See Issue #2667.

This is a possible solution that works smoothly in my environment. However, I have not figured out why it is necessary to reset `keypoints[i][3]` to non-negative values so I left the process alone.