### PR TITLE
Adding cropping to pose_estimation_pytorch/apis/analyze_videos.py

### DIFF
--- a/deeplabcut/compat.py
+++ b/deeplabcut/compat.py
@@ -874,6 +874,7 @@ def analyze_videos(
             auto_track=auto_track,
             identity_only=identity_only,
             overwrite=False,
+            cropping=cropping,
             **torch_kwargs,
         )
 

--- a/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
@@ -225,6 +225,11 @@ def analyze_videos(
         identity_only: sub-call for auto_track. If ``True`` and animal identity was
             learned by the model, assembly and tracking rely exclusively on identity
             prediction.
+        cropping: list or None, optional, default=None
+            List of cropping coordinates as [x1, x2, y1, y2].
+            Note that the same cropping parameters will then be used for all videos.
+            If different video crops are desired, run ``analyze_videos`` on individual
+            videos with the corresponding cropping coordinates.
 
     Returns:
         The scorer used to analyze the videos
@@ -256,6 +261,9 @@ def analyze_videos(
     snapshot_index, detector_snapshot_index = parse_snapshot_index_for_analysis(
         cfg, model_cfg, snapshot_index, detector_snapshot_index,
     )
+
+    if cropping is None and cfg.get("cropping", False):
+        cropping = cfg["x1"], cfg["x2"], cfg["y1"], cfg["y2"]
 
     # Get general project parameters
     bodyparts = model_cfg["metadata"]["bodyparts"]

--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -159,6 +159,24 @@ class VideoReader:
             y2 = int(self._height * y2)
         return x1, x2, y1, y2
 
+    def set_bbox(self, x1, x2, y1, y2, relative=False):
+        if x2 <= x1 or y2 <= y1:
+            raise ValueError(
+                f"Coordinates look wrong... " f"Ensure {x1} < {x2} and {y1} < {y2}."
+            )
+        if not relative:
+            x1 /= self._width
+            x2 /= self._width
+            y1 /= self._height
+            y2 /= self._height
+        bbox = x1, x2, y1, y2
+        if any(coord > 1 for coord in bbox):
+            warnings.warn(
+                "Bounding box larger than the video... " "Clipping to video dimensions."
+            )
+            bbox = tuple(map(lambda x: min(x, 1), bbox))
+        self._bbox = bbox
+
     @property
     def fps(self):
         return self._fps
@@ -204,24 +222,6 @@ class VideoWriter(VideoReader):
         self.dpi = dpi
         if fps:
             self.fps = fps
-
-    def set_bbox(self, x1, x2, y1, y2, relative=False):
-        if x2 <= x1 or y2 <= y1:
-            raise ValueError(
-                f"Coordinates look wrong... " f"Ensure {x1} < {x2} and {y1} < {y2}."
-            )
-        if not relative:
-            x1 /= self._width
-            x2 /= self._width
-            y1 /= self._height
-            y2 /= self._height
-        bbox = x1, x2, y1, y2
-        if any(coord > 1 for coord in bbox):
-            warnings.warn(
-                "Bounding box larger than the video... " "Clipping to video dimensions."
-            )
-            bbox = tuple(map(lambda x: min(x, 1), bbox))
-        self._bbox = bbox
 
     def shorten(
         self, start, end, suffix="short", dest_folder=None, validate_inputs=True


### PR DESCRIPTION
Hello DeepLabCut!

I'm integrating DLC-Pytorch into my project (2D/single animal) and I needed to add cropping functionality to `deeplabcut.analyze_videos`. Unfortunately I wasn't able to run the test scripts due different errors so I'd appreciate if someone from the team can run them, the log files of my runs are below. I tested the output of `deeplabcut.analyze_videos` with my data and it looked good so far.

testscript.py: https://datashare.mpcdf.mpg.de/s/UXTZAoKIejb0iKx
testscript_pytorch_multi_animal.py: https://datashare.mpcdf.mpg.de/s/AZsJ18QsA74CeRG
testscript_pytorch_single_animal.py: https://datashare.mpcdf.mpg.de/s/OrIwKmmMmkCwRho

The change is mostly moving VideoWriter.set_bbox to the parent class and pass cropping to VideoIterator. Everything was performed in 24ba1115 aka. 3.0.0rc4 on SUSE Linux 15.5.

Best,
Yanko