### PR TITLE
Fix bug introduced in PR #2764

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/apis/train.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/train.py
@@ -106,7 +106,7 @@ def train(
         device = utils.resolve_device(run_config)
 
     if gpus is None:
-        gpus = run_config["runner"]["gpus"]
+        gpus = run_config["runner"].get("gpus")
 
     if device == "mps" and task == Task.DETECT:
         device = "cpu"  # FIXME: Cannot train detectors on MPS


### PR DESCRIPTION
In [Pull Request #2764](https://github.com/DeepLabCut/DeepLabCut/pull/2764), I accidentaly introduced a bug:
`gpus` key may not be present in [run_config](https://github.com/DeepLabCut/DeepLabCut/blob/58bc75137c4c99a37a9bd3c5007e78d7d9655731/deeplabcut/pose_estimation_pytorch/apis/train.py#L109), and it crashed when trying to get the corresponding value like this. 
Using `.get()` instead of `[]` synthax returns `Null` when the key is not defined, instead of crashing.