### PR TITLE
Bug fixes: `find_closest_neighbors` + ellipse tracking

### DIFF
--- a/deeplabcut/core/crossvalutils.py
+++ b/deeplabcut/core/crossvalutils.py
@@ -75,7 +75,7 @@ def find_closest_neighbors(
     dist, inds = tree.query(query, k=k)
     idx = np.argsort(dist[:, 0])
     neighbors = np.full(len(query), -1, dtype=int)
-    picked = set()
+    picked = {tree.n}
     for i, ind in enumerate(inds[idx]):
         for j in ind:
             if j not in picked:

--- a/deeplabcut/core/trackingutils.py
+++ b/deeplabcut/core/trackingutils.py
@@ -112,6 +112,9 @@ class Ellipse:
         max_dist = max(
             self.height, self.width, other_ellipse.height, other_ellipse.width
         )
+        if max_dist == 0:
+            return 0
+
         dist = math.sqrt(
             (self.x - other_ellipse.x) ** 2 + (self.y - other_ellipse.y) ** 2
         )


### PR DESCRIPTION
This pull request makes two bug fixes:

In `deeplabcut/core/crossvalutils.py` - `find_closest_neighbors`
- The [cKDTree.query](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.cKDTree.query.html) method returns `n` (the size of the input data) for missing nieghbors (_"Missing neighbors are indicated with `self.n`."_). This wasn't taken into account, so this value could be returned in the index list, leading to an out-of-bounds error.

In `deeplabcut/core/trackingutils.py` - `calc_similarity_with`
- Zero division as we didn't check the height/width of ellipses was greater than 0
