### PR TITLE
DLC 3.0 - Function to export PyTorch models

### DIFF
--- a/deeplabcut/compat.py
+++ b/deeplabcut/compat.py
@@ -53,7 +53,7 @@ def get_available_aug_methods(engine: Engine) -> tuple[str, ...]:
     if engine == Engine.TF:
         return "imgaug", "default", "deterministic", "scalecrop", "tensorpack"
     elif engine == Engine.PYTORCH:
-        return ("albumentations", )
+        return ("albumentations",)
 
     raise RuntimeError(f"Unknown augmentation for engine: {engine}")
 
@@ -218,6 +218,7 @@ def train_network(
 
     if engine == Engine.TF:
         from deeplabcut.pose_estimation_tensorflow import train_network
+
         if max_snapshots_to_keep is None:
             max_snapshots_to_keep = 5
 
@@ -239,6 +240,7 @@ def train_network(
         )
     elif engine == Engine.PYTORCH:
         from deeplabcut.pose_estimation_pytorch.apis import train_network
+
         _update_device(gputouse, torch_kwargs)
         if "display_iters" not in torch_kwargs:
             torch_kwargs["display_iters"] = displayiters
@@ -299,6 +301,7 @@ def return_train_network_path(
 
     if engine == Engine.TF:
         from deeplabcut.pose_estimation_tensorflow import return_train_network_path
+
         return return_train_network_path(
             config,
             shuffle=shuffle,
@@ -306,7 +309,10 @@ def return_train_network_path(
             modelprefix=modelprefix,
         )
     elif engine == Engine.PYTORCH:
-        from deeplabcut.pose_estimation_pytorch.apis.utils import return_train_network_path
+        from deeplabcut.pose_estimation_pytorch.apis.utils import (
+            return_train_network_path,
+        )
+
         return return_train_network_path(
             config,
             shuffle=shuffle,
@@ -458,6 +464,7 @@ def evaluate_network(
 
     if engine == Engine.TF:
         from deeplabcut.pose_estimation_tensorflow import evaluate_network
+
         return evaluate_network(
             str(config),
             Shuffles=Shuffles,
@@ -473,6 +480,7 @@ def evaluate_network(
         )
     elif engine == Engine.PYTORCH:
         from deeplabcut.pose_estimation_pytorch.apis import evaluate_network
+
         _update_device(gputouse, torch_kwargs)
         return evaluate_network(
             config,
@@ -553,6 +561,7 @@ def return_evaluate_network_data(
 
     if engine == Engine.TF:
         from deeplabcut.pose_estimation_tensorflow import return_evaluate_network_data
+
         return return_evaluate_network_data(
             config,
             shuffle=shuffle,
@@ -816,6 +825,7 @@ def analyze_videos(
 
     if engine == Engine.TF:
         from deeplabcut.pose_estimation_tensorflow import analyze_videos
+
         kwargs = {}
         if use_openvino is not None:  # otherwise default comes from tensorflow API
             kwargs["use_openvino"] = use_openvino
@@ -846,6 +856,7 @@ def analyze_videos(
         )
     elif engine == Engine.PYTORCH:
         from deeplabcut.pose_estimation_pytorch.apis import analyze_videos
+
         _update_device(gputouse, torch_kwargs)
 
         if batchsize is not None:
@@ -907,6 +918,7 @@ def create_tracking_dataset(
 
     if engine == Engine.TF:
         from deeplabcut.pose_estimation_tensorflow import create_tracking_dataset
+
         return create_tracking_dataset(
             config,
             videos,
@@ -994,6 +1006,7 @@ def analyze_time_lapse_frames(
 
     if engine == Engine.TF:
         from deeplabcut.pose_estimation_tensorflow import analyze_time_lapse_frames
+
         return analyze_time_lapse_frames(
             config,
             directory,
@@ -1120,6 +1133,7 @@ def convert_detections2tracklets(
 
     if engine == Engine.TF:
         from deeplabcut.pose_estimation_tensorflow import convert_detections2tracklets
+
         return convert_detections2tracklets(
             config,
             videos,
@@ -1233,6 +1247,7 @@ def extract_maps(
 
     if engine == Engine.TF:
         from deeplabcut.pose_estimation_tensorflow import extract_maps
+
         return extract_maps(
             config,
             shuffle=shuffle,
@@ -1244,6 +1259,7 @@ def extract_maps(
         )
     elif engine == Engine.PYTORCH:
         from deeplabcut.pose_estimation_pytorch import extract_maps
+
         return extract_maps(
             config,
             shuffle=shuffle,
@@ -1404,6 +1420,7 @@ def extract_save_all_maps(
 
     if engine == Engine.TF:
         from deeplabcut.pose_estimation_tensorflow import extract_save_all_maps
+
         return extract_save_all_maps(
             config,
             shuffle=shuffle,
@@ -1419,6 +1436,7 @@ def extract_save_all_maps(
         )
     elif engine == Engine.PYTORCH:
         from deeplabcut.pose_estimation_pytorch import extract_save_all_maps
+
         return extract_save_all_maps(
             config,
             shuffle=shuffle,
@@ -1512,6 +1530,7 @@ def export_model(
 
     if engine == Engine.TF:
         from deeplabcut.pose_estimation_tensorflow import export_model
+
         return export_model(
             cfg_path=cfg_path,
             shuffle=shuffle,
@@ -1526,6 +1545,7 @@ def export_model(
         )
     elif engine == Engine.PYTORCH:
         from deeplabcut.pose_estimation_pytorch.apis.export import export_model
+
         return export_model(
             config=cfg_path,
             shuffle=shuffle,

--- a/deeplabcut/compat.py
+++ b/deeplabcut/compat.py
@@ -1450,14 +1450,12 @@ def export_model(
     wipepaths: bool = False,
     modelprefix: str = "",
     engine: Engine | None = None,
-):
+) -> None:
     """Export DeepLabCut models for the model zoo or for live inference.
 
     Saves the pose configuration, snapshot files, and frozen TF graph of the model to
-    directory named exported-models within the project directory
-
-    This function is only implemented for tensorflow models/shuffles, and will throw
-    an error if called with a PyTorch shuffle.
+    directory named exported-models within the project directory (and an
+    `exported-models-pytorch` directory for PyTorch models).
 
     Parameters
     -----------
@@ -1524,6 +1522,18 @@ def export_model(
             overwrite=overwrite,
             make_tar=make_tar,
             wipepaths=wipepaths,
+            modelprefix=modelprefix,
+        )
+    elif engine == Engine.PYTORCH:
+        from deeplabcut.pose_estimation_pytorch.apis.export import export_model
+        return export_model(
+            config=cfg_path,
+            shuffle=shuffle,
+            trainingsetindex=trainingsetindex,
+            snapshotindex=snapshotindex,
+            iteration=iteration,
+            overwrite=overwrite,
+            wipe_paths=wipepaths,
             modelprefix=modelprefix,
         )
 

--- a/deeplabcut/pose_estimation_pytorch/apis/__init__.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/__init__.py
@@ -18,6 +18,7 @@ from deeplabcut.pose_estimation_pytorch.apis.convert_detections_to_tracklets imp
     convert_detections2tracklets,
 )
 from deeplabcut.pose_estimation_pytorch.apis.evaluate import evaluate_network
+from deeplabcut.pose_estimation_pytorch.apis.export import export_model
 from deeplabcut.pose_estimation_pytorch.apis.train import train_network
 from deeplabcut.pose_estimation_pytorch.apis.visualization import (
     extract_maps,

--- a/deeplabcut/pose_estimation_pytorch/apis/export.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/export.py
@@ -60,6 +60,7 @@ def export_model(
             folder.
 
     Raises:
+        ValueError: If no snapshots could be found for the shuffle.
         ValueError: If a top-down model is exported but no detector snapshots are found.
 
     Examples:

--- a/deeplabcut/pose_estimation_pytorch/apis/export.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/export.py
@@ -104,7 +104,7 @@ def export_model(
 
         if len(detector_snapshots) == 0:
             raise ValueError(
-                "Attempting to export a top-down pose estimation model but no detector"
+                "Attempting to export a top-down pose estimation model but no detector "
                 f"snapshots were found in ``{loader.model_folder}`` for "
                 f"``detector_snapshot_index={detector_snapshot_index}``. You must "
                 f"export a detector snapshot with a top-down pose estimation model."
@@ -168,8 +168,8 @@ def get_export_filename(
     """
     export_filename = get_export_folder_name(loader)
     if detector_snapshot is not None:
-        export_filename += "_" + detector_snapshot.uid()
-    export_filename += "_" + snapshot.uid()
+        export_filename += "_snapshot-detector" + detector_snapshot.uid()
+    export_filename += "_snapshot-" + snapshot.uid()
     return export_filename + ".pt"
 
 

--- a/deeplabcut/pose_estimation_pytorch/apis/export.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/export.py
@@ -79,12 +79,11 @@ def export_model(
         modelprefix=modelprefix,
     )
 
-    # FIXME(niels): use loader.pose_task when integrated
-    pose_task = Task(loader.model_cfg["method"])
-
     if snapshotindex is None:
         snapshotindex = loader.project_cfg["snapshotindex"]
-    snapshots = utils.get_model_snapshots(snapshotindex, loader.model_folder, pose_task)
+    snapshots = utils.get_model_snapshots(
+        snapshotindex, loader.model_folder, loader.pose_task
+    )
 
     if len(snapshots) == 0:
         raise ValueError(
@@ -93,7 +92,7 @@ def export_model(
         )
 
     detector_snapshots = [None]
-    if pose_task == Task.TOP_DOWN:
+    if loader.pose_task == Task.TOP_DOWN:
         if detector_snapshot_index is None:
             detector_snapshot_index = loader.project_cfg["detector_snapshot_index"]
         detector_snapshots = utils.get_model_snapshots(

--- a/deeplabcut/pose_estimation_pytorch/apis/export.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/export.py
@@ -26,7 +26,7 @@ def export_model(
     trainingsetindex: int = 0,
     snapshotindex: int | None = None,
     detector_snapshot_index: int | None = None,
-    iteration: int = None,
+    iteration: int | None = None,
     overwrite: bool = False,
     wipe_paths: bool = False,
     modelprefix: str = "",

--- a/deeplabcut/pose_estimation_pytorch/apis/export.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/export.py
@@ -30,7 +30,7 @@ def export_model(
     iteration: int | None = None,
     overwrite: bool = False,
     wipe_paths: bool = False,
-    modelprefix: str = "",
+    modelprefix: str | None = None,
 ) -> None:
     """Export DeepLabCut models for live inference.
 
@@ -80,7 +80,7 @@ def export_model(
         config=cfg,
         trainset_index=trainingsetindex,
         shuffle=shuffle,
-        modelprefix=modelprefix,
+        modelprefix="" if modelprefix is None else modelprefix,
     )
 
     if snapshotindex is None:

--- a/deeplabcut/pose_estimation_pytorch/apis/export.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/export.py
@@ -16,6 +16,7 @@ import torch
 
 import deeplabcut.pose_estimation_pytorch.apis.utils as utils
 import deeplabcut.pose_estimation_pytorch.data as dlc3_data
+import deeplabcut.utils.auxiliaryfunctions as af
 from deeplabcut.pose_estimation_pytorch.runners.snapshots import Snapshot
 from deeplabcut.pose_estimation_pytorch.task import Task
 
@@ -70,11 +71,12 @@ def export_model(
         >>>     snapshotindex=-1,
         >>> )
     """
+    cfg = af.read_config(str(config))
     if iteration is not None:
-        raise ValueError(f"TODO(niels)")
+        cfg["iteration"] = iteration
 
     loader = dlc3_data.DLCLoader(
-        config=Path(config),
+        config=cfg,
         trainset_index=trainingsetindex,
         shuffle=shuffle,
         modelprefix=modelprefix,
@@ -145,7 +147,7 @@ def get_export_folder_name(loader: dlc3_data.DLCLoader) -> str:
         The name of the folder in which exported models should be placed for a shuffle.
     """
     return (
-        f"DLC_{loader.project_cfg['task']}_{loader.model_cfg['net_type']}_"
+        f"DLC_{loader.project_cfg['Task']}_{loader.model_cfg['net_type']}_"
         f"iteration-{loader.project_cfg['iteration']}_shuffle-{loader.shuffle}"
     )
 

--- a/deeplabcut/pose_estimation_pytorch/apis/export.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/export.py
@@ -1,0 +1,149 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Code to export DeepLabCut models for DLCLive inference"""
+import copy
+from pathlib import Path
+
+import torch
+
+import deeplabcut.pose_estimation_pytorch.apis.utils as utils
+import deeplabcut.pose_estimation_pytorch.data as dlc3_data
+from deeplabcut.pose_estimation_pytorch.task import Task
+
+
+def export_model(
+    config: str | Path,
+    shuffle: int = 1,
+    trainingsetindex: int = 0,
+    snapshotindex: int | None = None,
+    detector_snapshot_index: int | None = None,
+    iteration: int = None,
+    overwrite: bool = False,
+    wipe_paths: bool = False,
+    modelprefix: str = "",
+):
+    """Export DeepLabCut models for live inference.
+
+    Saves the pytorch_config.yaml configuration, snapshot files, of the model to a
+    directory named exported-models-pytorch within the project directory.
+
+    Args:
+        config: Path of the project configuration file
+        shuffle : The shuffle of the model to export.
+        trainingsetindex: The index of the training fraction for the model you wish to
+            export.
+        snapshotindex: The snapshot index for the weights you wish to export. If None,
+            uses the snapshotindex as defined in ``config.yaml``.
+        detector_snapshot_index: Only for TD models. If defined, uses the detector with
+            the given index for pose estimation. If None, uses the snapshotindex as
+            defined in the project ``config.yaml``.
+        iteration: The project iteration (active learning loop) you wish to export. If
+            None, the iteration listed in the project config file is used.
+        overwrite : bool, optional
+            If the model you wish to export has already been exported, whether to
+            overwrite. default = False
+        wipe_paths : bool, optional
+            Removes the actual path of your project and the init_weights from the
+            ``pytorch_config.yaml``.
+        modelprefix: Directory containing the deeplabcut models to use when evaluating
+            the network. By default, the models are assumed to exist in the project
+            folder.
+
+    Raises:
+        ValueError: If a top-down model is exported but no detector snapshots are found.
+
+    Examples:
+        Export the last stored snapshot for model trained with shuffle 3:
+        >>> import deeplabcut
+        >>> deeplabcut.export_model(
+        >>>     "/analysis/project/reaching-task/config.yaml",
+        >>>     shuffle=3,
+        >>>     snapshotindex=-1,
+        >>> )
+    """
+    if iteration is not None:
+        raise ValueError(f"TODO(niels)")
+
+    loader = dlc3_data.DLCLoader(
+        config=Path(config),
+        trainset_index=trainingsetindex,
+        shuffle=shuffle,
+        modelprefix=modelprefix,
+    )
+
+    # FIXME(niels): use loader.pose_task when integrated
+    pose_task = Task(loader.model_cfg["method"])
+
+    if snapshotindex is None:
+        snapshotindex = loader.project_cfg["snapshotindex"]
+    snapshots = utils.get_model_snapshots(snapshotindex, loader.model_folder, pose_task)
+
+    if len(snapshots) == 0:
+        raise ValueError(
+            f"Could not find any snapshots to export in ``{loader.model_folder}`` for "
+            f"``snapshotindex={snapshotindex}``."
+        )
+
+    detector_snapshots = [None]
+    if pose_task == Task.TOP_DOWN:
+        if detector_snapshot_index is None:
+            detector_snapshot_index = loader.project_cfg["detector_snapshot_index"]
+        detector_snapshots = utils.get_model_snapshots(
+            detector_snapshot_index, loader.model_folder, Task.DETECT
+        )
+
+        if len(detector_snapshots) == 0:
+            raise ValueError(
+                "Attempting to export a top-down pose estimation model but no detector"
+                f"snapshots were found in ``{loader.model_folder}`` for "
+                f"``detector_snapshot_index={detector_snapshot_index}``. You must "
+                f"export a detector snapshot with a top-down pose estimation model."
+            )
+
+    export_dir_name = (
+        f"DLC_{loader.project_cfg['task']}_{loader.model_cfg['net_type']}_"
+        f"iteration-{loader.project_cfg['iteration']}_shuffle-{shuffle}"
+    )
+    export_dir = loader.project_path / "exported-models-pytorch" / export_dir_name
+    export_dir.mkdir(exist_ok=True, parents=True)
+
+    load_kwargs = dict(map_location="cpu", weights_only=True)
+    for det_snapshot in detector_snapshots:
+        detector_weights = None
+        if det_snapshot is not None:
+            detector_weights = torch.load(det_snapshot.path, **load_kwargs)["model"]
+
+        for snapshot in snapshots:
+            export_filename = export_dir_name
+            if det_snapshot is not None:
+                export_filename += "_" + det_snapshot.uid()
+            export_filename += "_" + snapshot.uid()
+            export_path = export_dir / export_filename
+            if export_path.exists() and not overwrite:
+                continue
+
+            model_cfg = copy.deepcopy(loader.model_cfg)
+            if wipe_paths:
+                model_cfg["metadata"]["project_path"] = ""
+                model_cfg["metadata"]["pose_config_path"] = ""
+                if "weight_init" in model_cfg["train_settings"]:
+                    model_cfg["train_settings"]["weight_init"] = None
+                if "resume_training_from" in model_cfg:
+                    model_cfg["resume_training_from"] = None
+                if "resume_training_from" in model_cfg.get("detector", {}):
+                    model_cfg["detector"]["resume_training_from"] = None
+
+            pose_weights = torch.load(snapshot.path, **load_kwargs)["model"]
+            export_dict = dict(config=model_cfg, pose=pose_weights)
+            if detector_weights is not None:
+                export_dict["detector"] = detector_weights
+
+            torch.save(export_dict, export_path)

--- a/deeplabcut/pose_estimation_pytorch/apis/export.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/export.py
@@ -170,7 +170,7 @@ def get_export_filename(
     if detector_snapshot is not None:
         export_filename += "_" + detector_snapshot.uid()
     export_filename += "_" + snapshot.uid()
-    return export_filename
+    return export_filename + ".pt"
 
 
 def wipe_paths_from_model_config(model_cfg: dict) -> None:

--- a/deeplabcut/pose_estimation_pytorch/apis/export.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/export.py
@@ -31,7 +31,7 @@ def export_model(
     overwrite: bool = False,
     wipe_paths: bool = False,
     modelprefix: str = "",
-):
+) -> None:
     """Export DeepLabCut models for live inference.
 
     Saves the pytorch_config.yaml configuration, snapshot files, of the model to a

--- a/deeplabcut/pose_estimation_pytorch/data/dlcloader.py
+++ b/deeplabcut/pose_estimation_pytorch/data/dlcloader.py
@@ -67,11 +67,6 @@ class DLCLoader(Loader):
             engine=Engine.PYTORCH,
             modelprefix=modelprefix,
         )
-        self.split = self.load_split(self._project_config, trainset_index, shuffle)
-
-        # lazy-load DataFrames
-        self._loaded_df: dict[str, pd.DataFrame] | None = None
-        self._resolutions = set()
 
         super().__init__(
             self._project_root
@@ -79,6 +74,11 @@ class DLCLoader(Loader):
             / "train"
             / Engine.PYTORCH.pose_cfg_name
         )
+
+        # lazy-load split and DataFrames
+        self._split: dict[str, list[int]] | None = None
+        self._loaded_df: dict[str, pd.DataFrame] | None = None
+        self._resolutions = set()
 
     @property
     def project_cfg(self) -> dict:
@@ -123,6 +123,15 @@ class DLCLoader(Loader):
     def train_fraction(self) -> float:
         """Returns: the fraction of the dataset used for training"""
         return self._train_frac
+
+    @property
+    def split(self) -> dict[str, list[int]]:
+        if self._split is None:
+            self._split = self.load_split(
+                self._project_config, self._trainset_index, self.shuffle
+            )
+
+        return self._split
 
     def get_dataset_parameters(self) -> PoseDatasetParameters:
         """Retrieves dataset parameters based on the instance's configuration.

--- a/deeplabcut/pose_estimation_pytorch/data/dlcloader.py
+++ b/deeplabcut/pose_estimation_pytorch/data/dlcloader.py
@@ -31,20 +31,25 @@ class DLCLoader(Loader):
 
     def __init__(
         self,
-        config: str | Path,
+        config: str | Path | dict,
         trainset_index: int = 0,
         shuffle: int = 0,
         modelprefix: str = "",
     ):
         """
         Args:
-            config: path to the DeepLabCut project config
+            config: Path to the DeepLabCut project config, or the project config itself
             trainset_index: the index of the TrainingsetFraction for which to load data
             shuffle: the index of the shuffle for which to load data
             modelprefix: the modelprefix for the shuffle
         """
-        self._project_root = Path(config).parent
-        self._project_config = af.read_config(str(config))
+        if isinstance(config, (str, Path)):
+            self._project_root = Path(config).parent
+            self._project_config = af.read_config(str(config))
+        else:
+            self._project_root = Path(config["project_path"])
+            self._project_config = config
+
         self._shuffle = shuffle
         self._trainset_index = trainset_index
         self._train_frac = self._project_config["TrainingFraction"][trainset_index]

--- a/deeplabcut/pose_estimation_pytorch/data/dlcloader.py
+++ b/deeplabcut/pose_estimation_pytorch/data/dlcloader.py
@@ -210,11 +210,15 @@ class DLCLoader(Loader):
         # as in TF DeepLabCut, load the training data from the .mat/.pickle file
         if config.get("multianimalproject", False):
             image_sizes, df_train = _load_pickle_dataset(
-                dataset_file.with_suffix(".pickle"), config["scorer"], params=params,
+                dataset_file.with_suffix(".pickle"),
+                config["scorer"],
+                params=params,
             )
         else:
             image_sizes, df_train = _load_mat_dataset(
-                dataset_file.with_suffix(".mat"), config["scorer"], params=params,
+                dataset_file.with_suffix(".mat"),
+                config["scorer"],
+                params=params,
             )
 
         # load the full dataset file
@@ -302,9 +306,8 @@ class DLCLoader(Loader):
             the coco format data
         """
         with_individuals = "individuals" in df.columns.names
-        if (
-            not with_individuals and
-            (len(parameters.individuals) > 1 or len(parameters.unique_bpts) > 0)
+        if not with_individuals and (
+            len(parameters.individuals) > 1 or len(parameters.unique_bpts) > 0
         ):
             raise ValueError(
                 "The DataFrame contains single-animal annotations (for a single, "
@@ -373,7 +376,7 @@ class DLCLoader(Loader):
                             0 < keypoints[..., 1],
                             keypoints[..., 1] < height,
                         ),
-                    )
+                    ),
                 )
                 keypoints[:, 2] = np.where(is_visible, 2, 0)
                 num_keypoints = is_visible.sum()
@@ -509,7 +512,11 @@ def _load_pickle_dataset(
                     keypoints[idv_idx, bodypart, 0] = x
                     keypoints[idv_idx, bodypart, 1] = y
 
-            elif idv_idx == params.max_num_animals and data_unique is not None and keypoints_unique is None:
+            elif (
+                idv_idx == params.max_num_animals
+                and data_unique is not None
+                and keypoints_unique is None
+            ):
                 keypoints_unique = np.zeros((params.num_unique_bpts, 2))
                 keypoints_unique.fill(np.nan)
                 for joint_id, x, y in idv_bodyparts:
@@ -542,7 +549,9 @@ def _load_pickle_dataset(
 
 
 def _validate_dataframes(
-    dfs: dict[str, pd.DataFrame], df_train: pd.DataFrame, strict: bool = False,
+    dfs: dict[str, pd.DataFrame],
+    df_train: pd.DataFrame,
+    strict: bool = False,
 ) -> dict[str, pd.DataFrame]:
     """Validates the training/test DataFrames
 

--- a/docs/pytorch/user_guide.md
+++ b/docs/pytorch/user_guide.md
@@ -89,4 +89,4 @@ parameters are not valid for the DLC 3.0 PyTorch API.
 | `visualize_locrefs`            |     🟢      |                                                                                                     |                                                     |
 | `visualize_paf`                |     🟢      |                                                                                                     |                                                     |
 | `extract_save_all_maps`        |     🟢      |                                                                                                     |                                                     |
-| `export_model`                 |     🔴      |                                                                                                     |                                                     |
+| `export_model`                 |     🟢      |                                                                                                     |                                                     |

--- a/examples/openfield-Pranav-2018-10-30/config.yaml
+++ b/examples/openfield-Pranav-2018-10-30/config.yaml
@@ -7,7 +7,8 @@ identity:
 
 
 # Project path (change when moving around)
-project_path: WILL BE AUTOMATICALLY UPDATED BY DEMO CODE
+project_path: 
+  /Users/niels/Documents/upamathis/repos/DeepLabCut/examples/openfield-Pranav-2018-10-30
 
 
 # Default DeepLabCut engine to use for shuffle creation (either pytorch or tensorflow)
@@ -23,6 +24,9 @@ bodyparts:
 - leftear
 - rightear
 - tailbase
+
+
+# Fraction of video to start/stop when extracting frames for labeling/refinement
 
 
 # Fraction of video to start/stop when extracting frames for labeling/refinement

--- a/examples/openfield-Pranav-2018-10-30/config.yaml
+++ b/examples/openfield-Pranav-2018-10-30/config.yaml
@@ -7,8 +7,7 @@ identity:
 
 
 # Project path (change when moving around)
-project_path: 
-  /Users/niels/Documents/upamathis/repos/DeepLabCut/examples/openfield-Pranav-2018-10-30
+project_path: WILL BE AUTOMATICALLY UPDATED BY DEMO CODE
 
 
 # Default DeepLabCut engine to use for shuffle creation (either pytorch or tensorflow)
@@ -24,9 +23,6 @@ bodyparts:
 - leftear
 - rightear
 - tailbase
-
-
-# Fraction of video to start/stop when extracting frames for labeling/refinement
 
 
 # Fraction of video to start/stop when extracting frames for labeling/refinement

--- a/tests/pose_estimation_pytorch/apis/test_apis_export.py
+++ b/tests/pose_estimation_pytorch/apis/test_apis_export.py
@@ -1,0 +1,197 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Tests exporting models"""
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+import deeplabcut.pose_estimation_pytorch.apis.export as export
+import deeplabcut.utils.auxiliaryfunctions as af
+from deeplabcut.pose_estimation_pytorch import Task
+from deeplabcut.pose_estimation_pytorch.runners.snapshots import Snapshot
+
+
+def _mock_multianimal_project(project_dir: Path):
+    video_dir = project_dir / "videos"
+    video_dir.mkdir()
+
+    cfg_file, yaml_file = af.create_config_template(multianimal=True)
+    cfg_file["Task"] = "mock"
+    cfg_file["scorer"] = "mock"
+    cfg_file["video_sets"] = {str(video_dir / "vid.mp4"): dict(crop="0, 640, 0, 480")}
+    cfg_file["project_path"] = str(project_dir)
+    cfg_file["individuals"] = ["a", "b"]
+    cfg_file["uniquebodyparts"] = []
+    cfg_file["multianimalbodyparts"] = ["k1", "k2", "k3"]
+    cfg_file["bodyparts"] = "MULTI!"
+
+    with open(project_dir / "config.yaml", "w") as f:
+        yaml_file.dump(cfg_file, f)
+
+
+def _make_mock_loader(
+    project_path: Path,
+    project_task: str,
+    project_iteration: int,
+    model_folder: Path,
+    net_type: str,
+    pose_task: Task,
+    default_snapshot_index: int | str,
+    default_detector_snapshot_index: int | str,
+) -> Mock:
+    loader = Mock()
+    loader.project_path = project_path
+    loader.model_folder = model_folder
+    loader.pose_task = pose_task
+    loader.shuffle = 0
+
+    loader.project_cfg = dict(
+        task=project_task,
+        snapshotindex=default_snapshot_index,
+        detector_snapshotindex=default_detector_snapshot_index,
+        iteration=project_iteration,
+    )
+    loader.model_cfg = dict(
+        net_type=net_type,
+        metadata=dict(
+            project_path=str(project_path),
+            pose_config_path=str(loader.model_folder / "pytorch_config.yaml"),
+        ),
+        weight_init=None,
+        resume_training_from=None,
+    )
+    if pose_task == Task.TOP_DOWN:
+        loader.model_cfg["detector"] = dict(resume_training_from=None)
+
+    return loader
+
+
+def _get_export_model_data(project_dir, num_snapshots, task):
+    _mock_multianimal_project(project_dir)
+
+    model_dir = Path(project_dir) / "fake-shuffle-0"
+    model_dir.mkdir(exist_ok=True)
+    snapshots = []
+    snapshot_data = []
+    for i in range(num_snapshots):
+        snapshot = dict(model=dict(idx=i))
+        snapshot_path = model_dir / f"snapshot-{i:03}.pt"
+        torch.save(snapshot, snapshot_path)
+        snapshots.append(Snapshot(best=False, epochs=i, path=snapshot_path))
+        snapshot_data.append(snapshot)
+
+    detector_snapshots = []
+    detector_data = []
+    if task == Task.TOP_DOWN:
+        for i in range(num_snapshots):
+            snapshot = dict(model=dict(idx=i))
+            snapshot_path = model_dir / f"snapshot-detector-{i:03}.pt"
+            torch.save(snapshot, snapshot_path)
+            detector_data.append(snapshot)
+            detector_snapshots.append(
+                Snapshot(best=False, epochs=i, path=snapshot_path)
+            )
+
+    mock_loader = _make_mock_loader(
+        project_path=project_dir,
+        project_task="mock",
+        project_iteration=0,
+        model_folder=model_dir,
+        net_type="fake-net",
+        pose_task=task,
+        default_snapshot_index=-1,
+        default_detector_snapshot_index=-1,
+    )
+    return mock_loader, snapshots, snapshot_data, detector_snapshots, detector_data
+
+
+@pytest.mark.parametrize(
+    "task, num_snapshots, idx, detector_idx",
+    [
+        (Task.BOTTOM_UP, 10, 0, None),
+        (Task.BOTTOM_UP, 10, 5, None),
+        (Task.BOTTOM_UP, 10, -1, None),
+        (Task.TOP_DOWN, 10, 0, 0),
+        (Task.TOP_DOWN, 10, -1, 0),
+        (Task.TOP_DOWN, 10, -1, 5),
+        (Task.TOP_DOWN, 10, -1, -1),
+    ]
+)
+def test_export_model(
+    tmp_path_factory,
+    task: Task,
+    num_snapshots: int,
+    idx: int,
+    detector_idx: int | None,
+):
+    project_dir = tmp_path_factory.mktemp("tmp-project")
+    test_data = _get_export_model_data(project_dir, num_snapshots, task)
+    mock_loader, snapshots, snapshot_data, detector_snapshots, detector_data = test_data
+
+    def get_mock_loader(*args, **kwargs):
+        return mock_loader
+
+    with patch(
+        "deeplabcut.pose_estimation_pytorch.apis.export.dlc3_data.DLCLoader",
+        get_mock_loader,
+    ):
+        # export the model
+        export.export_model(
+            project_dir / "config.yaml",
+            snapshotindex=idx,
+            detector_snapshot_index=detector_idx,
+        )
+
+        # check that the correct snapshot was exported
+        snapshot = snapshots[idx]
+        detector = None
+        if task == Task.TOP_DOWN:
+            detector = detector_snapshots[detector_idx]
+
+        dir_name = export.get_export_folder_name(mock_loader)
+        filename = export.get_export_filename(mock_loader, snapshot, detector)
+        expected_export = project_dir / "exported-models-pytorch" / dir_name / filename
+        assert expected_export.exists()
+
+        # check that content of the exports are correct
+        exported_data = torch.load(expected_export, weights_only=True)
+        assert isinstance(exported_data, dict)
+        assert "config" in exported_data
+        assert exported_data["config"] == mock_loader.model_cfg
+
+        assert "pose" in exported_data
+        assert exported_data["pose"] == snapshot_data[idx]["model"]
+
+        if task == Task.TOP_DOWN:
+            assert "detector" in exported_data
+            assert exported_data["detector"] == detector_data[detector_idx]["model"]
+
+
+@patch("deeplabcut.pose_estimation_pytorch.apis.export.wipe_paths_from_model_config")
+@pytest.mark.parametrize("task", [Task.BOTTOM_UP, Task.TOP_DOWN])
+def test_export_model_clear_paths(mock_wipe: Mock, tmp_path_factory, task: Task):
+    project_dir = tmp_path_factory.mktemp("tmp-project")
+    test_data = _get_export_model_data(project_dir, 1, task)
+    mock_loader, snapshots, snapshot_data, detector_snapshots, detector_data = test_data
+
+    def get_mock_loader(*args, **kwargs):
+        return mock_loader
+
+    with patch(
+        "deeplabcut.pose_estimation_pytorch.apis.export.dlc3_data.DLCLoader",
+        get_mock_loader,
+    ):
+        export.export_model(project_dir / "config.yaml", wipe_paths=True)
+
+        # check that wipe_paths_from_model_config was called
+        assert mock_wipe.call_count == 1

--- a/tests/pose_estimation_pytorch/apis/test_apis_export.py
+++ b/tests/pose_estimation_pytorch/apis/test_apis_export.py
@@ -99,7 +99,7 @@ def _get_export_model_data(
 ):
     _mock_multianimal_project(project_dir)
 
-    model_dir = Path(project_dir) / f"iteration-{project_iteration}" /  "fake-shuffle-0"
+    model_dir = Path(project_dir) / f"iteration-{project_iteration}" / "fake-shuffle-0"
     model_dir.mkdir(exist_ok=True, parents=True)
     snapshots = []
     snapshot_data = []
@@ -145,7 +145,7 @@ def _get_export_model_data(
         (Task.TOP_DOWN, 10, -1, 0),
         (Task.TOP_DOWN, 10, -1, 5),
         (Task.TOP_DOWN, 10, -1, -1),
-    ]
+    ],
 )
 def test_export_model(
     project_dir,
@@ -255,7 +255,10 @@ def test_export_overwrite(project_dir, task: Task, overwrite: bool):
 @pytest.mark.parametrize("iteration", [5, 12])
 def test_export_change_iteration(project_dir, task: Task, iteration: int):
     test_data = _get_export_model_data(
-        project_dir, 1, task, project_iteration=0,
+        project_dir,
+        1,
+        task,
+        project_iteration=0,
     )
     mock_loader, snapshots, snapshot_data, detector_snapshots, detector_data = test_data
     snapshot = snapshots[0]
@@ -297,7 +300,8 @@ def test_export_change_iteration(project_dir, task: Task, iteration: int):
 
             # check the export exists for the correct iteration
             for loader, file_should_exist in [
-                (mock_loader, False), (loader_diff_iter, True)
+                (mock_loader, False),
+                (loader_diff_iter, True),
             ]:
                 dir_name = export.get_export_folder_name(loader)
                 filename = export.get_export_filename(loader, snapshot, detector)


### PR DESCRIPTION
Implements the `export_model` API method for models trained with the PyTorch engine. Tests are added for the different features of the `export_model` method.

The following modifications are made to implement the feature:

- The `DLCLoader` lazy-loads the DataFrames and train/test splits
- We can instantiate the `DLCLoader` with a project configuration directly (a `dict`) instead of having to pass a filepath
  - This makes it possible to change the project `iteration` dynamically when exporting models
