### PR TITLE
Swap button added to the track refinement GUI

### DIFF
--- a/conda-environments/DEEPLABCUT.yaml
+++ b/conda-environments/DEEPLABCUT.yaml
@@ -15,7 +15,7 @@
 #
 # install: conda env create -f DEEPLABCUT.yaml
 # update:  conda env update -f DEEPLABCUT.yaml
-name: dlcLocal
+name: DEEPLABCUT
 channels:
   - conda-forge
   - defaults

--- a/conda-environments/DEEPLABCUT.yaml
+++ b/conda-environments/DEEPLABCUT.yaml
@@ -15,7 +15,7 @@
 #
 # install: conda env create -f DEEPLABCUT.yaml
 # update:  conda env update -f DEEPLABCUT.yaml
-name: DEEPLABCUT
+name: dlcLocal
 channels:
   - conda-forge
   - defaults

--- a/deeplabcut/benchmark/base.py
+++ b/deeplabcut/benchmark/base.py
@@ -132,10 +132,7 @@ class Benchmark(abc.ABC):
                 "individuals were detected in those images."
             )
 
-        return {
-            img: predictions.get(img, tuple())
-            for img in test_images
-        }
+        return {img: predictions.get(img, tuple()) for img in test_images}
 
 
 @dataclasses.dataclass

