### PR TITLE
`KeypointAwareCrop`: uniform sampling when no keypoints are present

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/data/dataset.py
+++ b/deeplabcut/pose_estimation_pytorch/data/dataset.py
@@ -250,7 +250,7 @@ class PoseDataset(Dataset):
 
         # we use ..., :3 to pass the visibility flag along
         return {
-            "keypoints": pad_to_length(keypoints[..., :3], num_animals, -1).astype(
+            "keypoints": pad_to_length(keypoints[..., :3], num_animals, 0).astype(
                 np.single
             ),
             "keypoints_unique": keypoints_unique[..., :3].astype(np.single),

--- a/deeplabcut/pose_estimation_pytorch/data/transforms.py
+++ b/deeplabcut/pose_estimation_pytorch/data/transforms.py
@@ -78,7 +78,7 @@ def build_transforms(augmentations: dict) -> A.BaseCompose:
         if rotation is not None:
             rotation = (-rotation, rotation)
         if translation is not None:
-            translation = (0, translation)
+            translation = (-translation, translation)
 
         transforms.append(
             A.Affine(

--- a/deeplabcut/pose_estimation_pytorch/data/transforms.py
+++ b/deeplabcut/pose_estimation_pytorch/data/transforms.py
@@ -281,6 +281,8 @@ class KeypointAwareCrop(A.RandomCrop):
         sampling = self.crop_sampling
         if self.crop_sampling == "hybrid":
             sampling = np.random.choice(["uniform", "density"])
+        if len(kpts) == 0:
+            sampling = "uniform"
         if sampling == "uniform":
             center = np.random.random(2)
         else:
@@ -310,7 +312,7 @@ class KeypointAwareCrop(A.RandomCrop):
         self,
         keypoints,
         **params,
-    ) -> list[float]:
+    ) -> list[tuple[float]]:
         keypoints = super().apply_to_keypoints(keypoints, **params)
         new_keypoints = []
         for kp in keypoints:


### PR DESCRIPTION
Addresses issue #2769. When all keypoints labeled in an image are augmented outside of the image (e.g. they are close to the edge and a rotation is applied), no keypoints are left. Then, density-based sampling of the crop center fails as there are no keypoints to sample from.

Address a few other typos when it comes to image augmentation:
- When creating the `Affine` transform, the `translation` parameter must be given as `(-translation, translation)`
- Keypoints should be padded with `0`s (not visible) and not `-1` (not defined)