### PR TITLE
Look for uppercase video extensions when creating projects

### DIFF
--- a/deeplabcut/create_project/new.py
+++ b/deeplabcut/create_project/new.py
@@ -143,7 +143,9 @@ def create_new_project(
         # Check if it is a folder
         if os.path.isdir(i):
             vids_in_dir = [
-                os.path.join(i, vp) for vp in os.listdir(i) if vp.endswith(videotype)
+                os.path.join(i, vp)
+                for vp in os.listdir(i)
+                if vp.lower().endswith(videotype)
             ]
             vids = vids + vids_in_dir
             if len(vids_in_dir) == 0:

--- a/deeplabcut/gui/tabs/create_project.py
+++ b/deeplabcut/gui/tabs/create_project.py
@@ -131,7 +131,7 @@ class ProjectCreator(QtWidgets.QDialog):
             folder,
             relative=False,
         ):
-            if os.path.splitext(video)[1][1:] in DLCParams.VIDEOTYPES[1:]:
+            if os.path.splitext(video)[1][1:].lower() in DLCParams.VIDEOTYPES[1:]:
                 self.video_frame.fancy_list.add_item(video)
 
     def finalize_project(self):


### PR DESCRIPTION
Addresses issue #2760.

When loading videos from a folder (with the `python` API or the GUI), also matches video extensions that are in uppercase (e.g. `.MP4` instead of `.mp4`).