### PR TITLE
Resume training from existing snapshots option in GUI

### DIFF
--- a/deeplabcut/gui/components.py
+++ b/deeplabcut/gui/components.py
@@ -184,6 +184,81 @@ class VideoSelectionWidget(QtWidgets.QWidget):
         self.root.logger.info(f"Cleared selected videos")
 
 
+class SnapshotSelectionWidget(QtWidgets.QWidget):
+    def __init__(
+        self,
+        root: QtWidgets.QMainWindow,
+        parent: QtWidgets.QWidget,
+        margins: tuple,
+        select_button_text: str,
+    ):
+        super(SnapshotSelectionWidget, self).__init__(parent)
+
+        self.root = root
+        self.parent = parent
+
+        self.selected_snapshot = None
+
+        self._init_layout(margins, select_button_text)
+
+    def _init_layout(self, margins, select_button_text):
+        layout = _create_horizontal_layout(margins=margins)
+
+        # Select videos
+        self.select_snapshot_button = QtWidgets.QPushButton(select_button_text)
+        self.select_snapshot_button.setMaximumWidth(200)
+        self.select_snapshot_button.clicked.connect(self.select_snapshot)
+
+        # Selected snapshot text
+        self.selected_snapshot_text = QtWidgets.QLabel(
+            ""
+        )  # updated when snapshot is selected
+
+        # Clear snapshot selection
+        self.clear_snapshot_button = QtWidgets.QPushButton("Clear selection")
+        self.clear_snapshot_button.clicked.connect(self.clear_selected_snapshot)
+        self.clear_snapshot_button.hide()
+
+        layout.addWidget(self.select_snapshot_button)
+        layout.addWidget(self.selected_snapshot_text)
+        layout.addWidget(self.clear_snapshot_button, alignment=Qt.AlignRight)
+
+        self.setLayout(layout)
+
+    def _update_selected_snapshot_display(self):
+        if self.selected_snapshot is None:
+            self.selected_snapshot_text.setText("")
+            self.clear_snapshot_button.hide()
+        else:
+            self.selected_snapshot_text.setText(
+                f"{os.path.basename(self.selected_snapshot)}"
+            )
+            self.clear_snapshot_button.show()
+
+    def select_snapshot(self):
+        # Create a filter string with both lowercase and uppercase extensions
+        snapshot_types = ["*.pt", "*.PT"]
+        snapshot_files = f"Snapshots ({' '.join(snapshot_types)})"
+
+        directory_to_open = self.root.models_folder
+
+        selected_snapshot, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self,
+            "Select snapshot to start training from",
+            directory_to_open,
+            snapshot_files,
+        )
+        # When Canceling a file selection, Qt returns an empty string as selected file
+        if selected_snapshot:
+            self.selected_snapshot = os.path.abspath(selected_snapshot)
+
+        self._update_selected_snapshot_display()
+
+    def clear_selected_snapshot(self):
+        self.selected_snapshot = None
+        self._update_selected_snapshot_display()
+
+
 class TrainingSetSpinBox(QtWidgets.QSpinBox):
     def __init__(self, root, parent):
         super(TrainingSetSpinBox, self).__init__(parent)

--- a/deeplabcut/gui/tabs/train_network.py
+++ b/deeplabcut/gui/tabs/train_network.py
@@ -73,6 +73,8 @@ class TrainNetwork(DefaultTab):
         self._generate_layout_attributes()
         self.main_layout.addWidget(_create_label_widget(""))  # dummy label
 
+        self._pose_cfg_change(self._shuffle_display.pose_cfg)
+
         self.edit_posecfg_btn = QtWidgets.QPushButton("Edit pose_cfg.yaml")
         self.edit_posecfg_btn.setMinimumWidth(150)
         self.edit_posecfg_btn.clicked.connect(self.open_posecfg_editor)
@@ -171,7 +173,6 @@ class TrainNetwork(DefaultTab):
                 layout_widget.hide()
 
             self.main_layout.addWidget(layout_widget)
-            self._pose_cfg_change(self._shuffle_display.pose_cfg)
 
     def log_attribute_change(self, attribute: IntTrainAttribute, value: int) -> None:
         self.root.logger.info(f"{attribute.label} set to {value}")

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -662,7 +662,9 @@ class MainWindow(QMainWindow):
         self.tab_widget.addTab(self.video_editor, "Video editor (*)")
 
         if not self.is_multianimal:
-            self.tab_widget.removeTab(self.tab_widget.indexOf(self.unsupervised_id_tracking))
+            self.tab_widget.removeTab(
+                self.tab_widget.indexOf(self.unsupervised_id_tracking)
+            )
             self.tab_widget.removeTab(self.tab_widget.indexOf(self.refine_tracklets))
 
         self.setCentralWidget(self.tab_widget)

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -248,6 +248,20 @@ class MainWindow(QMainWindow):
             return str(Path(deeplabcut.__file__).parent / "pose_cfg.yaml")
 
     @property
+    def models_folder(self) -> str:
+        try:
+            return str(
+                compat.return_train_network_path(
+                    self.config,
+                    shuffle=int(self.shuffle_value),
+                    trainingsetindex=int(self.trainingset_index),
+                    modelprefix="",
+                )[2]
+            )
+        except FileNotFoundError:
+            return self.project_folder()
+
+    @property
     def inference_cfg_path(self) -> str:
         return os.path.join(
             self.cfg["project_path"],


### PR DESCRIPTION
Add widgets to GUI giving possibility to resume training from existing snapshots, both for pose model and detector.

This Pull Request adds the feature requested by [#2757](https://github.com/DeepLabCut/DeepLabCut/issues/2757) .