### PR TITLE
Location Refinement for Top-Down models

### DIFF
--- a/deeplabcut/gui/tabs/analyze_videos.py
+++ b/deeplabcut/gui/tabs/analyze_videos.py
@@ -330,13 +330,13 @@ class AnalyzeVideos(DefaultTab):
         shuffle = self.root.shuffle_value
 
         videos = list(self.files)
-        save_as_csv = self.save_as_csv.checkState() == Qt.Checked
-        save_as_nwb = self.save_as_nwb.checkState() == Qt.Checked
-        filter_data = self.filter_predictions.checkState() == Qt.Checked
+        save_as_csv = self.save_as_csv.isChecked()
+        save_as_nwb = self.save_as_nwb.isChecked()
+        filter_data = self.filter_predictions.isChecked()
         videotype = self.video_selection_widget.videotype_widget.currentText()
         try:
             create_video_all_detections = (
-                self.create_detections_video_checkbox.checkState() == Qt.Checked
+                self.create_detections_video_checkbox.isChecked()
             )
         except AttributeError:
             create_video_all_detections = False
@@ -361,12 +361,11 @@ class AnalyzeVideos(DefaultTab):
                 track_method=track_method,
             )
 
-        if self.plot_trajectories.checkState() == Qt.Checked:
+        if self.plot_trajectories.isChecked():
             bdpts = self.bodyparts_list_widget.selected_bodyparts
             self.root.logger.debug(
                 f"Selected body parts for plot_trajectories: {bdpts}"
             )
-            showfig = self.show_trajectory_plots.checkState() == Qt.Checked
             deeplabcut.plot_trajectories(
                 config,
                 videos=videos,
@@ -374,7 +373,7 @@ class AnalyzeVideos(DefaultTab):
                 videotype=videotype,
                 shuffle=shuffle,
                 filtered=filter_data,
-                showfigures=showfig,
+                showfigures=self.show_trajectory_plots.isChecked(),
                 track_method=track_method,
             )
 

--- a/deeplabcut/pose_estimation_pytorch/config/base/head_topdown.yaml
+++ b/deeplabcut/pose_estimation_pytorch/config/base/head_topdown.yaml
@@ -4,17 +4,22 @@ predictor:
   type: HeatmapPredictor
   apply_sigmoid: false
   clip_scores: true
-  location_refinement: false
+  location_refinement: true
+  locref_std: 7.2801
 target_generator:
   type: HeatmapGaussianGenerator
   num_heatmaps: "num_bodyparts"
   pos_dist_thresh: 17
   heatmap_mode: KEYPOINT
-  generate_locref: false
+  generate_locref: true
+  locref_std: 7.2801
 criterion:
   heatmap:
     type: WeightedMSECriterion
     weight: 1.0
+  locref:
+    type: WeightedHuberCriterion
+    weight: 0.05
 heatmap_config:
   channels:
   - "backbone_output_channels"
@@ -22,4 +27,12 @@ heatmap_config:
   strides: []
   final_conv:
     out_channels: "num_bodyparts"
+    kernel_size: 1
+locref_config:
+  channels:
+    - "backbone_output_channels"
+  kernel_size: []
+  strides: []
+  final_conv:
+    out_channels: "num_bodyparts x 2"
     kernel_size: 1


### PR DESCRIPTION
Location refinement is also need for top-down models, especially ResNets - otherwise sub-pixel accuracy cannot be obtained (which makes the pose estimation task too difficult for models like a stride 16 ResNet50).