### PR TITLE
Fix: Video Analysis for Single Animal projects

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -64,3 +64,5 @@ jobs:
           pip install git+https://github.com/${{ github.repository }}.git@${{ github.sha }}
           python examples/testscript.py
           python examples/testscript_multianimal.py
+          python examples/testscript_pytorch_single_animal.py
+          python examples/testscript_pytorch_multi_animal.py

--- a/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
@@ -38,7 +38,7 @@ import deeplabcut.pose_estimation_pytorch.runners.shelving as shelving
 from deeplabcut.pose_estimation_pytorch.runners import InferenceRunner
 from deeplabcut.pose_estimation_pytorch.task import Task
 from deeplabcut.refine_training_dataset.stitch import stitch_tracklets
-from deeplabcut.utils import auxfun_multianimal, auxiliaryfunctions, VideoReader
+from deeplabcut.utils import auxiliaryfunctions, VideoReader
 
 
 class VideoIterator(VideoReader):
@@ -295,6 +295,7 @@ def analyze_videos(
         cropping = cfg["x1"], cfg["x2"], cfg["y1"], cfg["y2"]
 
     # Get general project parameters
+    multi_animal = cfg["multianimalproject"]
     bodyparts = model_cfg["metadata"]["bodyparts"]
     unique_bodyparts = model_cfg["metadata"]["unique_bodyparts"]
     individuals = model_cfg["metadata"]["individuals"]
@@ -306,6 +307,15 @@ def analyze_videos(
 
     if batch_size is None:
         batch_size = cfg.get("batch_size", 1)
+
+    if not multi_animal:
+        save_as_df = True
+        if use_shelve:
+            print(
+                "The ``use_shelve`` parameter cannot be used for single animal "
+                "projects. Setting ``use_shelve=False``."
+            )
+            use_shelve = False
 
     snapshot = get_model_snapshots(snapshot_index, train_folder, pose_task)[0]
     print(f"Analyzing videos with {snapshot.path}")
@@ -399,7 +409,7 @@ def analyze_videos(
                 pickle.dump(metadata, f, pickle.HIGHEST_PROTOCOL)
 
             if use_shelve and save_as_df:
-                print("Can't `save_as_df` as `use_shelve=True`. Skipping.")
+                print("Can't ``save_as_df`` as ``use_shelve=True``. Skipping.")
 
             if not use_shelve:
                 output_data = _generate_output_data(pose_cfg, predictions)
@@ -409,7 +419,7 @@ def analyze_videos(
                 if save_as_df:
                     create_df_from_prediction(
                         predictions=predictions,
-                        cfg=cfg,
+                        multi_animal=multi_animal,
                         model_cfg=model_cfg,
                         dlc_scorer=dlc_scorer,
                         output_path=output_path,
@@ -417,7 +427,7 @@ def analyze_videos(
                         save_as_csv=save_as_csv,
                     )
 
-            if cfg["multianimalproject"]:
+            if multi_animal:
                 _generate_assemblies_file(
                     full_data_path=output_pkl,
                     output_path=output_path / f"{output_prefix}_assemblies.pickle",
@@ -460,7 +470,7 @@ def analyze_videos(
 def create_df_from_prediction(
     predictions: list[dict[str, np.ndarray]],
     dlc_scorer: str,
-    cfg: dict,
+    multi_animal: bool,
     model_cfg: dict,
     output_path: str | Path,
     output_prefix: str | Path,
@@ -482,14 +492,13 @@ def create_df_from_prediction(
     unique_bodyparts = model_cfg["metadata"]["unique_bodyparts"]
     individuals = model_cfg["metadata"]["individuals"]
     n_individuals = len(individuals)
-    multianimal_project = cfg.get("multianimalproject")
 
     print(f"Saving results in {output_h5} and {output_pkl}")
     coords = ["x", "y", "likelihood"]
     cols = [[dlc_scorer], bodyparts, coords]
     cols_names = ["scorer", "bodyparts", "coords"]
 
-    if multianimal_project:
+    if multi_animal:
         cols.insert(1, individuals)
         cols_names.insert(1, "individuals")
 

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/inference.py
@@ -152,7 +152,7 @@ def _video_inference_superanimal(
         df = create_df_from_prediction(
             predictions=predictions,
             dlc_scorer=dlc_scorer,
-            cfg=dict(multianimalproject=True),
+            multi_animal=True,
             model_cfg=model_cfg,
             output_path=output_path,
             output_prefix=output_prefix,

--- a/examples/testscript_pytorch_multi_animal.py
+++ b/examples/testscript_pytorch_multi_animal.py
@@ -125,5 +125,5 @@ if __name__ == "__main__":
         device="cpu",  # "cpu", "cuda:0", "mps"
         logger=None,
         create_labeled_videos=True,
-        delete_after_test_run=False,
+        delete_after_test_run=True,
     )

--- a/examples/testscript_pytorch_multi_animal.py
+++ b/examples/testscript_pytorch_multi_animal.py
@@ -25,6 +25,8 @@ def main(
     net_types: list[str],
     params: SyntheticProjectParameters,
     epochs: int = 1,
+    top_down_epochs: int = 1,
+    detector_epochs: int = 1,
     save_epochs: int = 1,
     batch_size: int = 1,
     detector_batch_size: int = 1,
@@ -34,7 +36,7 @@ def main(
     create_labeled_videos: bool = False,
     delete_after_test_run: bool = False,
 ) -> None:
-    project_path = Path("../synthetic-data-niels-multi-animal").resolve()
+    project_path = Path("synthetic-data-niels-multi-animal").resolve()
     config_path = project_path / "config.yaml"
     create_fake_project(path=project_path, params=params)
 
@@ -44,18 +46,21 @@ def main(
     train_frac = cfg["TrainingFraction"][trainset_index]
     try:
         for net_type in net_types:
+            epochs_ = epochs
+            if "top_down" in net_type:
+                epochs_ = top_down_epochs
             try:
                 run(
                     config_path=config_path,
                     train_fraction=train_frac,
                     trainset_index=trainset_index,
                     net_type=net_type,
-                    videos=[],
+                    videos=[str(project_path / "videos" / "video.mp4")],
                     device=device,
                     train_kwargs=dict(
                         train_settings=dict(
                             display_iters=50,
-                            epochs=epochs,
+                            epochs=epochs_,
                             batch_size=batch_size,
                         ),
                         runner=dict(
@@ -68,7 +73,7 @@ def main(
                         detector=dict(
                             train_settings=dict(
                                 display_iters=1,
-                                epochs=epochs,
+                                epochs=detector_epochs,
                                 batch_size=detector_batch_size,
                             ),
                             runner=dict(
@@ -95,27 +100,30 @@ def main(
 
 
 if __name__ == "__main__":
+    wandb_logger = {
+        "type": "WandbLogger",
+        "project_name": "testscript-dev",
+        "run_name": "test-logging",
+    }
     main(
-        net_types=["top_down_resnet_50", "resnet_50", "dekr_w18"],
+        net_types=["top_down_resnet_50", "resnet_50", "dekr_w32"],
         params=SyntheticProjectParameters(
             multianimal=True,
-            num_bodyparts=5,
+            num_bodyparts=4,
             num_individuals=3,
             num_unique=0,
-            num_frames=10,
-            frame_shape=(128, 256),
+            num_frames=25,
+            frame_shape=(256, 256),
         ),
-        batch_size=8,
+        batch_size=2,
         detector_batch_size=2,
-        epochs=3,
-        save_epochs=1,
+        epochs=8,
+        top_down_epochs=2,
+        detector_epochs=10,
+        save_epochs=4,
         max_snapshots_to_keep=2,
         device="cpu",  # "cpu", "cuda:0", "mps"
-        logger={
-            "type": "WandbLogger",
-            "project_name": "testscript-dev",
-            "run_name": "test-logging",
-        },
-        create_labeled_videos=False,
-        delete_after_test_run=True,
+        logger=None,
+        create_labeled_videos=True,
+        delete_after_test_run=False,
     )

--- a/examples/testscript_pytorch_single_animal.py
+++ b/examples/testscript_pytorch_single_animal.py
@@ -108,5 +108,5 @@ if __name__ == "__main__":
             frame_shape=(128, 128),
         ),
         create_labeled_videos=True,
-        delete_after_test_run=False,
+        delete_after_test_run=True,
     )

--- a/examples/testscript_pytorch_single_animal.py
+++ b/examples/testscript_pytorch_single_animal.py
@@ -33,8 +33,8 @@ def main(
 ) -> None:
     engine = Engine.PYTORCH
     if synthetic_data:
-        project_path = Path("../synthetic-data-niels-single-animal").resolve()
-        videos = []
+        project_path = Path("synthetic-data-niels-single-animal").resolve()
+        videos = [str(project_path / "videos" / "video.mp4")]
         create_fake_project(path=project_path, params=synthetic_data_params)
 
     else:
@@ -85,27 +85,28 @@ def main(
 
 
 if __name__ == "__main__":
+    wandb_logger = {
+        "type": "WandbLogger",
+        "project_name": "testscript-dev",
+        "run_name": "test-logging",
+    }
     main(
-        synthetic_data=False,
-        net_types=["resnet_50", "hrnet_w18", "hrnet_w32", "hrnet_w48"],
-        batch_size=8,
-        epochs=20,
-        save_epochs=10,
+        synthetic_data=True,
+        net_types=["resnet_50", "hrnet_w32"],
+        batch_size=4,
+        epochs=8,
+        save_epochs=2,
         max_snapshots_to_keep=2,
         device="cpu",  # "cpu", "cuda:0", "mps"
-        logger={
-            "type": "WandbLogger",
-            "project_name": "testscript-dev",
-            "run_name": "test-logging",
-        },
+        logger=None,
         synthetic_data_params=SyntheticProjectParameters(
             multianimal=False,
             num_bodyparts=4,
             num_individuals=1,
             num_unique=0,
-            num_frames=20,
-            frame_shape=(128, 256),
+            num_frames=12,
+            frame_shape=(128, 128),
         ),
-        create_labeled_videos=False,
-        delete_after_test_run=True,
+        create_labeled_videos=True,
+        delete_after_test_run=False,
     )


### PR DESCRIPTION
This pull request addresses issue #2796. For single animal projects, the results DataFrame needs to be output as there is no tracking or assembly.

It also improves the functional tests for PyTorch models on synthetic data. The data is generated such that movement of individuals makes sense, a video can be created and `create_labeled_video` can be run.