--- a/deeplabcut/benchmark/metrics.py
+++ b/deeplabcut/benchmark/metrics.py
@@ -234,9 +234,7 @@ def calc_rmse_from_obj(
             kpts.pop(ind)
 
     test_objects = {
-        k: v
-        for k, v in eval_results_obj.items()
-        if k in gt["annotations"].keys()
+        k: v for k, v in eval_results_obj.items() if k in gt["annotations"].keys()
     }
     if len(gt["annotations"]) != len(test_objects):
         gt_images = list(gt["annotations"].keys())

--- a/deeplabcut/create_project/new.py
+++ b/deeplabcut/create_project/new.py
@@ -276,9 +276,9 @@ def create_new_project(
     cfg_file["x2"] = 640
     cfg_file["y1"] = 277
     cfg_file["y2"] = 624
-    cfg_file[
-        "batch_size"
-    ] = 8  # batch size during inference (video - analysis); see https://www.biorxiv.org/content/early/2018/10/30/457242
+    cfg_file["batch_size"] = (
+        8  # batch size during inference (video - analysis); see https://www.biorxiv.org/content/early/2018/10/30/457242
+    )
     cfg_file["corner2move2"] = (50, 50)
     cfg_file["move2corner"] = True
     cfg_file["skeleton_color"] = "black"

--- a/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
@@ -272,9 +272,7 @@ def create_multianimaltraining_dataset(
     # Loading the encoder (if necessary downloading from TF)
     dlcparent_path = auxiliaryfunctions.get_deeplabcut_path()
     defaultconfigfile = os.path.join(dlcparent_path, "pose_cfg.yaml")
-    model_path = auxfun_models.check_for_weights(
-        net_type, Path(dlcparent_path)
-    )
+    model_path = auxfun_models.check_for_weights(net_type, Path(dlcparent_path))
 
     if Shuffles is None:
         Shuffles = range(1, num_shuffles + 1, 1)
@@ -425,9 +423,9 @@ def create_multianimaltraining_dataset(
                 "multi_step": [[1e-4, 7500], [5 * 1e-5, 12000], [1e-5, 200000]],
                 "save_iters": 10000,
                 "display_iters": 500,
-                "num_idchannel": len(cfg["individuals"])
-                if cfg.get("identity", False)
-                else 0,
+                "num_idchannel": (
+                    len(cfg["individuals"]) if cfg.get("identity", False) else 0
+                ),
                 "crop_size": list(crop_size),
                 "crop_sampling": crop_sampling,
             }

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -988,9 +988,7 @@ def create_training_dataset(
             defaultconfigfile = os.path.join(dlcparent_path, "pose_cfg.yaml")
         elif posecfg_template:
             defaultconfigfile = posecfg_template
-        model_path = auxfun_models.check_for_weights(
-            net_type, Path(dlcparent_path)
-        )
+        model_path = auxfun_models.check_for_weights(net_type, Path(dlcparent_path))
 
         if Shuffles is None:
             Shuffles = range(1, num_shuffles + 1)

--- a/deeplabcut/gui/tabs/extract_frames.py
+++ b/deeplabcut/gui/tabs/extract_frames.py
@@ -95,7 +95,8 @@ class ExtractFrames(DefaultTab):
 
         self.main_layout.addWidget(
             _create_label_widget(
-                "Frame extraction from a video subset (optional for automatic extraction)", "font:bold"
+                "Frame extraction from a video subset (optional for automatic extraction)",
+                "font:bold",
             )
         )
         self.video_selection_widget = VideoSelectionWidget(self.root, self)
@@ -206,7 +207,9 @@ class ExtractFrames(DefaultTab):
                 return
             first_video = videos[0]
             if len(videos) > 1:
-                self.root.writer.write(f"Only the first video ({first_video}) will be opened.")
+                self.root.writer.write(
+                    f"Only the first video ({first_video}) will be opened."
+                )
             video_path_in_folder = self._check_symlink(first_video)
             _ = launch_napari(str(video_path_in_folder))
             return

--- a/deeplabcut/gui/tabs/modelzoo.py
+++ b/deeplabcut/gui/tabs/modelzoo.py
@@ -72,7 +72,9 @@ class ModelZoo(DefaultTab):
 
         tooltip_label = QtWidgets.QLabel()
         tooltip_label.setPixmap(
-            QPixmap(os.path.join(BASE_DIR, "assets", "icons", "help2.png")).scaledToWidth(30)
+            QPixmap(
+                os.path.join(BASE_DIR, "assets", "icons", "help2.png")
+            ).scaledToWidth(30)
         )
         tooltip_label.setToolTip(
             "Approximate animal sizes in pixels, for spatial pyramid search. If left blank, defaults to video height +/- 50 pixels",

--- a/deeplabcut/gui/tabs/refine_tracklets.py
+++ b/deeplabcut/gui/tabs/refine_tracklets.py
@@ -253,6 +253,7 @@ class RefineTracklets(DefaultTab):
         vname = Path(video).stem
         datafile = os.path.join(dest, vname + DLCscorer + f"{method}.h5")
         self.manager, self.viz = deeplabcut.refine_tracklets(
+        #self.manager, self.viz = deeplabcut.refine_tracklets_napari(
             self.root.config,
             datafile,
             video,
@@ -261,3 +262,5 @@ class RefineTracklets(DefaultTab):
             max_gap=self.max_gap_widget.value(),
         )
         self.merge_button.setEnabled(True)
+
+  

--- a/deeplabcut/gui/tabs/refine_tracklets.py
+++ b/deeplabcut/gui/tabs/refine_tracklets.py
@@ -261,5 +261,3 @@ class RefineTracklets(DefaultTab):
             max_gap=self.max_gap_widget.value(),
         )
         self.merge_button.setEnabled(True)
-
-  

--- a/deeplabcut/gui/tabs/refine_tracklets.py
+++ b/deeplabcut/gui/tabs/refine_tracklets.py
@@ -253,7 +253,6 @@ class RefineTracklets(DefaultTab):
         vname = Path(video).stem
         datafile = os.path.join(dest, vname + DLCscorer + f"{method}.h5")
         self.manager, self.viz = deeplabcut.refine_tracklets(
-        #self.manager, self.viz = deeplabcut.refine_tracklets_napari(
             self.root.config,
             datafile,
             video,

--- a/deeplabcut/gui/tracklet_toolbox.py
+++ b/deeplabcut/gui/tracklet_toolbox.py
@@ -295,6 +295,7 @@ class PointSelector:
         self.lasso.connect_default_events()
         self.is_connected = True
 
+
 class TrackletVisualizer:
     def __init__(self, manager, videoname, trail_len=50):
         self.manager = manager
@@ -360,7 +361,7 @@ class TrackletVisualizer:
 
         img = self.video.read_frame()
         self.im = self.ax1.imshow(img)
-        self.scat = self.ax1.scatter([], [], s=self.dotsize ** 2, picker=True)
+        self.scat = self.ax1.scatter([], [], s=self.dotsize**2, picker=True)
         self.scat.set_offsets(manager.xy[:, 0])
         self.scat.set_color(self.colors)
         self.trails = sum(
@@ -452,8 +453,8 @@ class TrackletVisualizer:
         # Create dropdowns for selecting tracklets to swap, placing them near the swap button
         self.ax_dropdown1 = self.fig.add_axes([0.9, 0.15, 0.05, 0.03])
         self.ax_dropdown2 = self.fig.add_axes([0.9, 0.20, 0.05, 0.03])
-        self.textbox1 = TextBox(self.ax_dropdown1, 'ID 1')
-        self.textbox2 = TextBox(self.ax_dropdown2, 'ID 2')
+        self.textbox1 = TextBox(self.ax_dropdown1, "ID 1")
+        self.textbox2 = TextBox(self.ax_dropdown2, "ID 2")
         self.textbox1.on_submit(self.set_swap_id1)
         self.textbox2.on_submit(self.set_swap_id2)
 
@@ -464,17 +465,25 @@ class TrackletVisualizer:
         if self.swap_id1 is not None and self.swap_id2 is not None:
 
             # Get tracklet indices for each individual
-            inds1 = [k for k in range(len(self.manager.tracklet2id)) if self.manager.tracklet2id[k] == self.swap_id1]
-            inds2 = [k for k in range(len(self.manager.tracklet2id)) if self.manager.tracklet2id[k] == self.swap_id2]
-            
-            print(f'Swapping tracklets {self.swap_id1} and {self.swap_id2}')
+            inds1 = [
+                k
+                for k in range(len(self.manager.tracklet2id))
+                if self.manager.tracklet2id[k] == self.swap_id1
+            ]
+            inds2 = [
+                k
+                for k in range(len(self.manager.tracklet2id))
+                if self.manager.tracklet2id[k] == self.swap_id2
+            ]
+
+            print(f"Swapping tracklets {self.swap_id1} and {self.swap_id2}")
 
             # Frames to swap
             frames = []
             if len(self.cuts) == 2:
                 frames = list(range(min(self.cuts), max(self.cuts) + 1))
             elif len(self.cuts) == 1:
-                frames = [self.cuts[0]] 
+                frames = [self.cuts[0]]
             else:
                 frames = list(range(self.curr_frame, self.manager.nframes))
 
@@ -482,31 +491,33 @@ class TrackletVisualizer:
             for i in range(min(len(inds1), len(inds2))):
                 self.manager.swap_tracklets(inds1[i], inds2[i], frames)
                 self.display_traces()
-                self.slider.set_val(self.curr_frame)    
+                self.slider.set_val(self.curr_frame)
 
     def set_swap_id1(self, val):
         # check that the input is a valid from the list of individuals
         if int(val) in self.manager.tracklet2id:
             self.swap_id1 = int(val)
-            print('ID 1 set.')
+            print("ID 1 set.")
         else:
-            print(f'Invalid ID. Please select a valid ID from the list of individuals: {set(self.manager.tracklet2id)}')
+            print(
+                f"Invalid ID. Please select a valid ID from the list of individuals: {set(self.manager.tracklet2id)}"
+            )
             self.swap_id1 = None
 
     def set_swap_id2(self, val):
         # check that the input is a valid from the list of individuals
         if int(val) in self.manager.tracklet2id:
             self.swap_id2 = int(val)
-            print('ID 2 set.')
+            print("ID 2 set.")
         else:
-            print(f'Invalid ID. Please select a valid ID from the list of individuals: {set(self.manager.tracklet2id)}')
+            print(
+                f"Invalid ID. Please select a valid ID from the list of individuals: {set(self.manager.tracklet2id)}"
+            )
             self.swap_id2 = None
 
     def terminate(self, event):
         plt.close(self.fig)
         self.player.terminate()
-
-
 
     def fill_shaded_areas(self):
         self.clean_collections()
@@ -651,9 +662,9 @@ class TrackletVisualizer:
             if len(self.cuts) > 1:
                 self.cuts.sort()
                 if self.picked_pair:
-                    self.manager.tracklet_swaps[self.picked_pair][
-                        self.cuts
-                    ] = ~self.manager.tracklet_swaps[self.picked_pair][self.cuts]
+                    self.manager.tracklet_swaps[self.picked_pair][self.cuts] = (
+                        ~self.manager.tracklet_swaps[self.picked_pair][self.cuts]
+                    )
                     self.fill_shaded_areas()
                     self.cuts = []
                     for line in self.ax_slider.lines:
@@ -871,7 +882,7 @@ class TrackletVisualizer:
 
     def update_dotsize(self, val):
         self.dotsize = val
-        self.scat.set_sizes([self.dotsize ** 2])
+        self.scat.set_sizes([self.dotsize**2])
 
     @staticmethod
     def calc_distance(x1, y1, x2, y2):
@@ -976,6 +987,7 @@ class TrackletVisualizer:
             df.sort_index(inplace=True)
             df.to_hdf(output_path, key="df_with_missing", mode="w")
             df.to_csv(output_path.replace("h5", "csv"))
+
 
 def refine_tracklets(
     config,

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -59,9 +59,7 @@ def _check_for_updates(silent=True):
         _ = msg.addButton("Skip", msg.RejectRole)
         msg.exec_()
         if msg.clickedButton() is update_btn:
-            subprocess.check_call(
-                [sys.executable, "-m", *command]
-            )
+            subprocess.check_call([sys.executable, "-m", *command])
 
 
 class MainWindow(QMainWindow):

--- a/deeplabcut/modelzoo/api/superanimal_inference.py
+++ b/deeplabcut/modelzoo/api/superanimal_inference.py
@@ -271,7 +271,9 @@ def video_inference(
     customized_test_config="",
 ):
     if superanimal_name not in MODELOPTIONS:
-        raise ValueError(f"{superanimal_name} not available. Available ones are: {MODELOPTIONS}. If you are confident `superanimal_name` is right, try updating `dlclibrary` with `pip install -U dlclibrary`.")
+        raise ValueError(
+            f"{superanimal_name} not available. Available ones are: {MODELOPTIONS}. If you are confident `superanimal_name` is right, try updating `dlclibrary` with `pip install -U dlclibrary`."
+        )
 
     dlc_root_path = auxiliaryfunctions.get_deeplabcut_path()
 

--- a/deeplabcut/pose_estimation_3d/camera_calibration.py
+++ b/deeplabcut/pose_estimation_3d/camera_calibration.py
@@ -26,7 +26,9 @@ from deeplabcut.utils import auxiliaryfunctions_3d
 matplotlib_axes_logger.setLevel("ERROR")
 
 
-def calibrate_cameras(config, cbrow=8, cbcol=6, calibrate=False, alpha=0.4, search_window_size=(11, 11)):
+def calibrate_cameras(
+    config, cbrow=8, cbcol=6, calibrate=False, alpha=0.4, search_window_size=(11, 11)
+):
     """This function extracts the corners points from the calibration images, calibrates the camera and stores the calibration files in the project folder (defined in the config file).
 
     Make sure you have around 20-60 pairs of calibration images. The function should be used iteratively to select the right set of calibration images.

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -867,9 +867,7 @@ def evaluate_network(
                             pose = predict.argmax_pose_predict(
                                 scmap, locref, test_pose_cfg["stride"]
                             )
-                            PredicteData[
-                                imageindex, :
-                            ] = (
+                            PredicteData[imageindex, :] = (
                                 pose.flatten()
                             )  # NOTE: thereby     cfg_test['all_joints_names'] should be same order as bodyparts!
 
@@ -971,10 +969,7 @@ def evaluate_network(
                             print("Plotting...")
                             foldername = os.path.join(
                                 str(evaluationfolder),
-                                "LabeledImages_"
-                                + DLCscorer
-                                + "_"
-                                + snapshot_name,
+                                "LabeledImages_" + DLCscorer + "_" + snapshot_name,
                             )
                             auxiliaryfunctions.attempt_to_make_folder(foldername)
                             Plotting(
@@ -997,10 +992,7 @@ def evaluate_network(
                             ).T
                             foldername = os.path.join(
                                 str(evaluationfolder),
-                                "LabeledImages_"
-                                + DLCscorer
-                                + "_"
-                                + snapshot_name,
+                                "LabeledImages_" + DLCscorer + "_" + snapshot_name,
                             )
                             if not os.path.exists(foldername):
                                 print(
@@ -1104,14 +1096,14 @@ def get_available_requested_snapshots(
 
 
 def get_snapshots_by_index(
-    idx: Union[int, str], available_snapshots: List[str],
+    idx: Union[int, str],
+    available_snapshots: List[str],
 ) -> List[str]:
     """
     Assume available_snapshots is ordered in ascending order. Returns snapshot names.
     """
-    if (
-        isinstance(idx, int)
-        and -len(available_snapshots) <= idx < len(available_snapshots)
+    if isinstance(idx, int) and -len(available_snapshots) <= idx < len(
+        available_snapshots
     ):
         return [available_snapshots[idx]]
     elif idx == "all":

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -396,9 +396,7 @@ def evaluate_multianimal_full(
                         coords_pred = pred["coordinates"][0]
                         probs_pred = pred["confidence"]
                         for bpt, xy_gt in df.groupby(level="bodyparts"):
-                            inds_gt = np.flatnonzero(
-                                np.all(~np.isnan(xy_gt), axis=1)
-                            )
+                            inds_gt = np.flatnonzero(np.all(~np.isnan(xy_gt), axis=1))
                             n_joint = joints.index(bpt)
                             xy = coords_pred[n_joint]
                             if inds_gt.size and xy.size:
@@ -422,9 +420,9 @@ def evaluate_multianimal_full(
 
                         if plotting == "bodypart":
                             temp_xy = GT.unstack("bodyparts")[joints].values
-                            gt = temp_xy.reshape(
-                                (-1, 2, temp_xy.shape[1])
-                            ).T.swapaxes(1, 2)
+                            gt = temp_xy.reshape((-1, 2, temp_xy.shape[1])).T.swapaxes(
+                                1, 2
+                            )
                             h, w, _ = np.shape(frame)
                             fig.set_size_inches(w / 100, h / 100)
                             ax.set_xlim(0, w)
@@ -477,8 +475,7 @@ def evaluate_multianimal_full(
                     # Calculate overall prediction error
                     error = df_joint.xs("rmse", level="metrics", axis=1)
                     mask = (
-                        df_joint.xs("conf", level="metrics", axis=1)
-                        >= cfg["pcutoff"]
+                        df_joint.xs("conf", level="metrics", axis=1) >= cfg["pcutoff"]
                     )
                     error_masked = error[mask]
                     error_train = np.nanmean(error.iloc[trainIndices])
@@ -505,9 +502,7 @@ def evaluate_multianimal_full(
                             testIndices,
                         )
                         kpt_filename = DLCscorer + "-keypoint-results.csv"
-                        df_keypoint_error.to_csv(
-                            Path(evaluationfolder) / kpt_filename
-                        )
+                        df_keypoint_error.to_csv(Path(evaluationfolder) / kpt_filename)
 
                     if show_errors:
                         string = (
@@ -666,12 +661,8 @@ def evaluate_multianimal_full(
                 df.loc(axis=0)[("mAR_train", "mean")] = [
                     d[0]["mAR"] for d in results[2]
                 ]
-                df.loc(axis=0)[("mAP_test", "mean")] = [
-                    d[1]["mAP"] for d in results[2]
-                ]
-                df.loc(axis=0)[("mAR_test", "mean")] = [
-                    d[1]["mAR"] for d in results[2]
-                ]
+                df.loc(axis=0)[("mAP_test", "mean")] = [d[1]["mAP"] for d in results[2]]
+                df.loc(axis=0)[("mAR_test", "mean")] = [d[1]["mAR"] for d in results[2]]
                 with open(data_path.replace("_full.", "_map."), "wb") as file:
                     pickle.dump((df, paf_scores), file)
 

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_base.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_base.py
@@ -20,12 +20,10 @@ class BasePoseDataset(metaclass=abc.ABCMeta):
         self.cfg = cfg
 
     @abc.abstractmethod
-    def load_dataset(self):
-        ...
+    def load_dataset(self): ...
 
     @abc.abstractmethod
-    def next_batch(self):
-        ...
+    def next_batch(self): ...
 
     def sample_scale(self):
         if self.cfg.get("deterministic", False):

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_deterministic.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_deterministic.py
@@ -228,7 +228,7 @@ class DeterministicPoseDataset(BasePoseDataset):
 
     def compute_target_part_scoremap(self, joint_id, coords, data_item, size, scale):
         dist_thresh = self.cfg["pos_dist_thresh"] * scale
-        dist_thresh_sq = dist_thresh ** 2
+        dist_thresh_sq = dist_thresh**2
         num_joints = self.cfg["num_joints"]
         scmap = np.zeros(np.concatenate([size, np.array([num_joints])]))
         locref_size = np.concatenate([size, np.array([num_joints * 2])])
@@ -260,7 +260,7 @@ class DeterministicPoseDataset(BasePoseDataset):
                         pt_x = i * self.stride + self.half_stride
                         dx = j_x - pt_x
                         dy = j_y - pt_y
-                        dist = dx ** 2 + dy ** 2
+                        dist = dx**2 + dy**2
                         # print(la.norm(diff))
                         if dist <= dist_thresh_sq:
                             scmap[j, i, j_id] = 1

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
@@ -487,7 +487,7 @@ class ImgaugPoseDataset(BasePoseDataset):
         width = size[1]
         height = size[0]
         dist_thresh = float((width + height) / 6)
-        dist_thresh_sq = dist_thresh ** 2
+        dist_thresh_sq = dist_thresh**2
 
         std = dist_thresh / 4
         # Grid of coordinates
@@ -503,7 +503,7 @@ class ImgaugPoseDataset(BasePoseDataset):
                 map_j = grid.copy()
                 # Distance between the joint point and each coordinate
                 dist = np.linalg.norm(grid - (j_y, j_x), axis=2) ** 2
-                scmap_j = np.exp(-dist / (2 * (std ** 2)))
+                scmap_j = np.exp(-dist / (2 * (std**2)))
                 scmap[..., j_id] = scmap_j
                 locref_mask[dist <= dist_thresh_sq, j_id * 2 + 0] = 1
                 locref_mask[dist <= dist_thresh_sq, j_id * 2 + 1] = 1
@@ -528,7 +528,7 @@ class ImgaugPoseDataset(BasePoseDataset):
         self, joint_id, coords, data_item, size, scale
     ):
         dist_thresh = float(self.cfg["pos_dist_thresh"] * scale)
-        dist_thresh_sq = dist_thresh ** 2
+        dist_thresh_sq = dist_thresh**2
         num_joints = self.cfg["num_joints"]
 
         scmap = np.zeros(np.concatenate([size, np.array([num_joints])]))
@@ -555,7 +555,7 @@ class ImgaugPoseDataset(BasePoseDataset):
                 y = grid.copy()[:, :, 0]
                 dx = j_x - x * self.stride - self.half_stride
                 dy = j_y - y * self.stride - self.half_stride
-                dist = dx ** 2 + dy ** 2
+                dist = dx**2 + dy**2
                 mask1 = dist <= dist_thresh_sq
                 mask2 = (x >= min_x) & (x <= max_x)
                 mask3 = (y >= min_y) & (y <= max_y)

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_multianimal_imgaug.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_multianimal_imgaug.py
@@ -384,8 +384,7 @@ class MAImgaugPoseDataset(BasePoseDataset):
                         kpts[j * self._n_kpts + int(n)] = x, y
 
                 joint_id = [
-                    np.array(list(range(self._n_kpts)))
-                    for _ in range(self._n_animals)
+                    np.array(list(range(self._n_kpts))) for _ in range(self._n_animals)
                 ]
                 joint_ids.append(joint_id)
                 batch_joints.append(kpts)
@@ -417,8 +416,7 @@ class MAImgaugPoseDataset(BasePoseDataset):
                     for n, x, y in joints.get(j, []):
                         kpts[j * self._n_kpts + int(n)] = x, y
                 joint_id = [
-                    np.array(list(range(self._n_kpts)))
-                    for _ in range(self._n_animals)
+                    np.array(list(range(self._n_kpts))) for _ in range(self._n_animals)
                 ]
                 joint_ids.append(joint_id)
                 batch_joints.append(kpts)
@@ -621,7 +619,7 @@ class MAImgaugPoseDataset(BasePoseDataset):
         locref_size = *size, num_joints * 2
         locref_map = np.zeros(locref_size)
         locref_scale = 1.0 / self.cfg["locref_stdev"]
-        dist_thresh_sq = dist_thresh ** 2
+        dist_thresh_sq = dist_thresh**2
 
         partaffinityfield_shape = *size, self.cfg["num_limbs"] * 2
         partaffinityfield_map = np.zeros(partaffinityfield_shape)
@@ -647,7 +645,7 @@ class MAImgaugPoseDataset(BasePoseDataset):
         dx_ = dx * locref_scale
         dy = coords[:, 1] - yy * stride - half_stride
         dy_ = dy * locref_scale
-        dist = dx ** 2 + dy ** 2
+        dist = dx**2 + dy**2
         mask1 = dist <= dist_thresh_sq
         mask2 = (xx >= mins[:, 0]) & (xx <= maxs[:, 0])
         mask3 = (yy >= mins[:, 1]) & (yy <= maxs[:, 1])
@@ -722,9 +720,9 @@ class MAImgaugPoseDataset(BasePoseDataset):
                             mask = mask1 & mask2
                             temp = 1 - distance_across_abs[mask]
                             if self.cfg["weigh_only_present_joints"]:
-                                partaffinityfield_mask[
-                                    mask, [l * 2 + 0, l * 2 + 1]
-                                ] = 1.0
+                                partaffinityfield_mask[mask, [l * 2 + 0, l * 2 + 1]] = (
+                                    1.0
+                                )
                             partaffinityfield_map[mask, l * 2 + 0] = Dx * temp
                             partaffinityfield_map[mask, l * 2 + 1] = Dy * temp
 
@@ -754,7 +752,7 @@ class MAImgaugPoseDataset(BasePoseDataset):
         locref_map = np.zeros(locref_size)
 
         locref_scale = 1.0 / self.cfg["locref_stdev"]
-        dist_thresh_sq = dist_thresh ** 2
+        dist_thresh_sq = dist_thresh**2
 
         partaffinityfield_shape = np.concatenate(
             [size, np.array([self.cfg["num_limbs"] * 2])]
@@ -786,7 +784,7 @@ class MAImgaugPoseDataset(BasePoseDataset):
             map_j = grid.copy()
             # Distance between the joint point and each coordinate
             dist = np.linalg.norm(grid - (j_y, j_x), axis=2) ** 2
-            scmap_j = np.exp(-dist / (2 * (std ** 2)))
+            scmap_j = np.exp(-dist / (2 * (std**2)))
             scmap[..., j_id] = scmap_j
             locref_mask[dist <= dist_thresh_sq, j_id * 2 + 0] = 1
             locref_mask[dist <= dist_thresh_sq, j_id * 2 + 1] = 1

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_tensorpack.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_tensorpack.py
@@ -350,7 +350,7 @@ class TensorpackPoseDataset(BasePoseDataset):
         locref_map = np.zeros(locref_size)
 
         locref_scale = 1.0 / self.cfg["locref_stdev"]
-        dist_thresh_sq = dist_thresh ** 2
+        dist_thresh_sq = dist_thresh**2
 
         width = size[1]
         height = size[0]
@@ -375,7 +375,7 @@ class TensorpackPoseDataset(BasePoseDataset):
                         pt_x = i * stride + half_stride
                         dx = j_x - pt_x
                         dy = j_y - pt_y
-                        dist = dx ** 2 + dy ** 2
+                        dist = dx**2 + dy**2
                         # print(la.norm(diff))
                         if dist <= dist_thresh_sq:
                             scmap[j, i, j_id] = 1

--- a/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
+++ b/deeplabcut/pose_estimation_tensorflow/lib/inferenceutils.py
@@ -359,7 +359,7 @@ class Assembler:
         ind = _conv_square_to_condensed_indices(i, j, self.n_multibodyparts)
         mu = self._kde.mean[ind]
         sigma = self._kde.covariance[ind, ind]
-        z = (link.length ** 2 - mu) / sigma
+        z = (link.length**2 - mu) / sigma
         return 2 * (1 - 0.5 * (1 + erf(abs(z) / sqrt(2))))
 
     @staticmethod

--- a/deeplabcut/pose_estimation_tensorflow/nnets/base.py
+++ b/deeplabcut/pose_estimation_tensorflow/nnets/base.py
@@ -21,12 +21,10 @@ class BasePoseNet(metaclass=abc.ABCMeta):
         self.cfg = cfg
 
     @abc.abstractmethod
-    def extract_features(self, inputs):
-        ...
+    def extract_features(self, inputs): ...
 
     @abc.abstractmethod
-    def get_net(self, inputs):
-        ...
+    def get_net(self, inputs): ...
 
     def train(self, batch):
         heads = self.get_net(batch[Batch.inputs])

--- a/deeplabcut/pose_estimation_tensorflow/nnets/utils.py
+++ b/deeplabcut/pose_estimation_tensorflow/nnets/utils.py
@@ -86,8 +86,8 @@ def get_batch_spec(cfg):
 def make_2d_gaussian_kernel(sigma, size):
     sigma = tf.convert_to_tensor(sigma, dtype=tf.float32)
     k = tf.range(-size // 2 + 1, size // 2 + 1)
-    k = tf.cast(k ** 2, sigma.dtype)
-    k = tf.nn.softmax(-k / (2 * (sigma ** 2)))
+    k = tf.cast(k**2, sigma.dtype)
+    k = tf.nn.softmax(-k / (2 * (sigma**2)))
     return tf.einsum("i,j->ij", k, k)
 
 

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -776,9 +776,7 @@ def GetPoseS(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes):
             else:
                 frame = img_as_ubyte(frame)
             pose = predict.getpose(frame, dlc_cfg, sess, inputs, outputs)
-            PredictedData[
-                counter, :
-            ] = (
+            PredictedData[counter, :] = (
                 pose.flatten()
             )  # NOTE: thereby cfg['all_joints_names'] should be same order as bodyparts!
         elif counter >= nframes:
@@ -821,9 +819,7 @@ def GetPoseS_GTF(cfg, dlc_cfg, sess, inputs, outputs, cap, nframes):
             )
             pose[:, [0, 1, 2]] = pose[:, [1, 0, 2]]
             # pose = predict.getpose(frame, dlc_cfg, sess, inputs, outputs)
-            PredictedData[
-                counter, :
-            ] = (
+            PredictedData[counter, :] = (
                 pose.flatten()
             )  # NOTE: thereby cfg['all_joints_names'] should be same order as bodyparts!
         elif counter >= nframes:
@@ -1086,7 +1082,7 @@ def AnalyzeVideo(
             "iteration (active-learning)": cfg["iteration"],
             "training set fraction": trainFraction,
             "cropping": cfg["cropping"],
-            "cropping_parameters": coords
+            "cropping_parameters": coords,
             # "gpu_info": device_lib.list_local_devices()
         }
         metadata = {"data": dictionary}

--- a/deeplabcut/pose_estimation_tensorflow/training.py
+++ b/deeplabcut/pose_estimation_tensorflow/training.py
@@ -246,9 +246,11 @@ def train_network(
                 keepdeconvweights=keepdeconvweights,
                 allow_growth=allow_growth,
                 init_weights=init_weights,
-                remove_head=True
-                if superanimal_name != "" and superanimal_transfer_learning
-                else False,
+                remove_head=(
+                    True
+                    if superanimal_name != "" and superanimal_transfer_learning
+                    else False
+                ),
             )  # pass on path and file name for pose_cfg.yaml!
 
         elif "multi-animal" in cfg_dlc["dataset_type"]:

--- a/deeplabcut/pose_estimation_tensorflow/util/visualize.py
+++ b/deeplabcut/pose_estimation_tensorflow/util/visualize.py
@@ -31,7 +31,7 @@ def _npcircle(image, cx, cy, radius, color, transparency=0.0):
     cx = int(cx)
     cy = int(cy)
     y, x = np.ogrid[-radius:radius, -radius:radius]
-    index = x ** 2 + y ** 2 <= radius ** 2
+    index = x**2 + y**2 <= radius**2
     image[cy - radius : cy + radius, cx - radius : cx + radius][index] = (
         image[cy - radius : cy + radius, cx - radius : cx + radius][index].astype(
             "float32"

--- a/deeplabcut/pose_estimation_tensorflow/vis_dataset.py
+++ b/deeplabcut/pose_estimation_tensorflow/vis_dataset.py
@@ -67,7 +67,9 @@ def display_dataset():
                     continue
 
                 scmap_part = scmap[:, :, j]
-                scmap_part = imresize(scmap_part, 8.0, interpolationmethod=cv2.INTER_NEAREST)
+                scmap_part = imresize(
+                    scmap_part, 8.0, interpolationmethod=cv2.INTER_NEAREST
+                )
                 scmap_part = np.lib.pad(scmap_part, ((4, 0), (4, 0)), "minimum")
 
                 curr_plot.set_title("{}".format(j + 1))

--- a/deeplabcut/pose_estimation_tensorflow/visualizemaps.py
+++ b/deeplabcut/pose_estimation_tensorflow/visualizemaps.py
@@ -323,7 +323,7 @@ def visualize_paf(image, paf, step=5, colors=None):
         V = paf[:, :, n, 1]
         X, Y = np.meshgrid(np.arange(U.shape[1]), np.arange(U.shape[0]))
         M = np.zeros(U.shape, dtype=bool)
-        M[U ** 2 + V ** 2 < 0.5 * 0.5 ** 2] = True
+        M[U**2 + V**2 < 0.5 * 0.5**2] = True
         U = np.ma.masked_array(U, mask=M)
         V = np.ma.masked_array(V, mask=M)
         ax.quiver(

--- a/deeplabcut/pose_tracking_pytorch/model/backbones/vit_pytorch.py
+++ b/deeplabcut/pose_tracking_pytorch/model/backbones/vit_pytorch.py
@@ -111,7 +111,7 @@ class Attention(nn.Module):
         self.num_heads = num_heads
         head_dim = dim // num_heads
         # NOTE scale factor was wrong in my original version, can set manually to be compat with prev weights
-        self.scale = qk_scale or head_dim ** -0.5
+        self.scale = qk_scale or head_dim**-0.5
 
         self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
         self.attn_drop = nn.Dropout(attn_drop)

--- a/deeplabcut/pose_tracking_pytorch/solver/cosine_lr.py
+++ b/deeplabcut/pose_tracking_pytorch/solver/cosine_lr.py
@@ -96,14 +96,14 @@ class CosineLRScheduler(Scheduler):
                 i = math.floor(
                     math.log(1 - t / self.t_initial * (1 - self.t_mul), self.t_mul)
                 )
-                t_i = self.t_mul ** i * self.t_initial
-                t_curr = t - (1 - self.t_mul ** i) / (1 - self.t_mul) * self.t_initial
+                t_i = self.t_mul**i * self.t_initial
+                t_curr = t - (1 - self.t_mul**i) / (1 - self.t_mul) * self.t_initial
             else:
                 i = t // self.t_initial
                 t_i = self.t_initial
                 t_curr = t - (self.t_initial * i)
 
-            gamma = self.decay_rate ** i
+            gamma = self.decay_rate**i
             lr_min = self.lr_min * gamma
             lr_max_values = [v * gamma for v in self.base_values]
 
@@ -139,6 +139,6 @@ class CosineLRScheduler(Scheduler):
         else:
             return int(
                 math.floor(
-                    -self.t_initial * (self.t_mul ** cycles - 1) / (1 - self.t_mul)
+                    -self.t_initial * (self.t_mul**cycles - 1) / (1 - self.t_mul)
                 )
             )

--- a/deeplabcut/pose_tracking_pytorch/tracking_utils/reranking.py
+++ b/deeplabcut/pose_tracking_pytorch/tracking_utils/reranking.py
@@ -76,9 +76,7 @@ def re_ranking(
         k_reciprocal_expansion_index = np.unique(k_reciprocal_expansion_index)
         weight = np.exp(-original_dist[i, k_reciprocal_expansion_index])
         V[i, k_reciprocal_expansion_index] = weight / np.sum(weight)
-    original_dist = original_dist[
-        :query_num,
-    ]
+    original_dist = original_dist[:query_num,]
     if k2 != 1:
         V_qe = np.zeros_like(V, dtype=np.float16)
         for i in range(all_num):

--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -416,7 +416,7 @@ def extract_outlier_frames(
                 temp_dt = df_temp.diff(axis=0) ** 2
                 temp_dt.drop("likelihood", axis=1, level="coords", inplace=True)
                 sum_ = temp_dt.groupby(level="bodyparts", axis=1).sum()
-                ind = df_temp.index[(sum_ > epsilon ** 2).any(axis=1)].tolist()
+                ind = df_temp.index[(sum_ > epsilon**2).any(axis=1)].tolist()
                 Indices.extend(ind)
             elif outlieralgorithm == "fitting":
                 d, o = compute_deviations(
@@ -1002,7 +1002,7 @@ def PlottingSingleFrame(
                     plt.scatter(
                         df_x[ind, index],
                         df_y[ind, index],
-                        s=dotsize ** 2,
+                        s=dotsize**2,
                         color=colors(map2bp[i]),
                         alpha=alphavalue,
                     )
@@ -1074,7 +1074,7 @@ def PlottingSingleFramecv2(
                     plt.scatter(
                         df_x[ind, index],
                         df_y[ind, index],
-                        s=dotsize ** 2,
+                        s=dotsize**2,
                         color=colors(map2bp[i]),
                         alpha=alphavalue,
                     )

--- a/deeplabcut/refine_training_dataset/stitch.py
+++ b/deeplabcut/refine_training_dataset/stitch.py
@@ -222,13 +222,13 @@ class Tracklet:
         else:
             raise ValueError(f"Unknown where={where}")
         if norm:
-            return np.sqrt(np.sum(vel ** 2, axis=1)).mean()
+            return np.sqrt(np.sum(vel**2, axis=1)).mean()
         return vel.mean(axis=0)
 
     @property
     def maximal_velocity(self):
         vel = np.diff(self.centroid, axis=0) / np.diff(self.inds)[:, np.newaxis]
-        return np.sqrt(np.max(np.sum(vel ** 2, axis=1)))
+        return np.sqrt(np.max(np.sum(vel**2, axis=1)))
 
     def calc_rate_of_turn(self, where="head"):
         """
@@ -267,7 +267,7 @@ class Tracklet:
                 self.centroid[np.isin(self.inds, other_tracklet.inds)]
                 - other_tracklet.centroid[np.isin(other_tracklet.inds, self.inds)]
             )
-            return np.sqrt(np.sum(dist ** 2, axis=1)).mean()
+            return np.sqrt(np.sum(dist**2, axis=1)).mean()
         elif self < other_tracklet:
             return np.sqrt(
                 np.sum((self.centroid[-1] - other_tracklet.centroid[0]) ** 2)
@@ -300,7 +300,7 @@ class Tracklet:
                 d2 = self.centroid[0] - time_gap * self.calc_velocity("tail", False)
                 delta1 = self.centroid[0] - d1
                 delta2 = other_tracklet.centroid[-1] - d2
-            return (np.sqrt(np.sum(delta1 ** 2)) + np.sqrt(np.sum(delta2 ** 2))) / 2
+            return (np.sqrt(np.sum(delta1**2)) + np.sqrt(np.sum(delta2**2))) / 2
         return 0
 
     def time_gap_to(self, other_tracklet):
@@ -417,7 +417,7 @@ class Tracklet:
         # omega = 0.56 * beta ** 3 - 0.95 * beta ** 2 + 1.82 * beta + 1.43
         _, s, _ = sli.svd(mat, min(10, min(mat.shape)))
         # return np.argmin(s > omega * np.median(s))
-        eigen = s ** 2
+        eigen = s**2
         diff = np.abs(np.diff(eigen / eigen[0]))
         return np.argmin(diff > tol)
 

--- a/deeplabcut/refine_training_dataset/tracklets.py
+++ b/deeplabcut/refine_training_dataset/tracklets.py
@@ -176,9 +176,9 @@ class TrackletManager:
                             rows, cols = np.nonzero(has_data)
                             for i, j in zip(idx, better):
                                 sl = slice(j * 3, j * 3 + 3)
-                                tracklets_multi[
-                                    i, inds[rows[sl]], cols[sl]
-                                ] = remaining.flat[sl]
+                                tracklets_multi[i, inds[rows[sl]], cols[sl]] = (
+                                    remaining.flat[sl]
+                                )
                     else:
                         rows, cols = np.nonzero(has_data)
                         n = np.argmin(overwrite_risk)

--- a/deeplabcut/utils/auxfun_models.py
+++ b/deeplabcut/utils/auxfun_models.py
@@ -175,7 +175,8 @@ def smart_restore(restorer, sess, checkpoint_path, net_type):
     except ValueError as e:  # The path may be wrong, or the weights no longer exist
         dlcparent_path = auxiliaryfunctions.get_deeplabcut_path()
         correct_model_path = os.path.join(
-            dlcparent_path, MODELTYPE_FILEPATH_MAP[net_type],
+            dlcparent_path,
+            MODELTYPE_FILEPATH_MAP[net_type],
         )
         if checkpoint_path == correct_model_path:
             # The path is right, hence the weights are missing; we'll download them again.

--- a/deeplabcut/utils/conversioncode.py
+++ b/deeplabcut/utils/conversioncode.py
@@ -91,6 +91,96 @@ def convertcsv2h5(config, userfeedback=True, scorer=None):
         except FileNotFoundError:
             print("Attention:", folder, "does not appear to have labeled data!")
 
+def adapt_labeled_data_to_new_project(config_path, remove_old_bodyparts = False, other_scorer = False,  userfeedback=False):
+    ''' Given the config.yaml file, this function will convert the labels of an ancient project to a new project.
+        For this, the labeled data must be in the project folder, under the labeled-data folder and with the same configuration as all deeplabcut projects.
+
+    Parameters
+    ----------
+    config_path : str
+        The path to the config.yaml file.
+    remove_old_bodyparts : bool (default = False)
+        If True, the old bodyparts that are not in the new project will be removed from the dataframe.
+    other_scorer : bool (default = False)
+        If True, the labels will be converted to the new scorer.
+    userfeedback : bool (default = True)
+        If true the user will be asked specifically for each folder in labeled-data if the containing csv shall be converted to hdf format.'''
+
+    # Load the config file
+    cfg = dlc.auxiliaryfunctions.read_config(config_path)
+    
+    # Get the Project path
+    project_path = cfg['project_path']
+    
+    # Get the bodyparts
+    bodyparts = cfg['multianimalbodyparts']
+    print('New Bodyparts:', bodyparts)
+    
+    # Iterate over each labeled data video
+
+    # Use tqdm for a progress bar
+    for video in tqdm.tqdm(cfg['video_sets']):
+        print('Video:', video)
+        
+        video_name = video.split('\\')[-1]
+        # discard the file extension
+        video_name = video_name.split('.')[0]
+        # Load the csv file
+        label_path = os.path.join(project_path, 'labeled-data', video_name)
+        csv_files = [file for file in os.listdir(label_path) if file.endswith('.csv')]
+        if not csv_files:
+            print('No csv file in the folder:', label_path)
+        else:
+            csv_path = os.path.join(label_path, csv_files[0])
+            df = pd.read_csv(csv_path, header=None)
+        
+            # get the scorer
+            if other_scorer:
+                scorer = cfg['scorer']
+                # Change the scorer in the dataframe
+                df.iloc[0, 3:] = pd.Series([scorer]*len(df.columns[3:]))
+
+            else:
+                scorer = df.iloc[0, 3]
+            
+            # Get the individuals
+            individuals = np.unique(df.iloc[1, 3:])
+
+            # Get the old bodyparts
+            old_bodyparts = np.unique(df.iloc[2, 3:])
+            print('Old bodyparts:', old_bodyparts)
+            
+            # Get the unmber of old bodyparts
+            num_of_old_bodyparts = len(old_bodyparts)
+
+            # Bodyparts to add
+            print('Bodyparts to add:', set(bodyparts) - set(old_bodyparts))
+
+            # If a bodypart is missing, add it to the dataframe
+            for indx, bodypart in enumerate(bodyparts):
+                if bodypart not in old_bodyparts:
+                    num_of_old_bodyparts += 1
+                    for i, individual in enumerate(individuals):
+                        # create the columns for the bodypart, concatenate, the individual, the bodypart, and nan values
+                        x_column = pd.concat([pd.Series(scorer), pd.Series(individual), pd.Series(bodypart), pd.Series('x'), pd.Series(np.nan, index = df.index)], axis = 0, ignore_index = True)
+                        y_column = pd.concat([pd.Series(scorer), pd.Series(individual), pd.Series(bodypart), pd.Series('y'), pd.Series(np.nan, index = df.index)], axis = 0, ignore_index = True)
+                        # Insert the columns in the dataframe
+                        df.insert(i*2*num_of_old_bodyparts + indx*2 + 3, 'insert_' + bodypart + '_x' + individual ,x_column)
+                        df.insert(i*2*num_of_old_bodyparts + indx*2 + 4, 'insert' + bodypart + '_y' + individual, y_column)
+                        
+
+            # If the old bodyparts are not in the new project, remove them
+            if remove_old_bodyparts:
+                for bodypart in old_bodyparts:
+                    if bodypart not in bodyparts:
+                        df = df.drop(df.columns[df.iloc[2, :] == bodypart], axis = 1)
+
+
+            # Save the dataframe
+            df.to_csv(csv_path, index = False, header = False)
+
+    # Create/Update the h5 file
+    convertcsv2h5(config_path, userfeedback=userfeedback)
 
 def analyze_videos_converth5_to_csv(video_folder, videotype=".mp4", listofvideos=False):
     """

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -332,14 +332,14 @@ def CreateVideoSlow(
                             ax.scatter(
                                 df_x[ind][max(0, index - trailpoints) : index],
                                 df_y[ind][max(0, index - trailpoints) : index],
-                                s=dotsize ** 2,
+                                s=dotsize**2,
                                 color=color,
                                 alpha=alphavalue * 0.75,
                             )
                         ax.scatter(
                             df_x[ind, index],
                             df_y[ind, index],
-                            s=dotsize ** 2,
+                            s=dotsize**2,
                             color=color,
                             alpha=alphavalue,
                         )
@@ -967,7 +967,7 @@ def create_video_with_keypoints_only(
     plt.switch_backend("agg")
     fig = plt.figure(frameon=False, figsize=(nx / dpi, ny / dpi))
     ax = fig.add_subplot(111)
-    scat = ax.scatter([], [], s=dotsize ** 2, alpha=alpha)
+    scat = ax.scatter([], [], s=dotsize**2, alpha=alpha)
     coords = xyp[0, :, :2]
     coords[xyp[0, :, 2] < pcutoff] = np.nan
     scat.set_offsets(coords)

--- a/dlc.py
+++ b/dlc.py
@@ -7,6 +7,7 @@ Please see AUTHORS for contributors.
 https://github.com/DeepLabCut/DeepLabCut/blob/master/AUTHORS
 Licensed under GNU Lesser General Public License v3.0
 """
+
 from deeplabcut import cli
 
 

--- a/examples/testscript.py
+++ b/examples/testscript.py
@@ -181,7 +181,11 @@ if __name__ == "__main__":
         path_config_file,
         plotting=True,
         per_keypoint_evaluation=True,
-        snapshots_to_evaluate=["snapshot-3", "snapshot-5", "snapshot-6"],  # snapshot-5 intentionally missing :)
+        snapshots_to_evaluate=[
+            "snapshot-3",
+            "snapshot-5",
+            "snapshot-6",
+        ],  # snapshot-5 intentionally missing :)
     )
     # deeplabcut.evaluate_network(path_config_file,plotting=True,trainingsetindex=33)
     print("CUT SHORT VIDEO AND ANALYZE (with dynamic cropping!)")

--- a/tests/test_auxfun_models.py
+++ b/tests/test_auxfun_models.py
@@ -37,7 +37,5 @@ class CheckForWeightsTestCase(unittest.TestCase):
                     )
 
     def test_bad_modeltype(self):
-        actual_path = check_for_weights(
-            "dummymodel", "nonexistentpath"
-        )
+        actual_path = check_for_weights("dummymodel", "nonexistentpath")
         self.assertEqual(actual_path, "nonexistentpath")

--- a/tests/test_auxiliaryfunctions.py
+++ b/tests/test_auxiliaryfunctions.py
@@ -239,13 +239,14 @@ def mock_snapshot_folder(tmp_path):
     folder.mkdir()
 
     # mock files
-    snapshot_files = ["snapshot-4.index",
-                      "snapshot-5.index",
-                      "snapshot-6.index",
-                      "snapshot-3.data-00000-of-00001",
-                      "snapshot-3.index",
-                      "snapshot-3.meta",
-                      ]
+    snapshot_files = [
+        "snapshot-4.index",
+        "snapshot-5.index",
+        "snapshot-6.index",
+        "snapshot-3.data-00000-of-00001",
+        "snapshot-3.index",
+        "snapshot-3.meta",
+    ]
     for file_name in snapshot_files:
         (folder / file_name).touch()
 

--- a/tests/test_crossvalutils.py
+++ b/tests/test_crossvalutils.py
@@ -103,8 +103,8 @@ def test_benchmark_paf_graphs_montblanc(evaluation_data_and_metadata_montblanc):
     np.testing.assert_equal(
         results[1].loc["purity"].to_numpy().squeeze(),
         [
-            results_gt[0][6][('purity', 'mean')],
-            results_gt[0][6][('purity', 'std')],
+            results_gt[0][6][("purity", "mean")],
+            results_gt[0][6][("purity", "std")],
         ],
     )
     vals = [
@@ -116,9 +116,9 @@ def test_benchmark_paf_graphs_montblanc(evaluation_data_and_metadata_montblanc):
     np.testing.assert_equal(
         vals,
         [
-            results_gt[0][6][('mAP_train', 'mean')],
-            results_gt[0][6][('mAR_train', 'mean')],
-            results_gt[0][6][('mAP_test', 'mean')],
-            results_gt[0][6][('mAR_test', 'mean')],
+            results_gt[0][6][("mAP_train", "mean")],
+            results_gt[0][6][("mAR_train", "mean")],
+            results_gt[0][6][("mAP_test", "mean")],
+            results_gt[0][6][("mAR_test", "mean")],
         ],
     )

--- a/tests/test_dataset_augmentation.py
+++ b/tests/test_dataset_augmentation.py
@@ -98,7 +98,10 @@ def test_keypoint_horizontal_flip(
         keypoints=list(map(str, range(12))),
         symmetric_pairs=pairs,
     )
-    keypoints_aug = aug(images=[sample_image], keypoints=[sample_keypoints],)[
+    keypoints_aug = aug(
+        images=[sample_image],
+        keypoints=[sample_keypoints],
+    )[
         1
     ][0]
     temp = keypoints_aug.reshape((3, 12, 2))
@@ -124,7 +127,9 @@ def test_keypoint_horizontal_flip_with_nans(
     keypoints_aug = aug(
         images=[sample_image],
         keypoints=[sample_keypoints],
-    )[1][0]
+    )[
+        1
+    ][0]
     temp = keypoints_aug.reshape((3, 12, 2))
     for pair in pairs:
         temp[:, pair] = temp[:, pair[::-1]]

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -167,7 +167,7 @@ def test_get_available_requested_snapshots_ok():
         requested_snapshots=requested,
         available_snapshots=available,
     )
-    assert snapshots == ['snapshot-2']
+    assert snapshots == ["snapshot-2"]
 
 
 def test_get_available_requested_snapshots_error():
@@ -188,14 +188,14 @@ def test_get_snapshots_by_index_int_ok():
         idx=2,
         available_snapshots=available,
     )
-    assert snapshots == ['snapshot-3']
+    assert snapshots == ["snapshot-3"]
 
     # negative int
     snapshots = get_snapshots_by_index(
         idx=-2,
         available_snapshots=available,
     )
-    assert snapshots == ['snapshot-2']
+    assert snapshots == ["snapshot-2"]
 
     # all snapshots
     snapshots = get_snapshots_by_index(

--- a/tests/test_inferenceutils.py
+++ b/tests/test_inferenceutils.py
@@ -107,7 +107,7 @@ def test_link():
     j1 = inferenceutils.Joint(pos1, conf, idx=idx1)
     j2 = inferenceutils.Joint(pos2, conf, idx=idx2)
     link = inferenceutils.Link(j1, j2)
-    assert link.confidence == conf ** 2
+    assert link.confidence == conf**2
     assert link.idx == (idx1, idx2)
     assert link.to_vector() == [*pos1, *pos2]
 

--- a/tests/test_pose_multianimal_imgaug.py
+++ b/tests/test_pose_multianimal_imgaug.py
@@ -74,7 +74,9 @@ def test_get_batch(ma_dataset):
             == len(data_items)
             == batch_size
         )
-        for data_item, joint_id, batch_joint in zip(data_items, joint_ids, batch_joints):
+        for data_item, joint_id, batch_joint in zip(
+            data_items, joint_ids, batch_joints
+        ):
             assert len(data_item.joints) == len(joint_id)
             assert len(batch_joint) == len(np.concatenate(joint_id))
             start = 0


### PR DESCRIPTION
A new Swap identities button was added to the track refinement GUI. Two text boxes were added to choose the animal identities you want to swap, and some options to select the frames to swap:
- A time window selected with the flags (when there are two flags fixed)
- A single frame (when there's a single flag fix)
- And from the current frame till the end (when there are no flags fixed).

Also, a function called `adapt_labeled_data_to_new_project` was added, it allows you to adapt up to some point old dataset, for example, if you have an old dataset with some body parts and now you want to add body parts to the project, this function keeps the old points while allowing the new ones to be labeled. It was useful for me.