### PR TITLE
Fix reading gpus config

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/apis/train.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/train.py
@@ -105,6 +105,9 @@ def train(
         run_config["device"] = device
         device = utils.resolve_device(run_config)
 
+    if gpus is None:
+        gpus = run_config["runner"]["gpus"]
+
     if device == "mps" and task == Task.DETECT:
         device = "cpu"  # FIXME: Cannot train detectors on MPS
 


### PR DESCRIPTION
When not passed by argument to the train function, the gpus parameter is read from the pytorch_config.yaml file 
(Fix to issue [#2744](https://github.com/DeepLabCut/DeepLabCut/issues/2744))