### PR TITLE
Timeout retrieving latest package version from the Web

### DIFF
--- a/deeplabcut/gui/utils.py
+++ b/deeplabcut/gui/utils.py
@@ -8,7 +8,10 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
+from typing import Tuple
+
 from PySide6 import QtCore
+import re
 
 
 class Worker(QtCore.QObject):
@@ -38,6 +41,17 @@ def move_to_separate_thread(func):
     return worker, thread
 
 
+def parse_version(version: str) -> Tuple[int, int, int]:
+    """
+    Parses a version string into a tuple of (major, minor, patch).
+    """
+    match = re.search(r"(\d+)\.(\d+)\.(\d+)", version)
+    if match:
+        return tuple(int(part) for part in match.groups())
+    else:
+        raise ValueError(f"Invalid version format: {version}")
+
+
 def is_latest_deeplabcut_version():
     import json
     import urllib.request
@@ -46,4 +60,4 @@ def is_latest_deeplabcut_version():
     url = "https://pypi.org/pypi/deeplabcut/json"
     contents = urllib.request.urlopen(url).read()
     latest_version = json.loads(contents)["info"]["version"]
-    return VERSION == latest_version, latest_version
+    return parse_version(VERSION) >= parse_version(latest_version), latest_version


### PR DESCRIPTION
This morning, I had deeplabcut GUI stuck in [utils.is_latest_deeplabcut_version()](https://github.com/DeepLabCut/DeepLabCut/blob/48c5969408b10f66bd9ec337d1c4b7d2358e9e2b/deeplabcut/gui/window.py#L45C15-L45C31) and in [misc.is_latest_version()](https://github.com/DeepLabCut/DeepLabCut/blob/48c5969408b10f66bd9ec337d1c4b7d2358e9e2b/deeplabcut/gui/window.py#L46). After some investigation, it seems like 

```
url = "https://pypi.org/pypi/deeplabcut/json"
contents = urllib.request.urlopen(url).read()
```
was stuck because of some firewall or DNS in Python, but it was working when I was getting the data from the CLI (using `curl`) or in a web browser.
This case is not handeled by the [except URLError block of _check_for_updates()](https://github.com/DeepLabCut/DeepLabCut/blob/48c5969408b10f66bd9ec337d1c4b7d2358e9e2b/deeplabcut/gui/window.py#L47), this PR adds a timeout to trying to read the latest available package versions.