### PR TITLE
Fix: `gui/tabs/train_network.py, AttributeError: ‘NoneType’ object has no attribute ‘lower’`

### DIFF
--- a/deeplabcut/gui/tabs/train_network.py
+++ b/deeplabcut/gui/tabs/train_network.py
@@ -75,7 +75,7 @@ class TrainNetwork(DefaultTab):
             self.resume_from_snapshot_label.show()
             self.snapshot_selection_widget.show()
             # Display detector snapshot selection widget only if in Top-Down mode
-            if self._shuffle_display.pose_cfg.get("method").lower() == "td":
+            if self._shuffle_display.pose_cfg.get("method", "").lower() == "td":
                 self.detector_snapshot_selection_widget.show()
             else:
                 self.detector_snapshot_selection_widget.hide()


### PR DESCRIPTION
This fixes a small bug, as [reported in the DeepLabCut forum](https://forum.image.sc/t/attributeerror-nonetype-object-has-no-attribute-lower/104820):

```
deeplabcut\gui\tabs\train_network.py”, line 78, in _update_snapshot_selection_widgets_visibility
if self._shuffle_display.pose_cfg.get(“method”).lower() == “td”:
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: ‘NoneType’ object has no attribute ‘lower’
```

If the selected shuffle is a shuffle with the `TensorFlow` engine, then the `pose_cfg` won't have a "method" key, so `self._shuffle_display.pose_cfg.get(“method”)` will return `None` and the code will crash.