### PR TITLE
Fix failing tests - `tmpdir_factory` dir creation on OSX

### DIFF
--- a/tests/test_inferenceutils.py
+++ b/tests/test_inferenceutils.py
@@ -176,9 +176,9 @@ def test_assembler(tmpdir_factory, real_assemblies):
         1 for a in real_assemblies.values() for _ in a
     )
 
-    output_name = tmpdir_factory.mktemp("data").join("fake.h5")
-    ass.to_h5(output_name)
-    ass.to_pickle(str(output_name).replace("h5", "pickle"))
+    output_dir = tmpdir_factory.mktemp("data")
+    ass.to_h5(output_dir.join("fake.h5"))
+    ass.to_pickle(output_dir.join("fake.pickle"))
 
 
 def test_assembler_with_single_bodypart(real_assemblies):
@@ -288,9 +288,9 @@ def test_assembler_with_identity(tmpdir_factory, real_assemblies):
             eq.append(np.all(ids == ids[0]))
     assert all(eq)
 
-    output_name = tmpdir_factory.mktemp("data").join("fake.h5")
-    ass.to_h5(output_name)
-    ass.to_pickle(str(output_name).replace("h5", "pickle"))
+    output_dir = tmpdir_factory.mktemp("data")
+    ass.to_h5(output_dir.join("fake.h5"))
+    ass.to_pickle(output_dir.join("fake.pickle"))
 
 
 def test_assembler_calibration(real_assemblies):


### PR DESCRIPTION
Fixes failing tests on macOS due to `pytest` `tmpdir_factory` directory creation.