### PR TITLE
Make 3D Triangulate possible with pytorch_dlc branch and MA project

### DIFF
--- a/deeplabcut/pose_estimation_3d/triangulation.py
+++ b/deeplabcut/pose_estimation_3d/triangulation.py
@@ -89,7 +89,7 @@ def triangulate(
     To analyze only a few pair of videos:
     >>> deeplabcut.triangulate(config,[['C:\\yourusername\\rig-95\\Videos\\video1-camera-1.avi','C:\\yourusername\\rig-95\\Videos\\video1-camera-2.avi'],['C:\\yourusername\\rig-95\\Videos\\video2-camera-1.avi','C:\\yourusername\\rig-95\\Videos\\video2-camera-2.avi']])
     """
-    from deeplabcut.pose_estimation_pytorch import analyze_videos
+    from deeplabcut.compat import analyze_videos
     from deeplabcut.post_processing import filtering
 
     cfg_3d = auxiliaryfunctions.read_config(config)
@@ -270,6 +270,7 @@ def triangulate(
                             videotype=videotype,
                             shuffle=shuffle,
                             trainingsetindex=trainingsetindex,
+                            gputouse=gputouse,
                             destfolder=destfolder,
                         )
                         scorer_name[cam_names[j]] = DLCscorer
@@ -299,6 +300,7 @@ def triangulate(
                         videotype=videotype,
                         shuffle=shuffle,
                         trainingsetindex=trainingsetindex,
+                        gputouse=gputouse,
                         destfolder=destfolder,
                     )
                     scorer_name[cam_names[j]] = DLCscorer

--- a/deeplabcut/pose_estimation_3d/triangulation.py
+++ b/deeplabcut/pose_estimation_3d/triangulation.py
@@ -11,18 +11,13 @@
 
 import os
 from pathlib import Path
-
 import cv2
 import numpy as np
 import pandas as pd
 
-# from matplotlib.axes._axes import _log as matplotlib_axes_logger
-
 from deeplabcut.utils import auxfun_multianimal, auxiliaryfunctions
 from deeplabcut.utils import auxiliaryfunctions_3d
 from deeplabcut.core.trackingutils import TRACK_METHODS
-
-# matplotlib_axes_logger.setLevel("ERROR")
 
 
 def triangulate(

--- a/deeplabcut/utils/auxiliaryfunctions_3d.py
+++ b/deeplabcut/utils/auxiliaryfunctions_3d.py
@@ -322,12 +322,17 @@ def _associate_paired_view_tracks(tracklets1, tracklets2, F):
             _t1 = np.c_[_t1, np.ones((*_t1.shape[:2], 1))]
             _t2 = np.c_[_t2, np.ones((*_t2.shape[:2], 1))]
 
-            # cost for any point in time of t1 being the same
-            # any point in time of t2
-            cost = np.abs(np.nansum(np.matmul(_t1, F) * _t2, axis=2))
+            try:
+                # cost for any point in time of t1 being the same
+                # any point in time of t2
+                cost = np.abs(np.nansum(np.matmul(_t1, F) * _t2, axis=2))
 
-            # Get average cost of the entire track
-            cost = cost.mean()
+                # Get average cost of the entire track
+                cost = cost.mean()
+            except:
+                # typically when dim 2 differs, with uniquebodyparts
+                cost = 100000.0
+
             costs[i, j] = cost
 
     match_inds = linear_sum_assignment(np.abs(costs))


### PR DESCRIPTION
## Rationality

I proceeded with my project, and then found the `triangulate()` function dependent on TensorFlow modules. Further debugging revealed more problems relating to the 'single' individual, who has a different bodypart dimension from common individuals.

Finally, I made minor changes to make triangulation work on my dataset. These changes might also help with other 3D MA users.

## Changes

- Compute triangulated data with pose_estimation_pytorch

- Make correct MultiIndex with unique bodyparts

- adapt to DataFrame.to_hdf() changes