### PR TITLE
New detector options and better detector integration

### DIFF
--- a/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
@@ -107,6 +107,7 @@ def create_multianimaltraining_dataset(
     Shuffles=None,
     windows2linux=False,
     net_type=None,
+    detector_type=None,
     numdigits=2,
     crop_size=(400, 400),
     crop_sampling="hybrid",
@@ -155,8 +156,8 @@ def create_multianimaltraining_dataset(
                 * ``efficientnet-b4``
                 * ``efficientnet-b5``
                 * ``efficientnet-b6``
-            PyTorch (call ``deeplabcut.pose_estimation.available_models()`` for a
-            complete list)
+            PyTorch (call ``deeplabcut.pose_estimation_pytorch.available_models()`` for
+            a complete list)
                 * ``resnet_50``
                 * ``resnet_101``
                 * ``dekr_w18``
@@ -168,6 +169,16 @@ def create_multianimaltraining_dataset(
                 * ``top_down_hrnet_w32``
                 * ``top_down_hrnet_w48``
                 * ``animaltokenpose_base``
+
+    detector_type: string, optional, default=None
+        Only for the PyTorch engine.
+        When passing creating shuffles for top-down models, you can specify which
+        detector you want. If the detector_type is None, the ```ssdlite``` will be used.
+        The list of all available detectors can be obtained by calling
+        ``deeplabcut.pose_estimation_pytorch.available_models()``. Supported options:
+            * ``ssdlite``
+            * ``fasterrcnn_mobilenet_v3_large_fpn``
+            * ``fasterrcnn_resnet50_fpn_v2``
 
     numdigits: int, optional
 
@@ -583,6 +594,7 @@ def create_multianimaltraining_dataset(
                         pose_config_path=path_train_config,
                         net_type=net_type,
                         top_down=top_down,
+                        detector_type=detector_type,
                         weight_init=weight_init,
                     )
 

--- a/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
@@ -175,7 +175,7 @@ def create_multianimaltraining_dataset(
         When passing creating shuffles for top-down models, you can specify which
         detector you want. If the detector_type is None, the ```ssdlite``` will be used.
         The list of all available detectors can be obtained by calling
-        ``deeplabcut.pose_estimation_pytorch.available_models()``. Supported options:
+        ``deeplabcut.pose_estimation_pytorch.available_detectors()``. Supported options:
             * ``ssdlite``
             * ``fasterrcnn_mobilenet_v3_large_fpn``
             * ``fasterrcnn_resnet50_fpn_v2``

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -777,6 +777,7 @@ def create_training_dataset(
     trainIndices=None,
     testIndices=None,
     net_type=None,
+    detector_type=None,
     augmenter_type=None,
     posecfg_template=None,
     superanimal_name="",
@@ -830,8 +831,8 @@ def create_training_dataset(
                 * ``efficientnet-b4``
                 * ``efficientnet-b5``
                 * ``efficientnet-b6``
-            PyTorch (call ``deeplabcut.pose_estimation.available_models()`` for a
-            complete list)
+            PyTorch (call ``deeplabcut.pose_estimation_pytorch.available_models()`` for
+            a complete list)
                 * ``resnet_50``
                 * ``resnet_101``
                 * ``hrnet_w18``
@@ -846,6 +847,16 @@ def create_training_dataset(
                 * ``top_down_hrnet_w32``
                 * ``top_down_hrnet_w48``
                 * ``animaltokenpose_base``
+
+    detector_type: string, optional, default=None
+        Only for the PyTorch engine.
+        When passing creating shuffles for top-down models, you can specify which
+        detector you want. If the detector_type is None, the ```ssdlite``` will be used.
+        The list of all available detectors can be obtained by calling
+        ``deeplabcut.pose_estimation_pytorch.available_models()``. Supported options:
+            * ``ssdlite``
+            * ``fasterrcnn_mobilenet_v3_large_fpn``
+            * ``fasterrcnn_resnet50_fpn_v2``
 
     augmenter_type: string, optional, default=None
         Type of augmenter. The options available depend on which engine is used.
@@ -1272,6 +1283,7 @@ def create_training_dataset(
                             pose_config_path=path_train_config,
                             net_type=net_type,
                             top_down=top_down,
+                            detector_type=detector_type,
                             weight_init=weight_init,
                         )
 
@@ -1561,6 +1573,7 @@ def create_training_dataset_from_existing_split(
     shuffles: list[int] | None = None,
     userfeedback: bool = True,
     net_type: str | None = None,
+    detector_type: str | None = None,
     augmenter_type: str | None = None,
     posecfg_template: dict | None = None,
     superanimal_name: str = "",
@@ -1608,6 +1621,16 @@ def create_training_dataset_from_existing_split(
                 * ``efficientnet-b6``
             Currently supported  options for engine=Engine.TF can be obtained by calling
             ``deeplabcut.pose_estimation_pytorch.available_models()``.
+
+        detector_type: string, optional, default=None
+            Only for the PyTorch engine.
+            When passing creating shuffles for top-down models, you can specify which
+            detector you want. If the detector_type is None, the ```ssdlite``` will be
+            used. The list of all available detectors can be obtained by calling
+            ``deeplabcut.pose_estimation_pytorch.available_models()``. Supported options:
+                * ``ssdlite``
+                * ``fasterrcnn_mobilenet_v3_large_fpn``
+                * ``fasterrcnn_resnet50_fpn_v2``
 
         augmenter_type: Type of augmenter. Currently supported augmenters for
             engine=Engine.TF are
@@ -1680,6 +1703,7 @@ def create_training_dataset_from_existing_split(
         trainIndices=[train_idx for _ in range(num_copies)],
         testIndices=[test_idx for _ in range(num_copies)],
         net_type=net_type,
+        detector_type=detector_type,
         augmenter_type=augmenter_type,
         posecfg_template=posecfg_template,
         superanimal_name=superanimal_name,

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -853,7 +853,7 @@ def create_training_dataset(
         When passing creating shuffles for top-down models, you can specify which
         detector you want. If the detector_type is None, the ```ssdlite``` will be used.
         The list of all available detectors can be obtained by calling
-        ``deeplabcut.pose_estimation_pytorch.available_models()``. Supported options:
+        ``deeplabcut.pose_estimation_pytorch.available_detectors()``. Supported options:
             * ``ssdlite``
             * ``fasterrcnn_mobilenet_v3_large_fpn``
             * ``fasterrcnn_resnet50_fpn_v2``
@@ -1627,7 +1627,8 @@ def create_training_dataset_from_existing_split(
             When passing creating shuffles for top-down models, you can specify which
             detector you want. If the detector_type is None, the ```ssdlite``` will be
             used. The list of all available detectors can be obtained by calling
-            ``deeplabcut.pose_estimation_pytorch.available_models()``. Supported options:
+            ``deeplabcut.pose_estimation_pytorch.available_detectors()``. Supported
+            options:
                 * ``ssdlite``
                 * ``fasterrcnn_mobilenet_v3_large_fpn``
                 * ``fasterrcnn_resnet50_fpn_v2``

--- a/deeplabcut/pose_estimation_pytorch/__init__.py
+++ b/deeplabcut/pose_estimation_pytorch/__init__.py
@@ -14,7 +14,10 @@ from deeplabcut.pose_estimation_pytorch.apis import (
     evaluate_network,
     train_network,
 )
-from deeplabcut.pose_estimation_pytorch.config import available_models
+from deeplabcut.pose_estimation_pytorch.config import (
+    available_detectors,
+    available_models,
+)
 from deeplabcut.pose_estimation_pytorch.data.base import Loader
 from deeplabcut.pose_estimation_pytorch.data.cocoloader import COCOLoader
 from deeplabcut.pose_estimation_pytorch.data.dataset import (

--- a/deeplabcut/pose_estimation_pytorch/config/__init__.py
+++ b/deeplabcut/pose_estimation_pytorch/config/__init__.py
@@ -12,6 +12,7 @@ from deeplabcut.pose_estimation_pytorch.config.make_pose_config import (
     make_pytorch_pose_config,
 )
 from deeplabcut.pose_estimation_pytorch.config.utils import (
+    available_detectors,
     available_models,
     pretty_print,
     read_config_as_dict,

--- a/deeplabcut/pose_estimation_pytorch/config/detectors/fasterrcnn_mobilenet_v3_large_fpn.yaml
+++ b/deeplabcut/pose_estimation_pytorch/config/detectors/fasterrcnn_mobilenet_v3_large_fpn.yaml
@@ -1,0 +1,48 @@
+data:
+  colormode: RGB
+  inference:
+    normalize_images: true
+  train:
+    affine:
+      p: 0.5
+      rotation: 30
+      scaling: [ 1.0, 1.0 ]
+      translation: 40
+    collate:
+      type: ResizeFromDataSizeCollate
+      min_scale: 0.4
+      max_scale: 1.0
+      min_short_side: 128
+      max_short_side: 1152
+      multiple_of: 32
+      to_square: false
+    hflip: true
+    normalize_images: true
+device: auto
+model:
+  type: FasterRCNN
+  freeze_bn_stats: true
+  freeze_bn_weights: false
+  variant: fasterrcnn_mobilenet_v3_large_fpn
+runner:
+  type: DetectorTrainingRunner
+  eval_interval: 1
+  optimizer:
+    type: AdamW
+    params:
+      lr: 1e-4
+  scheduler:
+    type: LRListScheduler
+    params:
+      milestones: [ 160 ]
+      lr_list: [ [ 1e-5 ] ]
+  snapshots:
+    max_snapshots: 5
+    save_epochs: 25
+    save_optimizer_state: false
+train_settings:
+  batch_size: 1
+  dataloader_workers: 0
+  dataloader_pin_memory: true
+  display_iters: 500
+  epochs: 250

--- a/deeplabcut/pose_estimation_pytorch/config/detectors/fasterrcnn_resnet50_fpn_v2.yaml
+++ b/deeplabcut/pose_estimation_pytorch/config/detectors/fasterrcnn_resnet50_fpn_v2.yaml
@@ -1,0 +1,48 @@
+data:
+  colormode: RGB
+  inference:
+    normalize_images: true
+  train:
+    affine:
+      p: 0.5
+      rotation: 30
+      scaling: [ 1.0, 1.0 ]
+      translation: 40
+    collate:
+      type: ResizeFromDataSizeCollate
+      min_scale: 0.4
+      max_scale: 1.0
+      min_short_side: 128
+      max_short_side: 1152
+      multiple_of: 32
+      to_square: false
+    hflip: true
+    normalize_images: true
+device: auto
+model:
+  type: FasterRCNN
+  freeze_bn_stats: true
+  freeze_bn_weights: false
+  variant: fasterrcnn_resnet50_fpn_v2
+runner:
+  type: DetectorTrainingRunner
+  eval_interval: 1
+  optimizer:
+    type: AdamW
+    params:
+      lr: 1e-4
+  scheduler:
+    type: LRListScheduler
+    params:
+      milestones: [ 160 ]
+      lr_list: [ [ 1e-5 ] ]
+  snapshots:
+    max_snapshots: 5
+    save_epochs: 25
+    save_optimizer_state: false
+train_settings:
+  batch_size: 1
+  dataloader_workers: 0
+  dataloader_pin_memory: true
+  display_iters: 500
+  epochs: 250

--- a/deeplabcut/pose_estimation_pytorch/config/detectors/ssdlite.yaml
+++ b/deeplabcut/pose_estimation_pytorch/config/detectors/ssdlite.yaml
@@ -1,0 +1,47 @@
+data:
+  colormode: RGB
+  inference:
+    normalize_images: true
+  train:
+    affine:
+      p: 0.5
+      rotation: 30
+      scaling: [ 1.0, 1.0 ]
+      translation: 40
+    collate:
+      type: ResizeFromDataSizeCollate
+      min_scale: 0.4
+      max_scale: 1.0
+      min_short_side: 128
+      max_short_side: 1152
+      multiple_of: 32
+      to_square: false
+    hflip: true
+    normalize_images: true
+device: auto
+model:
+  type: SSDLite
+  freeze_bn_stats: true
+  freeze_bn_weights: false
+runner:
+  type: DetectorTrainingRunner
+  eval_interval: 1
+  optimizer:
+    type: AdamW
+    params:
+      lr: 1e-4
+  scheduler:
+    type: LRListScheduler
+    params:
+      milestones: [ 160 ]
+      lr_list: [ [ 1e-5 ] ]
+  snapshots:
+    max_snapshots: 5
+    save_epochs: 25
+    save_optimizer_state: false
+train_settings:
+  batch_size: 16
+  dataloader_workers: 0
+  dataloader_pin_memory: true
+  display_iters: 500
+  epochs: 250

--- a/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
+++ b/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
@@ -31,6 +31,7 @@ def make_pytorch_pose_config(
     pose_config_path: str,
     net_type: str | None = None,
     top_down: bool = False,
+    detector_type: str | None = None,
     weight_init: WeightInitialization | None = None,
 ) -> dict:
     """Creates a PyTorch pose configuration file for a DeepLabCut project
@@ -59,6 +60,8 @@ def make_pytorch_pose_config(
             by associating a detector to the pose model. Required for multi-animal
             projects when net_type is a backbone (as a backbone + heatmap head can only
             predict pose for single individuals).
+        detector_type: for top-down pose models, the architecture of the desired object
+            detection model
         weight_init: Specify how model weights should be initialized. If None, ImageNet
             pretrained weights from Timm will be loaded when training.
 
@@ -114,22 +117,17 @@ def make_pytorch_pose_config(
 
     is_top_down = model_cfg.get("method", "BU").upper() == "TD"
     if is_top_down:
-        # FIXME(niels): Currently, the variant used is the default MobileNet. In the
-        #  future, we want users to be able to choose which detector variant they use
-        #  when creating the configuration file, instead of having to update it once
-        #  created
-        variant = None
         if weight_init is not None:
             # FIXME(niels): We only have fasterrcnn_resnet50_fpn_v2 SuperAnimal weights.
             #  This should be updated once more SuperAnimal detectors are uploaded,
             #  so that users can choose which pre-trained detector they use.
-            variant = "fasterrcnn_resnet50_fpn_v2"
+            detector_type = "fasterrcnn_resnet50_fpn_v2"
 
         model_cfg = add_detector(
             configs_dir,
             model_cfg,
             len(individuals),
-            variant=variant,
+            detector_type=detector_type,
         )
 
     # add the default augmentations to the config
@@ -311,7 +309,7 @@ def add_detector(
     configs_dir: Path,
     config: dict,
     num_individuals: int,
-    variant: str | None = None
+    detector_type: str | None = None,
 ) -> dict:
     """Adds a detector to a model
 
@@ -319,22 +317,24 @@ def add_detector(
         configs_dir: path to the DeepLabCut "configs" directory
         config: model configuration to update
         num_individuals: the maximum number of individuals the model should detect
-        variant: the detector variant to use (if None, uses the variant set in the
-            default detector.yaml config)
+        detector_type: the type of detector to use (if None, uses ``ssdlite``)
 
     Returns:
         the model configuration with an added detector config
     """
+    if detector_type is None:
+        detector_type = "ssdlite"  # default detector
+
+    detector_type = detector_type.lower()
     config = copy.deepcopy(config)
-    detector_config = read_config_as_dict(configs_dir / "base" / "detector.yaml")
+    detector_config = read_config_as_dict(
+        configs_dir / "detectors" / f"{detector_type}.yaml"
+    )
     detector_config = replace_default_values(
         detector_config,
         num_individuals=num_individuals,
     )
-    if variant is not None:
-        detector_config["detector"]["model"]["variant"] = variant
-
-    config = update_config(config, detector_config)
+    config["detector"] = detector_config
     return config
 
 

--- a/deeplabcut/pose_estimation_pytorch/config/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/config/utils.py
@@ -175,6 +175,20 @@ def load_backbones(configs_dir: Path) -> list[str]:
     return backbones
 
 
+def load_detectors(configs_dir: Path) -> list[str]:
+    """
+    Args:
+        configs_dir: the Path to the folder containing the "configs" for PyTorch
+            DeepLabCut
+
+    Returns:
+        all detectors that are available
+    """
+    detector_dir = configs_dir / "detectors"
+    detectors = [p.stem for p in detector_dir.iterdir() if p.suffix == ".yaml"]
+    return detectors
+
+
 def read_config_as_dict(config_path: str | Path) -> dict:
     """
     Args:
@@ -252,3 +266,8 @@ def available_models() -> list[str]:
             models.add(variant)
 
     return list(sorted(models))
+
+
+def available_detectors() -> list[str]:
+    """Returns: all the possible detectors that can be used"""
+    return load_detectors(get_config_folder_path())

--- a/deeplabcut/pose_estimation_pytorch/models/detectors/__init__.py
+++ b/deeplabcut/pose_estimation_pytorch/models/detectors/__init__.py
@@ -13,3 +13,4 @@ from deeplabcut.pose_estimation_pytorch.models.detectors.base import (
     BaseDetector,
 )
 from deeplabcut.pose_estimation_pytorch.models.detectors.fasterRCNN import FasterRCNN
+from deeplabcut.pose_estimation_pytorch.models.detectors.ssd import SSDLite

--- a/deeplabcut/pose_estimation_pytorch/models/detectors/fasterRCNN.py
+++ b/deeplabcut/pose_estimation_pytorch/models/detectors/fasterRCNN.py
@@ -10,17 +10,16 @@
 #
 from __future__ import annotations
 
-import torch
 import torchvision.models.detection as detection
 
-from deeplabcut.pose_estimation_pytorch.models.detectors.base import (
-    DETECTORS,
-    BaseDetector,
+from deeplabcut.pose_estimation_pytorch.models.detectors.base import DETECTORS
+from deeplabcut.pose_estimation_pytorch.models.detectors.torchvision import (
+    TorchvisionDetectorAdaptor,
 )
 
 
 @DETECTORS.register_module
-class FasterRCNN(BaseDetector):
+class FasterRCNN(TorchvisionDetectorAdaptor):
     """A FasterRCNN detector
 
     Faster R-CNN: Towards Real-Time Object Detection with Region Proposal Networks
@@ -30,19 +29,11 @@ class FasterRCNN(BaseDetector):
 
     This class is a wrapper of the torchvision implementation of a FasterRCNN (source:
     https://github.com/pytorch/vision/blob/main/torchvision/models/detection/faster_rcnn.py).
-    Any variant implemented in torchvision can be used through this wrapper (see
-    available models at https://pytorch.org/vision/stable/models.html#object-detection).
 
-    Some of the variants (from fastest to most powerful) available:
+    Some of the available FasterRCNN variants (from fastest to most powerful):
       - fasterrcnn_mobilenet_v3_large_fpn
       - fasterrcnn_resnet50_fpn
       - fasterrcnn_resnet50_fpn_v2
-
-    The torchvision implementation does not allow to get both predictions and losses
-    with a single forward pass. Therefore, during evaluation only bounding box metrics
-    (mAP, mAR) are available for the test set. See validation loss issue:
-    - https://discuss.pytorch.org/t/compute-validation-loss-for-faster-rcnn/62333/12
-    - https://stackoverflow.com/a/65347721
 
     Args:
         variant: The FasterRCNN variant to use (see all options at
@@ -57,7 +48,7 @@ class FasterRCNN(BaseDetector):
         freeze_bn_stats: bool = False,
         freeze_bn_weights: bool = False,
         variant: str = "fasterrcnn_mobilenet_v3_large_fpn",
-        pretrained: bool = True,
+        pretrained: bool = False,
         box_score_thresh: float = 0.01,
     ) -> None:
         if not variant.lower().startswith("fasterrcnn"):
@@ -67,17 +58,13 @@ class FasterRCNN(BaseDetector):
             )
 
         super().__init__(
+            model=variant,
+            weights=("COCO_V1" if pretrained else None),
+            num_classes=None,
             freeze_bn_stats=freeze_bn_stats,
             freeze_bn_weights=freeze_bn_weights,
-            pretrained=pretrained,
+            box_score_thresh=box_score_thresh,
         )
-        model_fn = getattr(detection, variant)
-        weights = None
-        if self._pretrained:
-            weights = "COCO_V1"
-
-        # Load the model
-        self.model = model_fn(weights=weights, box_score_thresh=box_score_thresh)
 
         # Modify the base predictor to output the correct number of classes
         num_classes = 2
@@ -85,84 +72,3 @@ class FasterRCNN(BaseDetector):
         self.model.roi_heads.box_predictor = detection.faster_rcnn.FastRCNNPredictor(
             in_features, num_classes
         )
-
-        # See source:  https://stackoverflow.com/a/65347721
-        self.model.eager_outputs = lambda losses, detections: (losses, detections)
-
-    def forward(
-        self, x: torch.Tensor, targets: list[dict[str, torch.Tensor]] | None = None
-    ) -> tuple[dict[str, torch.Tensor], list[dict[str, torch.Tensor]]]:
-        """
-        Forward pass of the Faster R-CNN
-
-        Args:
-            x: images to be processed, of shape (b, c, h, w)
-            targets: ground-truth boxes present in the images
-
-        Returns:
-            losses: {'loss_name': loss_value}
-            detections: for each of the b images, {"boxes": bounding_boxes}
-        """
-        return self.model(x, targets)
-
-    def get_target(self, labels: dict) -> list[dict[str, torch.Tensor]]:
-        """
-        Returns target in a format FasterRCNN can handle
-
-        Args:
-            labels: dict of annotations, must contain the keys:
-                area: tensor containing area information for each annotation
-                labels: tensor containing class labels for each annotation
-                is_crowd: tensor indicating if each annotation is a crowd (1) or not (0)
-                image_id: tensor containing image ids for each annotation
-                boxes: tensor containing bounding box information for each annotation
-
-        Returns:
-            res: list of dictionaries, each representing target information for a single annotation.
-                 Each dictionary contains the following keys:
-                 'area'
-                 'labels'
-                 'is_crowd'
-                 'boxes'
-
-        Examples:
-            input:
-                annotations = {"area": torch.Tensor([100, 200]),
-                    "labels": torch.Tensor([1, 2]),
-                    "is_crowd": torch.Tensor([0, 1]),
-                    "boxes": torch.Tensor([[10, 20, 30, 40], [50, 60, 70, 80]])}
-            output:
-                res =  [
-                    {
-                        'area': tensor([100.]),
-                        'labels': tensor([1]),
-                        'image_id': tensor([1]),
-                        'is_crowd': tensor([0]),
-                        'boxes': tensor([[10., 20., 40., 60.]])
-                    },
-                    {
-                        'area': tensor([200.]),
-                        'labels': tensor([2]),
-                        'image_id': tensor([1]),
-                        'is_crowd': tensor([1]),
-                        'boxes': tensor([[50., 60., 70., 80.]])
-                    }
-                ]
-        """
-        res = []
-        for i, box_ann in enumerate(labels["boxes"]):
-            mask = (box_ann[:, 2] > 0.0) & (box_ann[:, 3] > 0.0)
-            box_ann = box_ann[mask]
-            # bbox format conversion (x, y, w, h) -> (x1, y1, x2, y2)
-            box_ann[:, 2] += box_ann[:, 0]
-            box_ann[:, 3] += box_ann[:, 1]
-            res.append(
-                {
-                    "area": labels["area"][i][mask],
-                    "labels": labels["labels"][i][mask],
-                    "is_crowd": labels["is_crowd"][i][mask],
-                    "boxes": box_ann,
-                }
-            )
-
-        return res

--- a/deeplabcut/pose_estimation_pytorch/models/detectors/ssd.py
+++ b/deeplabcut/pose_estimation_pytorch/models/detectors/ssd.py
@@ -1,0 +1,70 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+from __future__ import annotations
+
+import torchvision.models.detection as detection
+
+from deeplabcut.pose_estimation_pytorch.models.detectors.base import DETECTORS
+from deeplabcut.pose_estimation_pytorch.models.detectors.torchvision import (
+    TorchvisionDetectorAdaptor,
+)
+
+
+@DETECTORS.register_module
+class SSDLite(TorchvisionDetectorAdaptor):
+    """An SSD object detection model"""
+
+    def __init__(
+        self,
+        freeze_bn_stats: bool = False,
+        freeze_bn_weights: bool = False,
+        pretrained: bool = False,
+        pretrained_from_imagenet: bool = False,
+        box_score_thresh: float = 0.01,
+    ) -> None:
+        model_kwargs = dict(weights_backbone=None)
+        if pretrained_from_imagenet:
+            model_kwargs["weights_backbone"] = "IMAGENET1K_V2"
+
+        super().__init__(
+            model="ssdlite320_mobilenet_v3_large",
+            weights=None,
+            num_classes=2,
+            freeze_bn_stats=freeze_bn_stats,
+            freeze_bn_weights=freeze_bn_weights,
+            box_score_thresh=box_score_thresh,
+            model_kwargs=model_kwargs,
+        )
+
+        if pretrained and not pretrained_from_imagenet:
+            weights = detection.SSDLite320_MobileNet_V3_Large_Weights.verify("COCO_V1")
+            state_dict = weights.get_state_dict(progress=False, check_hash=True)
+            for k, v in state_dict.items():
+                key_parts = k.split(".")
+                if (
+                    len(key_parts) == 6
+                    and key_parts[0] == "head"
+                    and key_parts[1] == "classification_head"
+                    and key_parts[2] == "module_list"
+                    and key_parts[4] == "1"
+                    and key_parts[5] in ("weight", "bias")
+                ):
+                    # number of COCO classes: 90 + background (91)
+                    # number of DLC classes: 1 + background (2)
+                    # -> only keep weights for the background + first class
+
+                    # future improvement: find best-suited class for the project
+                    #   and use those weights, instead of naively taking the first
+                    all_classes_size = v.shape[0]
+                    two_classes_size = 2 * (all_classes_size // 91)
+                    state_dict[k] = v[:two_classes_size]
+
+            self.model.load_state_dict(state_dict)

--- a/deeplabcut/pose_estimation_pytorch/models/detectors/torchvision.py
+++ b/deeplabcut/pose_estimation_pytorch/models/detectors/torchvision.py
@@ -153,8 +153,8 @@ class TorchvisionDetectorAdaptor(BaseDetector):
             res.append(
                 {
                     "area": labels["area"][i][mask],
-                    "labels": labels["labels"][i][mask],
-                    "is_crowd": labels["is_crowd"][i][mask],
+                    "labels": labels["labels"][i][mask].long(),
+                    "is_crowd": labels["is_crowd"][i][mask].long(),
                     "boxes": box_ann,
                 }
             )

--- a/deeplabcut/pose_estimation_pytorch/models/detectors/torchvision.py
+++ b/deeplabcut/pose_estimation_pytorch/models/detectors/torchvision.py
@@ -1,0 +1,162 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Module to adapt torchvision detectors for DeepLabCut"""
+from __future__ import annotations
+
+import torch
+import torchvision.models.detection as detection
+
+from deeplabcut.pose_estimation_pytorch.models.detectors.base import (
+    BaseDetector,
+)
+
+
+class TorchvisionDetectorAdaptor(BaseDetector):
+    """An adaptor for torchvision detectors
+
+    This class is an adaptor for torchvision detectors to DeepLabCut detectors. Some of
+    the models (from fastest to most powerful) available are:
+      - ssdlite320_mobilenet_v3_large
+      - fasterrcnn_mobilenet_v3_large_fpn
+      - fasterrcnn_resnet50_fpn_v2
+
+    This class should not be used out-of-the-box. Subclasses (such as FasterRCNN or
+    SSDLite) should be used instead.
+
+    The torchvision implementation does not allow to get both predictions and losses
+    with a single forward pass. Therefore, during evaluation only bounding box metrics
+    (mAP, mAR) are available for the test set. See validation loss issue:
+    - https://discuss.pytorch.org/t/compute-validation-loss-for-faster-rcnn/62333/12
+    - https://stackoverflow.com/a/65347721
+
+    Args:
+        model: The torchvision model to use (see all options at
+            https://pytorch.org/vision/stable/models.html#object-detection).
+        weights: The weights to load for the model. If None, no pre-trained weights are
+            loaded.
+        num_classes: Number of classes that the model should output. If None, the number
+            of classes the model is pre-trained on is used.
+        freeze_bn_stats: Whether to freeze stats for BatchNorm layers.
+        freeze_bn_weights: Whether to freeze weights for BatchNorm layers.
+        box_score_thresh: during inference, only return proposals with a classification
+            score greater than box_score_thresh
+    """
+
+    def __init__(
+        self,
+        model: str,
+        weights: str | None = None,
+        num_classes: int | None = 2,
+        freeze_bn_stats: bool = False,
+        freeze_bn_weights: bool = False,
+        box_score_thresh: float = 0.01,
+        model_kwargs: dict | None = None,
+    ) -> None:
+        super().__init__(
+            freeze_bn_stats=freeze_bn_stats,
+            freeze_bn_weights=freeze_bn_weights,
+            pretrained=weights is not None,
+        )
+
+        # Load the model
+        model_fn = getattr(detection, model)
+        if model_kwargs is None:
+            model_kwargs = {}
+
+        self.model = model_fn(
+            weights=weights,
+            box_score_thresh=box_score_thresh,
+            num_classes=num_classes,
+            **model_kwargs,
+        )
+
+        # See source:  https://stackoverflow.com/a/65347721
+        self.model.eager_outputs = lambda losses, detections: (losses, detections)
+
+    def forward(
+        self, x: torch.Tensor, targets: list[dict[str, torch.Tensor]] | None = None
+    ) -> tuple[dict[str, torch.Tensor], list[dict[str, torch.Tensor]]]:
+        """
+        Forward pass of the torchvision detector
+
+        Args:
+            x: images to be processed, of shape (b, c, h, w)
+            targets: ground-truth boxes present in the images
+
+        Returns:
+            losses: {'loss_name': loss_value}
+            detections: for each of the b images, {"boxes": bounding_boxes}
+        """
+        return self.model(x, targets)
+
+    def get_target(self, labels: dict) -> list[dict[str, torch.Tensor]]:
+        """
+        Returns target in a format a torchvision detector can handle
+
+        Args:
+            labels: dict of annotations, must contain the keys:
+                area: tensor containing area information for each annotation
+                labels: tensor containing class labels for each annotation
+                is_crowd: tensor indicating if each annotation is a crowd (1) or not (0)
+                image_id: tensor containing image ids for each annotation
+                boxes: tensor containing bounding box information for each annotation
+
+        Returns:
+            res: list of dictionaries, each representing target information for a single
+                annotation. Each dictionary contains the following keys:
+                    'area'
+                    'labels'
+                    'is_crowd'
+                    'boxes'
+
+        Examples:
+            input:
+                annotations = {
+                    "area": torch.Tensor([100, 200]),
+                    "labels": torch.Tensor([1, 2]),
+                    "is_crowd": torch.Tensor([0, 1]),
+                    "boxes": torch.Tensor([[10, 20, 30, 40], [50, 60, 70, 80]])
+                }
+            output:
+                res =  [
+                    {
+                        'area': tensor([100.]),
+                        'labels': tensor([1]),
+                        'image_id': tensor([1]),
+                        'is_crowd': tensor([0]),
+                        'boxes': tensor([[10., 20., 40., 60.]])
+                    },
+                    {
+                        'area': tensor([200.]),
+                        'labels': tensor([2]),
+                        'image_id': tensor([1]),
+                        'is_crowd': tensor([1]),
+                        'boxes': tensor([[50., 60., 70., 80.]])
+                    }
+                ]
+        """
+        res = []
+        for i, box_ann in enumerate(labels["boxes"]):
+            mask = (box_ann[:, 2] > 0.0) & (box_ann[:, 3] > 0.0)
+            box_ann = box_ann[mask]
+            # bbox format conversion (x, y, w, h) -> (x1, y1, x2, y2)
+            box_ann[:, 2] += box_ann[:, 0]
+            box_ann[:, 3] += box_ann[:, 1]
+            res.append(
+                {
+                    "area": labels["area"][i][mask],
+                    "labels": labels["labels"][i][mask],
+                    "is_crowd": labels["is_crowd"][i][mask],
+                    "boxes": box_ann,
+                }
+            )
+
+        return res


### PR DESCRIPTION
# New Detector Options

This pull requests
- [x] adds SSDLite as a possible detector
- [x] adds a `detector_type` parameter to the `create_training_dataset` methods, allowing users to select which detector architecture to use when training top-down models
- [x] adds the detector selection to the GUI
- [x] Fix #2642: `TypeError: target labels must of int64 type, instead got torch.int32` on windows
