### PR TITLE
batched inference

### DIFF
--- a/deeplabcut/compat.py
+++ b/deeplabcut/compat.py
@@ -861,7 +861,7 @@ def analyze_videos(
             trainingsetindex=trainingsetindex,
             save_as_csv=save_as_csv,
             destfolder=destfolder,
-            batchsize=batchsize,
+            batch_size=batchsize,
             modelprefix=modelprefix,
             auto_track=auto_track,
             identity_only=identity_only,

--- a/deeplabcut/create_project/new.py
+++ b/deeplabcut/create_project/new.py
@@ -280,6 +280,7 @@ def create_new_project(
     cfg_file[
         "batch_size"
     ] = 8  # batch size during inference (video - analysis); see https://www.biorxiv.org/content/early/2018/10/30/457242
+    cfg_file["detector_batch_size"] = 1
     cfg_file["corner2move2"] = (50, 50)
     cfg_file["move2corner"] = True
     cfg_file["skeleton_color"] = "black"

--- a/deeplabcut/modelzoo/project_configs/superanimal_topviewmouse.yaml
+++ b/deeplabcut/modelzoo/project_configs/superanimal_topviewmouse.yaml
@@ -7,8 +7,7 @@ identity:
 
 
 # Project path (change when moving around)
-project_path: 
-  /Users/niels/Documents/upamathis/repos/DeepLabCut/deeplabcut/modelzoo/project_configs
+project_path:
 
 
 # Default DeepLabCut engine to use for shuffle creation (either pytorch or tensorflow)
@@ -45,9 +44,6 @@ bodyparts:
 - right_hip
 - tail_end
 - head_midpoint
-
-
-# Fraction of video to start/stop when extracting frames for labeling/refinement
 
 
 # Fraction of video to start/stop when extracting frames for labeling/refinement

--- a/deeplabcut/modelzoo/project_configs/superanimal_topviewmouse.yaml
+++ b/deeplabcut/modelzoo/project_configs/superanimal_topviewmouse.yaml
@@ -7,7 +7,8 @@ identity:
 
 
 # Project path (change when moving around)
-project_path:
+project_path: 
+  /Users/niels/Documents/upamathis/repos/DeepLabCut/deeplabcut/modelzoo/project_configs
 
 
 # Default DeepLabCut engine to use for shuffle creation (either pytorch or tensorflow)
@@ -44,6 +45,9 @@ bodyparts:
 - right_hip
 - tail_end
 - head_midpoint
+
+
+# Fraction of video to start/stop when extracting frames for labeling/refinement
 
 
 # Fraction of video to start/stop when extracting frames for labeling/refinement

--- a/deeplabcut/modelzoo/video_inference.py
+++ b/deeplabcut/modelzoo/video_inference.py
@@ -41,6 +41,7 @@ def video_inference_superanimal(
     video_adapt: bool = False,
     plot_trajectories: bool = False,
     batch_size: int = 1,
+    detector_batch_size: int = 1,
     pcutoff: float = 0.1,
     adapt_iterations: int = 1000,
     pseudo_threshold: float = 0.1,
@@ -94,6 +95,9 @@ def video_inference_superanimal(
 
     batch_size (int):
         The batch size to use for video inference. Only for PyTorch models.
+
+    detector_batch_size (int):
+        The batch size to use for the detector during video inference. Only for PyTorch.
 
     pcutoff (float):
         The p-value cutoff for the confidence of the prediction. The default is 0.1.
@@ -296,6 +300,7 @@ def video_inference_superanimal(
                 pcutoff,
                 device=device,
                 batch_size=batch_size,
+                detector_batch_size=detector_batch_size,
                 dest_folder=dest_folder,
                 customized_pose_checkpoint=customized_pose_checkpoint,
                 customized_detector_checkpoint=customized_detector_checkpoint,
@@ -437,6 +442,7 @@ video adaptation batch size: {video_adapt_batch_size}"""
             pcutoff,
             device=device,
             batch_size=batch_size,
+            detector_batch_size=detector_batch_size,
             dest_folder=dest_folder,
             customized_pose_checkpoint=customized_pose_checkpoint,
             customized_detector_checkpoint=customized_detector_checkpoint,

--- a/deeplabcut/modelzoo/video_inference.py
+++ b/deeplabcut/modelzoo/video_inference.py
@@ -40,6 +40,7 @@ def video_inference_superanimal(
     dest_folder: Optional[str] = None,
     video_adapt: bool = False,
     plot_trajectories: bool = False,
+    batch_size: int = 1,
     pcutoff: float = 0.1,
     adapt_iterations: int = 1000,
     pseudo_threshold: float = 0.1,
@@ -87,8 +88,12 @@ def video_inference_superanimal(
     video_adapt (bool):
         Whether to perform video adaptation. The default is False.
         You only need to perform it on one video because the adaptation generalizes to all videos that are similar.
+
     plot_trajectories (bool):
         Whether to plot the trajectories. The default is False.
+
+    batch_size (int):
+        The batch size to use for video inference. Only for PyTorch models.
 
     pcutoff (float):
         The p-value cutoff for the confidence of the prediction. The default is 0.1.
@@ -290,6 +295,7 @@ def video_inference_superanimal(
                 max_individuals,
                 pcutoff,
                 device=device,
+                batch_size=batch_size,
                 dest_folder=dest_folder,
                 customized_pose_checkpoint=customized_pose_checkpoint,
                 customized_detector_checkpoint=customized_detector_checkpoint,
@@ -430,6 +436,7 @@ video adaptation batch size: {video_adapt_batch_size}"""
             max_individuals,
             pcutoff,
             device=device,
+            batch_size=batch_size,
             dest_folder=dest_folder,
             customized_pose_checkpoint=customized_pose_checkpoint,
             customized_detector_checkpoint=customized_detector_checkpoint,

--- a/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
@@ -161,7 +161,8 @@ def analyze_videos(
     detector_snapshot_index: int | str | None = None,
     device: str | None = None,
     destfolder: str | None = None,
-    batchsize: int | None = None,
+    batch_size: int | None = None,
+    detector_batch_size: int | None = None,
     modelprefix: str = "",
     transform: A.Compose | None = None,
     auto_track: bool | None = True,
@@ -171,7 +172,6 @@ def analyze_videos(
     """Makes prediction based on a trained network.
 
     # TODO:
-        - allow batch size greater than 1
         - other options missing options such as shelve
         - pass detector path or detector runner
 
@@ -206,8 +206,10 @@ def analyze_videos(
             snapshot to use, used in the same way as ``snapshot_index``
         modelprefix: directory containing the deeplabcut models to use when evaluating
             the network. By default, they are assumed to exist in the project folder.
-        batchsize: the batch size to use for inference. Takes the value from the
-            PyTorch config as a default
+        batch_size: the batch size to use for inference. Takes the value from the
+            PyTorch config as a default.
+        detector_batch_size: the batch size to use for detector inference. Takes the
+            value from the PyTorch config as a default.
         transform: Optional custom transforms to apply to the video
         overwrite: Overwrite any existing videos
         auto_track: By default, tracking and stitching are automatically performed,
@@ -261,6 +263,9 @@ def analyze_videos(
     if device is not None:
         model_cfg["device"] = device
 
+    if batch_size is None:
+        batch_size = model_cfg["train_settings"]["batch_size"]
+
     snapshot = get_model_snapshots(snapshot_index, train_folder, pose_task)[0]
     print(f"Analyzing videos with {snapshot.path}")
     detector_path, detector_snapshot = None, None
@@ -271,6 +276,9 @@ def analyze_videos(
                 "snapshot! Please specify your desired detector_snapshotindex in your "
                 "project's configuration file."
             )
+
+        if detector_batch_size is None:
+            detector_batch_size = model_cfg["detector"]["train_settings"]["batch_size"]
 
         detector_snapshot = get_model_snapshots(
             detector_snapshot_index, train_folder, Task.DETECT
@@ -291,8 +299,10 @@ def analyze_videos(
         max_individuals=max_num_animals,
         num_bodyparts=len(bodyparts),
         num_unique_bodyparts=len(unique_bodyparts),
+        batch_size=batch_size,
         with_identity=with_identity,
         transform=transform,
+        detector_batch_size=detector_batch_size,
         detector_path=detector_path,
         detector_transform=None,
     )

--- a/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
@@ -206,9 +206,9 @@ def analyze_videos(
         modelprefix: directory containing the deeplabcut models to use when evaluating
             the network. By default, they are assumed to exist in the project folder.
         batch_size: the batch size to use for inference. Takes the value from the
-            PyTorch config as a default.
+            project config as a default.
         detector_batch_size: the batch size to use for detector inference. Takes the
-            value from the PyTorch config as a default.
+            value from the project config as a default.
         transform: Optional custom transforms to apply to the video
         overwrite: Overwrite any existing videos
         auto_track: By default, tracking and stitching are automatically performed,

--- a/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
@@ -118,12 +118,11 @@ def video_inference(
         if detector_runner is None:
             raise ValueError("Must use a detector for top-down video analysis")
 
-        print("Running Detector")
+        print(f"Running detector with batch size {detector_runner.batch_size}")
         bbox_predictions = detector_runner.inference(images=tqdm(video))
-
         video.set_context(bbox_predictions)
 
-    print("Running Pose Prediction")
+    print(f"Running pose prediction with batch size {pose_runner.batch_size}")
     predictions = pose_runner.inference(images=tqdm(video))
 
     if with_identity:
@@ -264,7 +263,7 @@ def analyze_videos(
         model_cfg["device"] = device
 
     if batch_size is None:
-        batch_size = model_cfg["train_settings"]["batch_size"]
+        batch_size = cfg["batch_size"]
 
     snapshot = get_model_snapshots(snapshot_index, train_folder, pose_task)[0]
     print(f"Analyzing videos with {snapshot.path}")
@@ -278,7 +277,7 @@ def analyze_videos(
             )
 
         if detector_batch_size is None:
-            detector_batch_size = model_cfg["detector"]["train_settings"]["batch_size"]
+            detector_batch_size = cfg.get("detector_batch_size", 1)
 
         detector_snapshot = get_model_snapshots(
             detector_snapshot_index, train_folder, Task.DETECT

--- a/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
@@ -336,7 +336,7 @@ def analyze_videos(
                 pytorch_config=model_cfg,
                 dlc_scorer=dlc_scorer,
                 train_fraction=train_fraction,
-                batch_size=batchsize,
+                batch_size=batch_size,
                 runtime=(runtime[0], runtime[1]),
                 video=VideoReader(str(video)),
             )

--- a/deeplabcut/pose_estimation_pytorch/apis/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/utils.py
@@ -372,9 +372,11 @@ def get_inference_runners(
     max_individuals: int,
     num_bodyparts: int,
     num_unique_bodyparts: int,
+    batch_size: int = 1,
     device: str | None = None,
     with_identity: bool = False,
     transform: A.BaseCompose | None = None,
+    detector_batch_size: int = 1,
     detector_path: str | Path | None = None,
     detector_transform: A.BaseCompose | None = None,
 ) -> tuple[InferenceRunner, InferenceRunner | None]:
@@ -386,10 +388,12 @@ def get_inference_runners(
         max_individuals: the maximum number of individuals per image
         num_bodyparts: the number of bodyparts predicted by the model
         num_unique_bodyparts: the number of unique_bodyparts predicted by the model
+        batch_size: the batch size to use for the pose model.
         with_identity: whether the pose model has an identity head
         device: if defined, overwrites the device selection from the model config
         transform: the transform for pose estimation. if None, uses the transform
             defined in the config.
+        detector_batch_size: the batch size to use for the detector
         detector_path: the path to the detector snapshot from which to load weights,
             for top-down models (if a detector runner is needed)
         detector_transform: the transform for object detection. if None, uses the
@@ -450,6 +454,7 @@ def get_inference_runners(
                 model=DETECTORS.build(detector_config),
                 device=detector_device,
                 snapshot_path=detector_path,
+                batch_size=detector_batch_size,
                 preprocessor=build_bottom_up_preprocessor(
                     color_mode=model_config["detector"]["data"]["colormode"],
                     transform=detector_transform,
@@ -464,6 +469,7 @@ def get_inference_runners(
         model=PoseModel.build(model_config["model"]),
         device=device,
         snapshot_path=snapshot_path,
+        batch_size=batch_size,
         preprocessor=pose_preprocessor,
         postprocessor=pose_postprocessor,
     )

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/inference.py
@@ -56,6 +56,7 @@ def _video_inference_superanimal(
     max_individuals: int,
     pcutoff: float,
     batch_size: int = 1,
+    detector_batch_size: int = 1,
     device: Optional[str] = None,
     dest_folder: Optional[str] = None,
     customized_pose_checkpoint: Optional[str] = None,
@@ -88,6 +89,8 @@ def _video_inference_superanimal(
             automatic device selection.
 
         batch_size: The batch size to use for video inference.
+
+        detector_batch_size: The batch size to use for the detector for video inference.
 
         dest_folder: Destination folder for the results. If not specified, the
             results are saved in the same folder as the video. Defaults to None.
@@ -146,6 +149,7 @@ def _video_inference_superanimal(
         num_bodyparts=len(config["bodyparts"]),
         num_unique_bodyparts=0,
         batch_size=batch_size,
+        detector_batch_size=detector_batch_size,
         detector_path=detector_path,
     )
     pose_task = Task(config.get("method", "BU"))

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/inference.py
@@ -55,6 +55,7 @@ def _video_inference_superanimal(
     model_name: str,
     max_individuals: int,
     pcutoff: float,
+    batch_size: int = 1,
     device: Optional[str] = None,
     dest_folder: Optional[str] = None,
     customized_pose_checkpoint: Optional[str] = None,
@@ -85,6 +86,8 @@ def _video_inference_superanimal(
             If not specified, the device is automatically determined by the
             `select_device` function. Defaults to None, which triggers
             automatic device selection.
+
+        batch_size: The batch size to use for video inference.
 
         dest_folder: Destination folder for the results. If not specified, the
             results are saved in the same folder as the video. Defaults to None.
@@ -142,6 +145,7 @@ def _video_inference_superanimal(
         max_individuals=max_individuals,
         num_bodyparts=len(config["bodyparts"]),
         num_unique_bodyparts=0,
+        batch_size=batch_size,
         detector_path=detector_path,
     )
     pose_task = Task(config.get("method", "BU"))

--- a/deeplabcut/pose_estimation_pytorch/runners/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/inference.py
@@ -51,6 +51,9 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
             postprocessor: the postprocessor to use on images after inference
         """
         super().__init__(model=model, device=device, snapshot_path=snapshot_path)
+        if not isinstance(batch_size, int) or batch_size <= 0:
+            raise ValueError(f"batch_size must be a positive integer; is {batch_size}")
+
         self.batch_size = batch_size
         self.preprocessor = preprocessor
         self.postprocessor = postprocessor

--- a/deeplabcut/pose_estimation_pytorch/runners/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/inference.py
@@ -11,7 +11,6 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from collections import defaultdict
 from pathlib import Path
 from typing import Any, Generic, Iterable
 

--- a/deeplabcut/pose_estimation_pytorch/runners/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/inference.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
+from collections import defaultdict
 from pathlib import Path
 from typing import Any, Generic, Iterable
 
@@ -35,6 +36,7 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
     def __init__(
         self,
         model: ModelType,
+        batch_size: int = 1,
         device: str = "cpu",
         snapshot_path: str | Path | None = None,
         preprocessor: Preprocessor | None = None,
@@ -49,11 +51,17 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
             postprocessor: the postprocessor to use on images after inference
         """
         super().__init__(model=model, device=device, snapshot_path=snapshot_path)
+        self.batch_size = batch_size
         self.preprocessor = preprocessor
         self.postprocessor = postprocessor
 
         if self.snapshot_path is not None and self.snapshot_path != "":
             self.load_snapshot(self.snapshot_path, self.device, self.model)
+
+        self._batch: torch.Tensor | None = None
+        self._contexts: list[dict] = []
+        self._image_batch_sizes: list[int] = []
+        self._predictions: list = []
 
     @abstractmethod
     def predict(self, inputs: torch.Tensor) -> list[dict[str, dict[str, np.ndarray]]]:
@@ -94,24 +102,86 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
 
         results = []
         for data in images:
-            if isinstance(data, (str, np.ndarray)):
-                input_image, context = data, {}
-            else:
-                input_image, context = data
+            self._prepare_inputs(data)
+            self._process_full_batches()
+            results += self._extract_results()
 
-            if self.preprocessor is not None:
-                # TODO: input batch should also be able to be a dict[str, torch.Tensor]
-                input_image, context = self.preprocessor(input_image, context)
+        # Process the last batch even if not full
+        if self._inputs_waiting_for_processing():
+            self._process_batch()
+            results += self._extract_results()
 
-            image_predictions = self.predict(input_image)
+        return results
+
+    def _prepare_inputs(
+        self, data: str | np.ndarray | tuple[str | np.ndarray, dict],
+    ) -> None:
+        """
+        Prepares inputs for an image and adds them to the data ready to be processed
+        """
+        if isinstance(data, (str, np.ndarray)):
+            inputs, context = data, {}
+        else:
+            inputs, context = data
+
+        if self.preprocessor is not None:
+            inputs, context = self.preprocessor(inputs, context)
+        else:
+            inputs = torch.as_tensor(inputs)
+
+        if self._batch is None:
+            self._batch = inputs
+        else:
+            self._batch = torch.cat([self._batch, inputs], dim=0)
+
+        self._contexts.append(context)
+        self._image_batch_sizes.append(len(inputs))
+
+    def _process_full_batches(self) -> None:
+        """Processes prepared inputs in batches of the desired batch size."""
+        while self._batch is not None and len(self._batch) >= self.batch_size:
+            self._process_batch()
+
+    def _extract_results(self) -> list:
+        """Obtains results that were obtained from processing a batch."""
+        results = []
+        while (
+            len(self._image_batch_sizes) > 0
+            and len(self._predictions) >= self._image_batch_sizes[0]
+        ):
+            num_predictions = self._image_batch_sizes[0]
+            image_predictions = self._predictions[:num_predictions]
+            context = self._contexts[0]
+
             if self.postprocessor is not None:
                 # TODO: Should we return context?
                 # TODO: typing update - the post-processor can remove a dict level
                 image_predictions, _ = self.postprocessor(image_predictions, context)
 
+            self._contexts = self._contexts[1:]
+            self._image_batch_sizes = self._image_batch_sizes[1:]
+            self._predictions = self._predictions[num_predictions:]
             results.append(image_predictions)
 
         return results
+
+    def _process_batch(self) -> None:
+        """
+        Processes a batch. There must be inputs waiting to be processed before this is
+        called, otherwise this method will raise an error.
+        """
+        batch = self._batch[:self.batch_size]
+        self._predictions += self.predict(batch)
+
+        # remove processed inputs from batch
+        if len(self._batch) <= self.batch_size:
+            self._batch = None
+        else:
+            self._batch = self._batch[self.batch_size:]
+
+    def _inputs_waiting_for_processing(self) -> bool:
+        """Returns: Whether there are inputs which have not yet been processed"""
+        return self._batch is not None and len(self._batch) > 0
 
 
 class PoseInferenceRunner(InferenceRunner[PoseModel]):
@@ -134,24 +204,19 @@ class PoseInferenceRunner(InferenceRunner[PoseModel]):
                     "unique_bodypart": "poses": np.ndarray},
             ]
         """
-        # TODO: iterates over batch one element at a time
-        batch_size = 1
-        batch_predictions = []
-        for i in range(0, len(inputs), batch_size):
-            batch_inputs = inputs[i : i + batch_size]
-            batch_inputs = batch_inputs.to(self.device)
-            batch_outputs = self.model(batch_inputs)
-            raw_predictions = self.model.get_predictions(batch_outputs)
-
-            for b in range(batch_size):
-                image_predictions = {}
-                for head, head_outputs in raw_predictions.items():
-                    image_predictions[head] = {}
-                    for pred_name, pred in head_outputs.items():
-                        image_predictions[head][pred_name] = pred[b].cpu().numpy()
-                batch_predictions.append(image_predictions)
-
-        return batch_predictions
+        outputs = self.model(inputs.to(self.device))
+        raw_predictions = self.model.get_predictions(outputs)
+        predictions = [
+            {
+                head: {
+                    pred_name: pred[b].cpu().numpy()
+                    for pred_name, pred in head_outputs.items()
+                }
+                for head, head_outputs in raw_predictions.items()
+            }
+            for b in range(len(inputs))
+        ]
+        return predictions
 
 
 class DetectorInferenceRunner(InferenceRunner[BaseDetector]):
@@ -179,31 +244,23 @@ class DetectorInferenceRunner(InferenceRunner[BaseDetector]):
                     "unique_bodypart": "poses": np.ndarray},
             ]
         """
-        # TODO: iterates over batch one element at a time
-        batch_size = 1
-        batch_predictions = []
-        for i in range(0, len(inputs), batch_size):
-            batch_inputs = inputs[i : i + batch_size]
-            batch_inputs = batch_inputs.to(self.device)
-            _, raw_predictions = self.model(batch_inputs)
-            for b, item in enumerate(raw_predictions):
-                # take the top-k bounding boxes as individuals
-                batch_predictions.append(
-                    {
-                        "detection": {
-                            "bboxes": item["boxes"]
-                            .cpu()
-                            .numpy()
-                            .reshape(-1, 4),
-                            "scores": item["scores"]
-                            .cpu()
-                            .numpy()
-                            .reshape(-1),
-                        }
-                    }
-                )
-
-        return batch_predictions
+        _, raw_predictions = self.model(inputs.to(self.device))
+        predictions = [
+            {
+                "detection": {
+                    "bboxes": item["boxes"]
+                    .cpu()
+                    .numpy()
+                    .reshape(-1, 4),
+                    "scores": item["scores"]
+                    .cpu()
+                    .numpy()
+                    .reshape(-1),
+                }
+            }
+            for item in raw_predictions
+        ]
+        return predictions
 
 
 def build_inference_runner(
@@ -211,6 +268,7 @@ def build_inference_runner(
     model: nn.Module,
     device: str,
     snapshot_path: str | Path,
+    batch_size: int = 1,
     preprocessor: Preprocessor | None = None,
     postprocessor: Postprocessor | None = None,
 ) -> InferenceRunner:
@@ -222,6 +280,7 @@ def build_inference_runner(
         model: the model to run
         device: the device to use (e.g. {'cpu', 'cuda:0', 'mps'})
         snapshot_path: the snapshot from which to load the weights
+        batch_size: the batch size to use to run inference
         preprocessor: the preprocessor to use on images before inference
         postprocessor: the postprocessor to use on images after inference
 
@@ -232,6 +291,7 @@ def build_inference_runner(
         model=model,
         device=device,
         snapshot_path=snapshot_path,
+        batch_size=batch_size,
         preprocessor=preprocessor,
         postprocessor=postprocessor,
     )

--- a/deeplabcut/pose_estimation_pytorch/runners/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/inference.py
@@ -132,13 +132,17 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
         else:
             inputs = torch.as_tensor(inputs)
 
+        self._contexts.append(context)
+        self._image_batch_sizes.append(len(inputs))
+
+        # skip when there are no inputs for an image
+        if len(inputs) == 0:
+            return
+
         if self._batch is None:
             self._batch = inputs
         else:
             self._batch = torch.cat([self._batch, inputs], dim=0)
-
-        self._contexts.append(context)
-        self._image_batch_sizes.append(len(inputs))
 
     def _process_full_batches(self) -> None:
         """Processes prepared inputs in batches of the desired batch size."""

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -141,6 +141,7 @@ default_augmenter:
 snapshotindex:
 detector_snapshotindex:
 batch_size:
+detector_batch_size:
 \n
 # Cropping Parameters (for analysis and outlier frame detection)
 cropping:
@@ -211,6 +212,12 @@ def read_config(configname):
                 if cfg.get("engine") is None:
                     cfg["engine"] = Engine.TF.aliases[0]
                     write_config(configname, cfg)
+
+                if cfg.get("detector_snapshotindex") is None:
+                    cfg["detector_snapshotindex"] = -1
+
+                if cfg.get("detector_batch_size") is None:
+                    cfg["detector_batch_size"] = 1
 
                 if cfg["project_path"] != curr_dir:
                     cfg["project_path"] = curr_dir

--- a/tests/pose_estimation_pytorch/runners/test_runners_inference.py
+++ b/tests/pose_estimation_pytorch/runners/test_runners_inference.py
@@ -1,0 +1,138 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Tests inference runners"""
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+import torch
+
+import deeplabcut.pose_estimation_pytorch.data.postprocessor as post
+import deeplabcut.pose_estimation_pytorch.data.preprocessor as prep
+import deeplabcut.pose_estimation_pytorch.runners.inference as inference
+
+
+class MockInferenceRunner(inference.InferenceRunner):
+    """Mocks the predict function for an inference runner"""
+
+    def __init__(
+        self,
+        batch_size: int = 1,
+        preprocessor: prep.Preprocessor | None = None,
+        postprocessor: post.Postprocessor | None = None,
+    ) -> None:
+        super().__init__(
+            model=Mock(),
+            batch_size=batch_size,
+            preprocessor=preprocessor,
+            postprocessor=postprocessor,
+        )
+        self.batch_shapes = []
+
+    def predict(self, inputs: torch.Tensor) -> list[dict[str, dict[str, np.ndarray]]]:
+        self.batch_shapes.append(tuple(inputs.shape))
+        return [  # return first elem of input
+            {"mock": {"index": i[0, 0, 0].detach().numpy()}}
+            for i in inputs
+        ]
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 4, 8])
+def test_mock_bottom_up(batch_size):
+    h, w = 640, 480
+    images = [i * np.ones((1, 3, h, w)) for i in range(10)]
+
+    runner = MockInferenceRunner(batch_size=batch_size)
+    predictions = runner.inference(images)
+
+    print()
+    print(f"Num images: {len(predictions)}")
+    print(f"Num predictions: {len(predictions)}")
+    print(f"Batch shapes: {runner.batch_shapes}")
+    print(80 * "-")
+    for i in images:
+        print(i[0, 0, 0, 0])
+        print("----")
+    print(80 * "-")
+    for p in predictions:
+        print(p)
+        print("----")
+
+    _check_batch_shapes(batch_size, h, w, runner.batch_shapes)
+    assert len(images) == len(predictions)
+    for i, p in zip(images, predictions):
+        assert len(p) == 1  # only 1 output per image
+        assert i[0, 0, 0, 0] == p[0]["mock"]["index"]
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 4, 8])
+@pytest.mark.parametrize(
+    "detections_per_image",
+    [
+        [1, 1, 1, 1, 1],
+        [1, 2, 3, 4],
+        [3, 4, 2, 1, 4],
+        [4, 23, 5, 20, 64, 100]
+    ]
+)
+def test_mock_top_down(batch_size, detections_per_image):
+    h, w = 8, 8
+    images = []
+    for index, num_detections in enumerate(detections_per_image):
+        detections = np.concatenate(
+            [
+                (1_000_000 * (index + 1) + i) * np.ones((1, 3, h, w))
+                for i in range(num_detections)
+            ],
+            axis=0,
+        )
+        images.append(detections)
+
+    runner = MockInferenceRunner(batch_size=batch_size)
+    predictions = runner.inference(images)
+
+    print()
+    print(f"Num images: {len(predictions)}")
+    print(f"Num predictions: {len(predictions)}")
+    print(80 * "-")
+    for i in images:
+        for i_det in i:
+            print(i_det.shape)
+            print(i_det[0, 0, 0])
+        print("----")
+
+    print(80 * "-")
+    for p in predictions:
+        print(p)
+        print("----")
+
+    _check_batch_shapes(batch_size, h, w, runner.batch_shapes)
+
+    assert len(images) == len(predictions)
+    for i, p in zip(images, predictions):
+        assert len(p) == len(i)  # one prediction per input
+        for i_det, p_det in zip(i, p):
+            print(i_det.shape)
+            print(p_det["mock"]["index"])
+            assert i_det[0, 0, 0] == p_det["mock"]["index"]
+
+
+def _check_batch_shapes(batch_size, h, w, batch_shapes) -> None:
+    for b in batch_shapes[:-1]:
+        assert b[0] == batch_size
+        assert b[1] == 3
+        assert b[2] == h
+        assert b[3] == w
+
+    assert batch_shapes[-1][0] <= batch_size
+    assert batch_shapes[-1][1] <= 3
+    assert batch_shapes[-1][2] <= h
+    assert batch_shapes[-1][3] <= w

--- a/tests/pose_estimation_pytorch/runners/test_runners_inference.py
+++ b/tests/pose_estimation_pytorch/runners/test_runners_inference.py
@@ -78,6 +78,8 @@ def test_mock_bottom_up(batch_size):
     "detections_per_image",
     [
         [1, 1, 1, 1, 1],
+        [0, 1, 0, 1, 1],  # some frames might not have predictions
+        [0, 0, 0, 5, 2],
         [1, 2, 3, 4],
         [3, 4, 2, 1, 4],
         [4, 23, 5, 20, 64, 100]
@@ -87,13 +89,17 @@ def test_mock_top_down(batch_size, detections_per_image):
     h, w = 8, 8
     images = []
     for index, num_detections in enumerate(detections_per_image):
-        detections = np.concatenate(
-            [
-                (1_000_000 * (index + 1) + i) * np.ones((1, 3, h, w))
-                for i in range(num_detections)
-            ],
-            axis=0,
-        )
+        if num_detections == 0:
+            detections = np.zeros((0, 3, 1, 1))  # random shape when no detections
+        else:
+            detections = np.concatenate(
+                [
+                    (1_000_000 * (index + 1) + i) * np.ones((1, 3, h, w))
+                    for i in range(num_detections)
+                ],
+                axis=0,
+            )
+
         images.append(detections)
 
     runner = MockInferenceRunner(batch_size=batch_size)


### PR DESCRIPTION
Implemented batched inference for video analysis.

- updated the InferenceRunner classes to support batched inference
- added a `detector_batch_size` attribute to the project `config.yaml` (with default value 1)
- added `batch_size` and `detector_batch_size` parameters to `video_inference_superanimal`
- added `batch_size` and `detector_batch_size` parameters to `analyze_videos ` (with default value `None`, which means that the batch sizes used are the ones defined in the `config.yaml`)
- added tests to ensure all frames are processed for top-down and bottom-up models