### PR TITLE
bug fix: find closest neighbors

### DIFF
--- a/deeplabcut/core/crossvalutils.py
+++ b/deeplabcut/core/crossvalutils.py
@@ -82,7 +82,7 @@ def find_closest_neighbors(
                 picked.add(j)
                 neighbors[idx[i]] = j
                 break
-        if len(picked) == n_preds:
+        if len(picked) == (n_preds + 1):
             break
     return neighbors
 


### PR DESCRIPTION
Bug fix: need to pick one more neighbor as the "picked" set now contains the `n+1`th element (as fixed by #2709).