### PR TITLE
Data compatibility - Benchmark 

### DIFF
--- a/deeplabcut/benchmark/__init__.py
+++ b/deeplabcut/benchmark/__init__.py
@@ -85,7 +85,11 @@ def evaluate(
                 continue
         benchmark = benchmark_cls()
         for name in benchmark.names():
-            if Result(method_name=name, benchmark_name=benchmark_cls.name) in results:
+            if Result(
+                code=benchmark.code,
+                method_name=name,
+                benchmark_name=benchmark_cls.name,
+            ) in results:
                 continue
             else:
                 result = benchmark.evaluate(name, on_error=on_error)

--- a/deeplabcut/benchmark/base.py
+++ b/deeplabcut/benchmark/base.py
@@ -59,7 +59,7 @@ class Benchmark(abc.ABC):
         raise NotImplementedError()
 
     def __init__(self):
-        keys = ["name", "keypoints", "ground_truth", "metadata"]
+        keys = ["code", "name", "keypoints", "ground_truth", "metadata"]
         for key in keys:
             if not hasattr(self, key):
                 raise NotImplementedError(
@@ -110,6 +110,7 @@ class Benchmark(abc.ABC):
             else:
                 raise NotImplementedError() from exception
         return Result(
+            code=self.code,
             method_name=name,
             benchmark_name=self.name,
             mean_avg_precision=mean_avg_precision,
@@ -139,6 +140,7 @@ class Benchmark(abc.ABC):
 class Result:
     """Benchmark result."""
 
+    code: str
     method_name: str
     benchmark_name: str
     root_mean_squared_error: float = float("nan")
@@ -146,6 +148,7 @@ class Result:
     benchmark_version: str = __version__
 
     _export_mapping = dict(
+        code="code",
         benchmark_name="benchmark",
         method_name="method",
         benchmark_version="version",

--- a/deeplabcut/benchmark/benchmarks.py
+++ b/deeplabcut/benchmark/benchmarks.py
@@ -96,6 +96,16 @@ class ParentingMouseBenchmark(deeplabcut.benchmark.base.Benchmark):
             symmetric_kpts=[(0, 4), (1, 3)],
         )
 
+    def _validate_predictions(self, name: str, predictions: dict) -> dict:
+        """Fixes filenames for predictions made on old versions of the dataset"""
+        return super()._validate_predictions(
+            name,
+            {
+                k.replace("Dummy", "D").replace("Dead pup", "DP"): v
+                for k, v in predictions.items()
+            },
+        )
+
 
 class MarmosetBenchmark(deeplabcut.benchmark.base.Benchmark):
     """Dataset with two marmosets.


### PR DESCRIPTION
Makes the changes to the names in the parenting benchmark backwards compatible (models evaluated correctly, even on the previous version of the dataset).

Adds the "code" key from benchmarks to the Results object, so that it can be used when generating the benchmarks page.