### PR TITLE
Default PAF config update

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/config/base/head_bodyparts_with_paf.yaml
+++ b/deeplabcut/pose_estimation_pytorch/config/base/head_bodyparts_with_paf.yaml
@@ -1,5 +1,4 @@
 type: DLCRNetHead
-weight_init: normal
 predictor:
   type: PartAffinityFieldPredictor
   num_animals: "num_individuals"
@@ -11,12 +10,12 @@ predictor:
   min_affinity: 0.05
   graph: "paf_graph"
   edges_to_keep: "paf_edges_to_keep"
-  apply_sigmoid: false
-  clip_scores: true
+  apply_sigmoid: true
+  clip_scores: false
 target_generator:
   type: SequentialGenerator
   generators:
-  - type: HeatmapGaussianGenerator
+  - type: HeatmapPlateauGenerator
     num_heatmaps: "num_bodyparts"
     pos_dist_thresh: 17
     heatmap_mode: KEYPOINT
@@ -27,7 +26,7 @@ target_generator:
     width: 20
 criterion:
   heatmap:
-    type: WeightedMSECriterion
+    type: WeightedBCECriterion
     weight: 1.0
   locref:
     type: WeightedHuberCriterion

--- a/deeplabcut/pose_estimation_pytorch/models/heads/dlcrnet.py
+++ b/deeplabcut/pose_estimation_pytorch/models/heads/dlcrnet.py
@@ -55,6 +55,7 @@ class DLCRNetHead(HeatmapHead):
                 in_refined_channels
             )
             locref_config["channels"][0] = locref_config["channels"][-1]
+
         super().__init__(
             predictor,
             target_generator,
@@ -64,6 +65,9 @@ class DLCRNetHead(HeatmapHead):
             locref_config,
             weight_init,
         )
+        if num_stages > 0:
+            self.stride *= 2  # extra deconv layer where it's multi-stage
+
         self.paf_head = DeconvModule(**paf_config)
 
         self.convt1 = self._make_layer_same_padding(


### PR DESCRIPTION
This pull request updates the default PAF configuration file to match the tensorflow version:

- Plateau generator instead of Gaussian
- BCE instead of MSE heatmap loss
- Bug fix: PAF model stride computation