### PR TITLE
pytorch_dlc - Small updates and bug fixes

### DIFF
--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -969,6 +969,7 @@ def create_training_dataset(
             num_shuffles,
             Shuffles,
             net_type=net_type,
+            detector_type=detector_type,
             trainIndices=trainIndices,
             testIndices=testIndices,
             userfeedback=userfeedback,

--- a/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
@@ -350,6 +350,7 @@ def analyze_videos(
                 dlc_scorer=dlc_scorer,
                 train_fraction=train_fraction,
                 batch_size=batch_size,
+                cropping=cropping,
                 runtime=(runtime[0], runtime[1]),
                 video=VideoReader(str(video)),
             )
@@ -543,15 +544,20 @@ def _generate_metadata(
     dlc_scorer: str,
     train_fraction: int,
     batch_size: int,
+    cropping: list[int] | None,
     runtime: tuple[float, float],
     video: VideoReader,
 ) -> dict:
     w, h = video.dimensions
-    cropping = cfg.get("cropping", False)
-    if cropping:
-        cropping_parameters = [cfg["x1"], cfg["x2"], cfg["y1"], cfg["y2"]]
-    else:
+    if cropping is None:
         cropping_parameters = [0, w, 0, h]
+    else:
+        if not len(cropping) == 4:
+            raise ValueError(
+                "The cropping parameters should be exactly 4 values: [x_min, x_max, "
+                f"y_min, y_max]. Found {cropping}"
+            )
+        cropping_parameters = cropping
 
     metadata = {
         "start": runtime[0],
@@ -565,7 +571,7 @@ def _generate_metadata(
         "nframes": video.get_n_frames(),
         "iteration (active-learning)": cfg["iteration"],
         "training set fraction": train_fraction,
-        "cropping": cropping,
+        "cropping": cropping is not None,
         "cropping_parameters": cropping_parameters,
     }
     return {"data": metadata}

--- a/deeplabcut/pose_estimation_pytorch/apis/evaluate.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/evaluate.py
@@ -391,7 +391,7 @@ def evaluate_network(
     for train_set_index in train_set_indices:
         for shuffle in shuffles:
             loader = DLCLoader(
-                config=Path(cfg["project_path"]) / "config.yaml",
+                config=config,
                 shuffle=shuffle,
                 trainset_index=train_set_index,
                 modelprefix=modelprefix,

--- a/deeplabcut/pose_estimation_pytorch/config/base/detector.yaml
+++ b/deeplabcut/pose_estimation_pytorch/config/base/detector.yaml
@@ -27,7 +27,7 @@ detector:
     variant: fasterrcnn_mobilenet_v3_large_fpn
   runner:
     type: DetectorTrainingRunner
-    eval_interval: 1
+    eval_interval: 10
     optimizer:
       type: AdamW
       params:

--- a/deeplabcut/pose_estimation_pytorch/config/base/head_bodyparts.yaml
+++ b/deeplabcut/pose_estimation_pytorch/config/base/head_bodyparts.yaml
@@ -11,6 +11,7 @@ target_generator:
   num_heatmaps: "num_bodyparts"
   pos_dist_thresh: 17
   heatmap_mode: KEYPOINT
+  gradient_masking: false
   generate_locref: true
   locref_std: 7.2801
 criterion:

--- a/deeplabcut/pose_estimation_pytorch/config/base/head_bodyparts_with_paf.yaml
+++ b/deeplabcut/pose_estimation_pytorch/config/base/head_bodyparts_with_paf.yaml
@@ -19,6 +19,7 @@ target_generator:
     num_heatmaps: "num_bodyparts"
     pos_dist_thresh: 17
     heatmap_mode: KEYPOINT
+    gradient_masking: false
     generate_locref: true
     locref_std: 7.2801
   - type: PartAffinityFieldGenerator

--- a/deeplabcut/pose_estimation_pytorch/config/base/head_identity.yaml
+++ b/deeplabcut/pose_estimation_pytorch/config/base/head_identity.yaml
@@ -7,6 +7,7 @@ target_generator:
   num_heatmaps: "num_individuals"
   pos_dist_thresh: 17
   heatmap_mode: INDIVIDUAL
+  gradient_masking: false
   generate_locref: false
 criterion:
   heatmap:

--- a/deeplabcut/pose_estimation_pytorch/config/base/head_topdown.yaml
+++ b/deeplabcut/pose_estimation_pytorch/config/base/head_topdown.yaml
@@ -11,6 +11,8 @@ target_generator:
   num_heatmaps: "num_bodyparts"
   pos_dist_thresh: 17
   heatmap_mode: KEYPOINT
+  gradient_masking: true
+  background_weight: 0.0
   generate_locref: true
   locref_std: 7.2801
 criterion:

--- a/deeplabcut/pose_estimation_pytorch/config/dekr/dekr_w18.yaml
+++ b/deeplabcut/pose_estimation_pytorch/config/dekr/dekr_w18.yaml
@@ -31,6 +31,7 @@ model:
       predictor:
         type: DEKRPredictor
         apply_sigmoid: false
+        use_heatmap: false
         clip_scores: true
         num_animals: "num_individuals"
         keypoint_score_type: combined

--- a/deeplabcut/pose_estimation_pytorch/config/dekr/dekr_w32.yaml
+++ b/deeplabcut/pose_estimation_pytorch/config/dekr/dekr_w32.yaml
@@ -31,6 +31,7 @@ model:
       predictor:
         type: DEKRPredictor
         apply_sigmoid: false
+        use_heatmap: false
         clip_scores: true
         num_animals: "num_individuals"
         keypoint_score_type: combined

--- a/deeplabcut/pose_estimation_pytorch/config/dekr/dekr_w48.yaml
+++ b/deeplabcut/pose_estimation_pytorch/config/dekr/dekr_w48.yaml
@@ -31,6 +31,7 @@ model:
       predictor:
         type: DEKRPredictor
         apply_sigmoid: false
+        use_heatmap: false
         clip_scores: true
         num_animals: "num_individuals"
         keypoint_score_type: combined

--- a/deeplabcut/pose_estimation_pytorch/models/predictors/paf_predictor.py
+++ b/deeplabcut/pose_estimation_pytorch/models/predictors/paf_predictor.py
@@ -177,9 +177,10 @@ class PartAffinityFieldPredictor(BasePredictor):
         poses_unique = -torch.ones((batch_size, 1, self.num_uniquebodyparts, 4))
         for i, data_dict in enumerate(preds):
             assemblies, unique = self.assembler._assemble(data_dict, ind_frame=0)
-            for j, assembly in enumerate(assemblies):
-                poses[i, j, :, :4] = torch.from_numpy(assembly.data)
-                poses[i, j, :, 4] = assembly.affinity
+            if assemblies is not None:
+                for j, assembly in enumerate(assemblies):
+                    poses[i, j, :, :4] = torch.from_numpy(assembly.data)
+                    poses[i, j, :, 4] = assembly.affinity
             if unique is not None:
                 poses_unique[i, 0, :, :4] = torch.from_numpy(unique)
 

--- a/deeplabcut/pose_estimation_pytorch/models/target_generators/pafs_targets.py
+++ b/deeplabcut/pose_estimation_pytorch/models/target_generators/pafs_targets.py
@@ -29,17 +29,11 @@ class PartAffinityFieldGenerator(BaseGenerator):
     """
 
     def __init__(self, graph: list[list[int, int]], width: float):
-        """Summary:
-        Constructor of the PartAffinityFieldGenerator class.
-        Loads the data.
-
+        """
         Args:
             graph: list of pairs of keypoint indices forming
                 the graph edges
             width: width of the vector field in pixels
-
-        Returns:
-            None
 
         Examples:
             input:
@@ -58,7 +52,7 @@ class PartAffinityFieldGenerator(BaseGenerator):
         batch_size, _, height, width = outputs["heatmap"].shape
         coords = labels[self.label_keypoint_key].cpu().numpy()
 
-        partaffinityfield_map = np.zeros(
+        paf_map = np.zeros(
             (batch_size, height, width, self.num_limbs * 2), dtype=np.float32
         )
         grid = np.mgrid[:height, :width].transpose((1, 2, 0))
@@ -102,14 +96,14 @@ class PartAffinityFieldGenerator(BaseGenerator):
                         mask2 = distance_across_abs <= 1
                         mask = mask1 & mask2
                         temp = 1 - distance_across_abs[mask]
-                        partaffinityfield_map[b, mask, l * 2 + 0] = vec_x_norm * temp
-                        partaffinityfield_map[b, mask, l * 2 + 1] = vec_y_norm * temp
+                        paf_map[b, mask, l * 2 + 0] = vec_x_norm * temp
+                        paf_map[b, mask, l * 2 + 1] = vec_y_norm * temp
 
-        partaffinityfield_map = partaffinityfield_map.transpose((0, 3, 1, 2))
+        paf_map = paf_map.transpose((0, 3, 1, 2))
         return {
             "paf": {
                 "target": torch.tensor(
-                    partaffinityfield_map, device=outputs["paf"].device
+                    paf_map, device=outputs["paf"].device
                 )
             }
         }

--- a/deeplabcut/pose_estimation_pytorch/runners/logger.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/logger.py
@@ -194,7 +194,10 @@ class ImageLoggerMixin(ABC):
         image = F.convert_image_dtype(image.detach().cpu(), dtype=torch.uint8)
         if keypoints is not None and len(keypoints) > 0:
             assert len(keypoints.shape) == 3
-            keypoints[keypoints < 0] = np.nan
+            # Use visibility and force torchvision >= 0.18
+            # pytorch.org/vision/0.18/generated/torchvision.utils.draw_keypoints.html
+            # pytorch.org/vision/0.17/generated/torchvision.utils.draw_keypoints.html
+            keypoints[torch.any(torch.isnan(keypoints), dim=-1)] = -1
             image = draw_keypoints(
                 image, keypoints=keypoints[..., :2], colors="red", radius=5
             )

--- a/docs/pytorch/pytorch_config.md
+++ b/docs/pytorch/pytorch_config.md
@@ -379,10 +379,7 @@ default.
 Additionally, you can log results to [Weights and Biases](https://wandb.ai/site), by adding a
 `WandbLogger`. Just make sure you're logged in to your `wandb` account before starting 
 your training run (with `wandb login` from your shell). For more information, see their
-[tutorials](https://docs.wandb.ai/tutorials) and their documentation for 
-[`wandb.init`](https://docs.wandb.ai/ref/python/init). You can also log images as they are seen by the model to `wandb` 
-with the `image_log_interval`. This logs a random train and test image, as well as the 
-targets and heatmaps for that image.
+[tutorials](https://docs.wandb.ai/tutorials) and their documentation for [`wandb.init`](https://docs.wandb.ai/ref/python/init).
 
 Logging to `wandb` is a good way to keep track of what you've run, including performance
 and metrics.
@@ -390,11 +387,14 @@ and metrics.
 ```yaml
 logger:
  type: WandbLogger
- image_log_interval: 5  # how often images are logged to wandb (in epochs)
  project_name: my-dlc3-project  # the name of the project where the run should be logged
  run_name: dekr-w32-shuffle0  # the name of the run to log
  ...  # any other argument you can pass to `wandb.init`, such as `tags: ["dekr", "split=0"]`
 ```
+
+You can also log images as they are seen by the model to `wandb` 
+with the `image_log_interval`. This logs a random train and test image, as well as the 
+targets and heatmaps for that image.
 
 ## Training Top-Down Models
 

--- a/tests/pose_estimation_pytorch/runners/test_logger.py
+++ b/tests/pose_estimation_pytorch/runners/test_logger.py
@@ -55,14 +55,21 @@ class MockImageLogger(logging.ImageLoggerMixin):
 )
 @pytest.mark.parametrize("denormalize", [True, False])
 def test_prepare_image(keypoints: list[list[float]], denormalize: bool) -> None:
+    image = torch.ones((3, 256, 256))
+    keypoints = torch.tensor(keypoints)
+
     print()
-    print(torch.tensor(keypoints).shape)
+    print(f"IMAGE: {image.shape}")
+    print(f"KEYPOINTS: {keypoints.shape}")
+    for k in keypoints:
+        print(k)
+    print()
     print()
 
     logger = MockImageLogger()
     logger._prepare_image(
-        image=torch.zeros((3, 256, 256)),
+        image=image,
         denormalize=denormalize,
-        keypoints=torch.tensor(keypoints),
+        keypoints=keypoints,
         bboxes=None,
     )

--- a/tests/pose_estimation_pytorch/runners/test_logger.py
+++ b/tests/pose_estimation_pytorch/runners/test_logger.py
@@ -1,0 +1,68 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Tests loggers"""
+from typing import Any
+
+import pytest
+import torch
+
+import deeplabcut.pose_estimation_pytorch.runners.logger as logging
+
+
+class MockImageLogger(logging.ImageLoggerMixin):
+    """Mock image logger"""
+
+    def log_images(
+        self,
+        inputs: dict[str, Any],
+        outputs: dict[str, torch.Tensor],
+        targets: dict[str, dict[str, torch.Tensor]],
+        step: int,
+    ) -> None:
+        pass
+
+
+@pytest.mark.parametrize(
+    "keypoints",
+    [
+        [
+            [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+        ],
+        [
+            [[float("nan"), float("nan")], [float("nan"), float("nan")]],
+        ],
+        [
+            [[0.0, 0.0], [1, 1], [2, 2]],
+        ],
+        [[[float("nan"), 0.0], [1, 1], [2, 2]]],
+        [[[-1.0, -1.0], [1, 1], [2, 2]]],
+        [
+            [[-1.0, -1.0], [-1.0, -1.0]],
+        ],
+        [
+            [[-1.0, -1.0], [-1.0, -1.0]],
+            [[1.0, 1.0], [1.0, 1.0]],
+        ],
+    ],
+)
+@pytest.mark.parametrize("denormalize", [True, False])
+def test_prepare_image(keypoints: list[list[float]], denormalize: bool) -> None:
+    print()
+    print(torch.tensor(keypoints).shape)
+    print()
+
+    logger = MockImageLogger()
+    logger._prepare_image(
+        image=torch.zeros((3, 256, 256)),
+        denormalize=denormalize,
+        keypoints=torch.tensor(keypoints),
+        bboxes=None,
+    )


### PR DESCRIPTION
This pull requests makes some small updates and bug fixes:

Addresses #2703 to deal with NaNs when logging images to WandB
- The issue comes from NaNs being converted to integers 
- With `torchvision>=0.18`, we can use a visibility flag. I think that's too restrictive for now, added a comment and we can pin torchvision in the future.
- Tests were added to ensure this works.

Addresses #2733 for modified project configuration filenames
- This is for consistency in the codebase. It is not regular DeepLabCut workflow to have a project configuration file named anything other than `config.yaml`, and no other method is guaranteed to work.

Fixes a bug when calling `create_training_dataset` with a non-default detector for multi-animal projects:
- `detector_type=detector_type,` was not passed to `create_multianimaltraining_dataset`

When calling video inference with cropping=True, updates the metadata for the predictions correctly:
- So the keypoints are displayed correctly when calling `create_labeled_video` and analysis is correct

PAF predictor - Fixes a bug when there are no detections
- The assembler returns None instead of an empty list when no assemblies are found
- This deals with it by checking that the assemblies aren't None

Heatmap target generation - Fixes a bug where gradients might be masked if there is missing data
- also adds gradient masking configuration to the configuration files
