### PR TITLE
Fix: correct the early return error when save_epochs=1 and optimize the clean up way

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/runners/snapshots.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/snapshots.py
@@ -130,17 +130,15 @@ class TorchSnapshotManager:
                     current_best.path.rename(new_name)
                 else:
                     current_best.path.unlink(missing_ok=False)
-        else:
+        elif last or epoch % self.save_epochs == 0:
             # Save regular snapshot if needed
-            should_save = last or epoch % self.save_epochs == 0
-            if should_save:
-                save_path = self.snapshot_path(epoch=epoch)
-                parsed_state_dict = {
-                    k: v
-                    for k, v in state_dict.items()
-                    if self.save_optimizer_state or k != "optimizer"
-                }
-                torch.save(parsed_state_dict, save_path)
+            save_path = self.snapshot_path(epoch=epoch)
+            parsed_state_dict = {
+                k: v
+                for k, v in state_dict.items()
+                if self.save_optimizer_state or k != "optimizer"
+            }
+            torch.save(parsed_state_dict, save_path)
 
         # Clean up old snapshots if needed
         existing_snapshots = [s for s in self.snapshots() if not s.best]

--- a/deeplabcut/pose_estimation_pytorch/runners/snapshots.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/snapshots.py
@@ -113,11 +113,11 @@ class TorchSnapshotManager:
         ):
             current_best = self.best()
             self._best_metric = metrics[self._key]
-            
+
             # Save the new best model
             save_path = self.snapshot_path(epoch, best=True)
             parsed_state_dict = {
-                k: v 
+                k: v
                 for k, v in state_dict.items()
                 if self.save_optimizer_state or k != "optimizer"
             }

--- a/deeplabcut/pose_estimation_pytorch/runners/snapshots.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/snapshots.py
@@ -113,40 +113,42 @@ class TorchSnapshotManager:
         ):
             current_best = self.best()
             self._best_metric = metrics[self._key]
+            
+            # Save the new best model
             save_path = self.snapshot_path(epoch, best=True)
             parsed_state_dict = {
-                k: v
+                k: v 
                 for k, v in state_dict.items()
                 if self.save_optimizer_state or k != "optimizer"
             }
             torch.save(parsed_state_dict, save_path)
 
+            # Handle previous best model
             if current_best is not None:
-                # rename if the current best should have been saved, otherwise delete
                 if current_best.epochs % self.save_epochs == 0:
                     new_name = self.snapshot_path(epoch=current_best.epochs)
                     current_best.path.rename(new_name)
                 else:
                     current_best.path.unlink(missing_ok=False)
-            return
+        else:
+            # Save regular snapshot if needed
+            should_save = last or epoch % self.save_epochs == 0
+            if should_save:
+                save_path = self.snapshot_path(epoch=epoch)
+                parsed_state_dict = {
+                    k: v
+                    for k, v in state_dict.items()
+                    if self.save_optimizer_state or k != "optimizer"
+                }
+                torch.save(parsed_state_dict, save_path)
 
-        if not (last or epoch % self.save_epochs == 0):
-            return
-
+        # Clean up old snapshots if needed
         existing_snapshots = [s for s in self.snapshots() if not s.best]
         if len(existing_snapshots) >= self.max_snapshots:
-            num_to_delete = 1 + len(existing_snapshots) - self.max_snapshots
+            num_to_delete = len(existing_snapshots) - self.max_snapshots
             to_delete = existing_snapshots[:num_to_delete]
             for snapshot in to_delete:
                 snapshot.path.unlink(missing_ok=False)
-
-        save_path = self.snapshot_path(epoch=epoch)
-        parsed_state_dict = {
-            k: v
-            for k, v in state_dict.items()
-            if self.save_optimizer_state or k != "optimizer"
-        }
-        torch.save(parsed_state_dict, save_path)
 
     def best(self) -> Snapshot | None:
         """Returns: the path to the best snapshot, if it exists"""


### PR DESCRIPTION
- Fixed an issue causing an incorrect early return when save_epochs=1.
- clean up old snapshots if the number of existing snapshots exceeds the maximum allowed (executed at the end of the process).

Special thanks to @n-poulsen  for your invaluable guidance! 🙏