### PR TITLE
PyTorch model evaluation - `per_keypoint_evaluation` and `comparisonbodyparts`

### DIFF
--- a/deeplabcut/compat.py
+++ b/deeplabcut/compat.py
@@ -488,6 +488,8 @@ def evaluate_network(
             trainingsetindex=trainingsetindex,
             plotting=plotting,
             show_errors=show_errors,
+            comparison_bodyparts=comparisonbodyparts,
+            per_keypoint_evaluation=per_keypoint_evaluation,
             modelprefix=modelprefix,
             **torch_kwargs,
         )

--- a/deeplabcut/core/metrics/api.py
+++ b/deeplabcut/core/metrics/api.py
@@ -25,7 +25,7 @@ def compute_metrics(
     pcutoff: float = -1,
     oks_bbox_margin: int = 0,
     oks_sigma: float = 0.1,
-    per_keypoint_evaluation: bool = False,
+    per_keypoint_rmse: bool = False,
 ) -> dict:
     """Computes pose estimation performance metrics
 
@@ -71,7 +71,7 @@ def compute_metrics(
         oks_bbox_margin: The margin to add around keypoints to compute the area for OKS
             computation.
         oks_sigma: The OKS sigma to use to compute pose.
-        per_keypoint_evaluation: Compute per-keypoint RMSE values.
+        per_keypoint_rmse: Compute per-keypoint RMSE values.
 
     Returns:
         A dictionary containing keys "rmse", "rmse_cutoff", "mAP" and "mAR" mapping
@@ -100,26 +100,32 @@ def compute_metrics(
         }  # Sample output scores
     """
     data = prepare_evaluation_data(ground_truth, predictions)
-    rmse, rmse_pcutoff = distance_metrics.compute_rmse(data, single_animal, pcutoff)
     oks_scores = distance_metrics.compute_oks(
         data=data,
         oks_sigma=oks_sigma,
         oks_bbox_margin=oks_bbox_margin,
     )
-    results = dict(rmse=rmse, rmse_pcutoff=rmse_pcutoff, **oks_scores)
+
+    data_unique = None
+    if unique_bodypart_gt is not None:
+        assert unique_bodypart_poses is not None
+        data_unique = prepare_evaluation_data(unique_bodypart_gt, unique_bodypart_poses)
+
+    rmse_scores = distance_metrics.compute_rmse(
+        data,
+        single_animal,
+        pcutoff,
+        data_unique=data_unique,
+        per_keypoint_results=per_keypoint_rmse,
+    )
+    results = dict(**rmse_scores, **oks_scores)
 
     if not single_animal:
-        det_rmse, det_rmse_p = distance_metrics.compute_detection_rmse(data, pcutoff)
+        det_rmse, det_rmse_p = distance_metrics.compute_detection_rmse(
+            data, pcutoff, data_unique=data_unique,
+        )
         results["rmse_detections"] = det_rmse
         results["rmse_detections_pcutoff"] = det_rmse_p
-
-    if unique_bodypart_gt is not None:
-        # TODO: We should integrate unique bodyparts to main RMSE computation
-        assert unique_bodypart_poses is not None
-        unique_bpt = prepare_evaluation_data(unique_bodypart_gt, unique_bodypart_poses)
-        unique_bpt_metrics = distance_metrics.compute_rmse(unique_bpt, True, pcutoff)
-        results["rmse_unique_bpts"] = unique_bpt_metrics[0]
-        results["rmse_unique_bpts_pcutoff"] = unique_bpt_metrics[1]
 
     return results
 

--- a/deeplabcut/core/metrics/api.py
+++ b/deeplabcut/core/metrics/api.py
@@ -25,6 +25,7 @@ def compute_metrics(
     pcutoff: float = -1,
     oks_bbox_margin: int = 0,
     oks_sigma: float = 0.1,
+    per_keypoint_evaluation: bool = False,
 ) -> dict:
     """Computes pose estimation performance metrics
 
@@ -70,6 +71,7 @@ def compute_metrics(
         oks_bbox_margin: The margin to add around keypoints to compute the area for OKS
             computation.
         oks_sigma: The OKS sigma to use to compute pose.
+        per_keypoint_evaluation: Compute per-keypoint RMSE values.
 
     Returns:
         A dictionary containing keys "rmse", "rmse_cutoff", "mAP" and "mAR" mapping
@@ -78,6 +80,10 @@ def compute_metrics(
         If unique bodyparts are given, two extra keys "rmse_unique_bodyparts" and
         "rmse_pcutoff_unique_bodyparts" are also returned, containing the metrics for
         the unique bodyparts head.
+
+        If `per_keypoint_evaluation=True`, "keypoint_rmse", "keypoint_rmse_cutoff" (and
+        optionally "unique_keypoint_rmse" and "unique_keypoint_rmse_cutoff") keys are
+        added, containing a list of floats representing the RMSE for each keypoint.
 
     Examples:
         >>> # Define the p-cutoff, prediction, and target DataFrames

--- a/deeplabcut/core/metrics/distance_metrics.py
+++ b/deeplabcut/core/metrics/distance_metrics.py
@@ -225,6 +225,8 @@ def compute_rmse(
     if np.any(~np.isnan(pixel_errors)):
         rmse = np.nanmean(pixel_errors).item()
 
+        # TODO: CHECK THAT THIS WORKS WITH np.nanmean(pixel_errors, axis=1).item()
+
         keypoint_scores = np.stack([m.keypoint_scores() for m in matches])
         pixel_errors_cutoff = pixel_errors[keypoint_scores >= pcutoff]
         if np.any(~np.isnan(pixel_errors_cutoff)):

--- a/deeplabcut/core/metrics/distance_metrics.py
+++ b/deeplabcut/core/metrics/distance_metrics.py
@@ -152,13 +152,12 @@ def compute_oks(
     }
 
 
-def compute_rmse(
+def match_predictions_for_rmse(
     data: list[tuple[np.ndarray, np.ndarray]],
     single_animal: bool,
-    pcutoff: float,
     oks_bbox_margin: float = 0.0,
-) -> tuple[float, float]:
-    """Computes the RMSE for pose predictions.
+) -> list[matching.PotentialMatch]:
+    """Matches GT keypoints to predictions to compute RMSE.
 
     Single animal RMSE is computed by simply calculating the distance between each
     ground truth keypoint and the corresponding prediction.
@@ -176,16 +175,16 @@ def compute_rmse(
             num_bpts, 3). For the GT, the 3 coordinates are (x, y, visibility) while for
             the pose they are (x, y, confidence score).
         single_animal: Whether this is a single animal dataset.
-        pcutoff: The p-cutoff to use to compute RMSE.
         oks_bbox_margin: When single_animal is False, predictions are matched to GT
             using OKS. This is the margin used to apply when computing the bbox from
             the pose to compute OKS.
 
     Returns:
-        The RMSE and RMSE after removing all detections with a score below the pcutoff.
+        A list containing the predictions matched to ground truth.
 
     Raises:
-        AssertionError
+        ValueError: If `single_animal=True` but more than one ground truth/predicted
+        keypoint is found for an entry
     """
     matches = []
     for gt, pred in data:
@@ -217,27 +216,106 @@ def compute_rmse(
 
         matches.extend(image_matches)
 
-    rmse, rmse_cutoff = float("nan"), float("nan")
-    if len(matches) == 0:
-        return rmse, rmse_cutoff
+    return matches
 
-    pixel_errors = np.stack([m.pixel_errors() for m in matches])
-    if np.any(~np.isnan(pixel_errors)):
-        rmse = np.nanmean(pixel_errors).item()
 
-        # TODO: CHECK THAT THIS WORKS WITH np.nanmean(pixel_errors, axis=1).item()
+def compute_rmse(
+    data: list[tuple[np.ndarray, np.ndarray]],
+    single_animal: bool,
+    pcutoff: float,
+    data_unique: list[tuple[np.ndarray, np.ndarray]] | None = None,
+    per_keypoint_results: bool = False,
+    oks_bbox_margin: float = 0.0,
+) -> dict[str, float]:
+    """Computes the RMSE for pose predictions.
 
+    Single animal RMSE is computed by simply calculating the distance between each
+    ground truth keypoint and the corresponding prediction.
+
+    Multi-animal RMSE is computed differently: predictions are first matched to ground
+    truth individuals using greedy OKS matching. RMSE is then computed only between
+    predictions and the ground truth pose they are matched to, only when the OKS is
+    non-zero (greater than a small threshold). Predictions that cannot be matched to
+    any ground truth with non-zero OKS are not used to compute RMSE.
+
+    Args:
+        data: The data for which to compute RMSE. This is a list containing (gt_poses,
+            predicted_poses), where gt_pose is an array of shape (num_gt_individuals,
+            num_bpts, 3) and predicted_poses is an array of shape (num_predictions,
+            num_bpts, 3). For the GT, the 3 coordinates are (x, y, visibility) while for
+            the pose they are (x, y, confidence score).
+        single_animal: Whether this is a single animal dataset.
+        pcutoff: The p-cutoff to use to compute RMSE.
+        data_unique: Unique bodypart ground truth and predictions to include in RMSE
+            computations, if there are any such bodyparts.
+        per_keypoint_results: Whether to compute the RMSE for each individual keypoint.
+        oks_bbox_margin: When single_animal is False, predictions are matched to GT
+            using OKS. This is the margin used to apply when computing the bbox from
+            the pose to compute OKS.
+
+    Returns:
+        A dictionary matching metric names to values. It will at least have "rmse" and
+        "rmse_cutoff" keys. If `per_keypoint_results=True` and there is at least one
+        non-NaN pixel error it will also contain "rmse_keypoint_X" and
+        "rmse_cutoff_keypoint_X" keys for each bodypart, where X is the index of the
+        bodypart.
+
+    Raises:
+        ValueError: If `single_animal=True` but more than one ground truth/predicted
+            keypoint is found for an entry
+    """
+    matches = match_predictions_for_rmse(data, single_animal, oks_bbox_margin)
+    pixel_errors, keypoint_scores = None, None
+    if len(matches) > 0:
+        pixel_errors = np.stack([m.pixel_errors() for m in matches])
         keypoint_scores = np.stack([m.keypoint_scores() for m in matches])
-        pixel_errors_cutoff = pixel_errors[keypoint_scores >= pcutoff]
-        if np.any(~np.isnan(pixel_errors_cutoff)):
-            rmse_cutoff = np.nanmean(pixel_errors_cutoff).item()
 
-    return rmse, rmse_cutoff
+    error, support, cutoff_error, cutoff_support = 0, 0, 0, 0
+    if pixel_errors is not None:
+        error, support, cutoff_error, cutoff_support = collect_pixel_errors(
+            pixel_errors, keypoint_scores, pcutoff,
+        )
+
+    unique_pixel_errors, unique_keypoint_scores = None, None
+    if data_unique is not None:
+        u_matches = match_predictions_for_rmse(data_unique, single_animal=True)
+        if len(u_matches) > 0:
+            unique_pixel_errors = np.stack([m.pixel_errors() for m in u_matches])
+            unique_keypoint_scores = np.stack([m.keypoint_scores() for m in u_matches])
+
+            u_error, u_support, u_cutoff_error, u_cutoff_support = collect_pixel_errors(
+                unique_pixel_errors, unique_keypoint_scores, pcutoff,
+            )
+            error += u_error
+            support += u_support
+            cutoff_error += u_cutoff_error
+            cutoff_support += u_cutoff_support
+
+    results = dict(rmse=float("nan"), rmse_pcutoff=float("nan"))
+    if support > 0:
+        results["rmse"] = error / support
+    if cutoff_support > 0:
+        results["rmse_pcutoff"] = cutoff_error / cutoff_support
+
+    if per_keypoint_results:
+        bodypart_errors = [("rmse_keypoint", pixel_errors)]
+        if unique_pixel_errors is not None:
+            bodypart_errors.append(("rmse_unique_keypoint", unique_pixel_errors))
+
+        for key_prefix, bpt_errors in bodypart_errors:
+            for idx, keypoint_error in enumerate(bpt_errors.T):
+                rmse = float("nan")
+                if np.any(~np.isnan(keypoint_error)):
+                    rmse = np.nanmean(keypoint_error)
+                results[f"{key_prefix}_{idx}"] = rmse
+
+    return results
 
 
 def compute_detection_rmse(
     data: list[tuple[np.ndarray, np.ndarray]],
     pcutoff: float,
+    data_unique: list[tuple[np.ndarray, np.ndarray]] | None = None,
 ) -> tuple[float, float]:
     """Computes the detection RMSE for pose predictions.
 
@@ -254,6 +332,8 @@ def compute_detection_rmse(
             num_bpts, 3). For the GT, the 3 coordinates are (x, y, visibility) while for
             the pose they are (x, y, confidence score).
         pcutoff: The p-cutoff to use to compute RMSE.
+        data_unique: Unique bodypart ground truth and predictions to include in RMSE
+            computations, if there are any such bodyparts.
 
     Returns:
         The detection RMSE and detection RMSE after removing all detections with a
@@ -281,6 +361,17 @@ def compute_detection_rmse(
                     distances.append(np.linalg.norm(gt[:2] - pred[:2]))
                     scores.append(bpt_pred[pred_index, 2])
 
+    if data_unique is not None:
+        for image_gt, image_pred in data_unique:
+            assert len(image_gt) == len(image_pred) == 1, (
+                f"Unique GT an predictions must have length 1! Found {image_gt.shape}, "
+                f"{image_pred.shape}."
+            )
+            unique_gt, unique_pred = image_gt[0], image_pred[0]
+            for gt, pred in zip(unique_gt, unique_pred):
+                distances.append(np.linalg.norm(gt[:2] - pred[:2]))
+                scores.append(pred[2])
+
     rmse, rmse_cutoff = float("nan"), float("nan")
     if len(distances) == 0:
         return rmse, rmse_cutoff
@@ -295,3 +386,38 @@ def compute_detection_rmse(
             rmse_cutoff = np.nanmean(pixel_errors_cutoff).item()
 
     return rmse, rmse_cutoff
+
+
+def collect_pixel_errors(
+    pixel_errors: np.ndarray,
+    keypoint_scores: np.ndarray,
+    pcutoff: float,
+) -> tuple[float, int, float, int]:
+    """Collects pixel errors for RMSE computation
+
+    Args:
+        pixel_errors: The pixel errors to collect, of shape (num_matches, num_bodyparts)
+        keypoint_scores: The scores corresponding to the pixel errors, of shape
+            (num_matches, num_bodyparts).
+        pcutoff: The pcutoff to use when computing cutoff RMSE.
+
+    Returns: error, support, cutoff_error, support_cutoff
+        error: The sum of all pixel errors.
+        support: The number of valid pixel errors.
+        cutoff_error: The sum of all pixel errors with score > pcutoff.
+        support_cutoff: The number of valid pixel errors with score > pcutoff.
+    """
+    error = 0.0
+    cutoff_error = 0.0
+    support = np.sum(~np.isnan(pixel_errors)).item()
+    support_cutoff = 0
+    if support > 0:
+        error += np.nansum(pixel_errors).item()
+
+        cutoff_mask = keypoint_scores >= pcutoff
+        cutoff_pixel_errors = pixel_errors[cutoff_mask]
+        support_cutoff = np.sum(~np.isnan(cutoff_pixel_errors)).item()
+        if support_cutoff > 0:
+            cutoff_error = np.nansum(cutoff_pixel_errors)
+
+    return error, support, cutoff_error, support_cutoff

--- a/deeplabcut/pose_estimation_pytorch/README.md
+++ b/deeplabcut/pose_estimation_pytorch/README.md
@@ -269,7 +269,6 @@ from deeplabcut.pose_estimation_pytorch.data import (
     build_transforms,
     DLCLoader,
 )
-from deeplabcut.pose_estimation_pytorch.task import Task
 
 loader = DLCLoader(
     config="/path/to/my/project/config.yaml",
@@ -279,12 +278,12 @@ loader = DLCLoader(
 train_dataset = loader.create_dataset(
     transform=build_transforms(loader.model_cfg["data"]["train"]),
     mode="train",
-    task=Task.BOTTOM_UP,
+    task=loader.pose_task,
 )
 valid_dataset = loader.create_dataset(
     transform=build_transforms(loader.model_cfg["data"]["train"]),
     mode="test",
-    task=Task.BOTTOM_UP,
+    task=loader.pose_task,
 )
 ```
 
@@ -358,7 +357,6 @@ model_cfg = make_pytorch_pose_config(
     top_down=True,
 )
 write_config(config_path=model_cfg_path, config=model_cfg)
-task = Task(model_cfg["method"])
 
 # Create the loader for the COCO dataset
 loader = COCOLoader(
@@ -370,12 +368,12 @@ loader = COCOLoader(
 train_dataset = loader.create_dataset(
     transform=build_transforms(loader.model_cfg["data"]["train"]),
     mode="train",
-    task=task,
+    task=loader.pose_task,
 )
 valid_dataset = loader.create_dataset(
     transform=build_transforms(loader.model_cfg["data"]["train"]),
     mode="test",
-    task=task,
+    task=loader.pose_task,
 )
 ```
 

--- a/deeplabcut/pose_estimation_pytorch/apis/evaluate.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/evaluate.py
@@ -59,9 +59,9 @@ def predict(
         pose_runner: The runner to use for pose estimation
         loader: The loader containing the data to predict poses on
         mode: {"train", "test"} The mode to predict on
-        detector_runner: If the task is "TD", a detector runner can be given to detect
-            individuals in the images. If no detector is given, ground truth bounding
-            boxes will be used to crop individuals before pose estimation
+        detector_runner: If the loader's `pose_task` is "TD", a detector runner can be
+            given to detect individuals in the images. If no detector is given, ground
+            truth bounding boxes will be used to crop individuals before pose estimation
 
     Returns:
         The paths of images for which predictions were computed mapping to the
@@ -109,9 +109,9 @@ def evaluate(
         pose_runner: The runner for pose estimation
         loader: The loader containing the data to evaluate
         mode: Either 'train' or 'test'
-        detector_runner: If task == 'TD', a detector can be given to compute bounding
-            boxes for pose estimation. If no detector is given, ground truth bounding
-            boxes are used.
+        detector_runner: If the loader's `pose_task` is "TD", a detector can be given to
+            compute bounding boxes for pose estimation. If no detector is given, ground
+            truth bounding boxes are used.
         parameters: PoseDatasetParameters to use. If None, the parameters will be
             obtained from the given Loader. This can be used to change the names of
             bodyparts, e.g. when a model is trained with memory replay.

--- a/docs/pytorch/user_guide.md
+++ b/docs/pytorch/user_guide.md
@@ -76,11 +76,11 @@ parameters are not valid for the DLC 3.0 PyTorch API.
 
 | API Method                     | Implemented | Parameters not yet implemented                                                                      | Parameters invalid for pytorch                      |
 |--------------------------------|:-----------:|-----------------------------------------------------------------------------------------------------|-----------------------------------------------------|
-| `train_network`                |     🟢      | `keepdeconvweights`                                                                                 | `maxiters`, `saveiters`, `allow_growth`, `autotune` |
+| `train_network`                |     🟠      | `keepdeconvweights`                                                                                 | `maxiters`, `saveiters`, `allow_growth`, `autotune` |
 | `return_train_network_path`    |     🟢      |                                                                                                     |                                                     |
-| `evaluate_network`             |     🟢      | `comparisonbodyparts`, `rescale`, `per_keypoint_evaluation`                                         |                                                     |
+| `evaluate_network`             |     🟠      | `rescale`                                                                                           |                                                     |
 | `return_evaluate_network_data` |     🔴      |                                                                                                     | `TFGPUinference`, `allow_growth`                    |
-| `analyze_videos`               |     🟢      | `in_random_order`, `dynamic`, `n_tracks`, `calibrate`                                               |                                                     |
+| `analyze_videos`               |     🟠      | `in_random_order`, `dynamic`, `n_tracks`, `calibrate`                                               |                                                     |
 | `create_tracking_dataset`      |     🔴      |                                                                                                     |                                                     |
 | `analyze_time_lapse_frames`    |     🟠      | the name has changed to  `analyze_images` to better reflect what it actually does (no video needed) |                                                     |
 | `convert_detections2tracklets` |     🟢      | `greedy`, `calibrate`, `window_size`                                                                |                                                     |

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -374,6 +374,7 @@ def run(
         trainingsetindex=trainset_index,
         device=device,
         plotting=True,
+        per_keypoint_evaluation=True,
     )
     times.append(time.time())
     log_step(f"Evaluation time: {times[-1] - times[-2]} seconds")

--- a/tests/core/metrics/test_metrics_api.py
+++ b/tests/core/metrics/test_metrics_api.py
@@ -16,6 +16,17 @@ from numpy.testing import assert_almost_equal
 import deeplabcut.core.metrics as metrics
 
 
+def _get_gt_and_pred_with_constant_err(
+    num_idv: int, num_bpt: int, error: float
+) -> tuple[np.ndarray, np.ndarray]:
+    gt = np.arange(num_idv * num_bpt * 3).astype(float).reshape((num_idv, num_bpt, 3))
+    gt[..., 2] = 2
+    predictions = gt.copy()
+    predictions[..., 2] = 0.9
+    predictions[..., :2] += error
+    return gt, predictions
+
+
 def test_computing_metrics_with_no_predictions():
     gt = np.arange(5 * 6 * 3).astype(float).reshape((5, 6, 3))
     gt[..., 2] = 2
@@ -30,11 +41,7 @@ def test_computing_metrics_with_no_predictions():
 @pytest.mark.parametrize("error", [0.5, 1, 2])
 def test_computing_metrics_with_constant_error(error):
     # only works for small errors: otherwise another matching can be found
-    gt = np.arange(5 * 6 * 3).astype(float).reshape((5, 6, 3))
-    gt[..., 2] = 2
-    predictions = gt.copy()
-    predictions[..., 2] = 0.9
-    predictions[..., :2] += error
+    gt, predictions = _get_gt_and_pred_with_constant_err(5, 6, error)
     results = metrics.compute_metrics(
         ground_truth={"image": gt},
         predictions={"image": predictions},
@@ -43,6 +50,46 @@ def test_computing_metrics_with_constant_error(error):
     )
     assert_almost_equal(results["rmse"], np.sqrt(2) * error)
     assert_almost_equal(results["rmse_pcutoff"], np.sqrt(2) * error)
+
+
+@pytest.mark.parametrize("error", [0.5, 1, 2])
+def test_metrics_with_unique_with_constant_error(error):
+    # only works for small errors: otherwise another matching can be found
+    gt, predictions = _get_gt_and_pred_with_constant_err(5, 6, error)
+    gt_unique, pred_unique = _get_gt_and_pred_with_constant_err(1, 8, error)
+    results = metrics.compute_metrics(
+        ground_truth={"image": gt},
+        predictions={"image": predictions},
+        unique_bodypart_gt={"image": gt_unique},
+        unique_bodypart_poses={"image": pred_unique},
+    )
+    assert_almost_equal(results["rmse"], np.sqrt(2) * error)
+    assert_almost_equal(results["rmse_pcutoff"], np.sqrt(2) * error)
+
+
+@pytest.mark.parametrize("error", [0.5, 1, 2])
+def test_metrics_per_bpt_with_unique_with_constant_error(error):
+    # only works for small errors: otherwise another matching can be found
+    gt, predictions = _get_gt_and_pred_with_constant_err(5, 6, error)
+    gt_unique, pred_unique = _get_gt_and_pred_with_constant_err(1, 8, error)
+    results = metrics.compute_metrics(
+        ground_truth={"image": gt},
+        predictions={"image": predictions},
+        unique_bodypart_gt={"image": gt_unique},
+        unique_bodypart_poses={"image": pred_unique},
+        per_keypoint_rmse=True,
+    )
+    assert_almost_equal(results["rmse"], np.sqrt(2) * error)
+    assert_almost_equal(results["rmse_pcutoff"], np.sqrt(2) * error)
+
+    for bpt_idx in range(gt.shape[1]):
+        key = f"rmse_keypoint_{bpt_idx}"
+        assert key in results
+        assert_almost_equal(results[key], np.sqrt(2) * error)
+    for bpt_idx in range(gt_unique.shape[1]):
+        key = f"rmse_unique_keypoint_{bpt_idx}"
+        assert key in results
+        assert_almost_equal(results[key], np.sqrt(2) * error)
 
 
 @pytest.mark.parametrize("error", [0.5, 1, 2])

--- a/tests/core/metrics/test_metrics_rmse_computation.py
+++ b/tests/core/metrics/test_metrics_rmse_computation.py
@@ -57,7 +57,8 @@ from deeplabcut.core.metrics.distance_metrics import (
 )
 def test_rmse_single_image(gt: list, pred: list, result: tuple[float, float]):
     data = [(np.asarray(gt), np.asarray(pred))]
-    rmse, rmse_cutoff = compute_rmse(data, False, pcutoff=0.6, oks_bbox_margin=10.0)
+    computed_results = compute_rmse(data, False, pcutoff=0.6, oks_bbox_margin=10.0)
+    rmse, rmse_cutoff = computed_results["rmse"], computed_results["rmse_pcutoff"]
     expected_rmse, expected_rmse_cutoff = result
     assert_almost_equal(rmse, expected_rmse)
     assert_almost_equal(rmse_cutoff, expected_rmse_cutoff)
@@ -83,7 +84,8 @@ def test_rmse_pcutoff(gt: list, pred: list, result: tuple[float, float]):
     data = [(np.asarray(gt), np.asarray(pred))]
     expected_rmse, expected_rmse_cutoff = result
 
-    rmse, rmse_cutoff = compute_rmse(data, False, pcutoff=0.6, oks_bbox_margin=10.0)
+    computed_results = compute_rmse(data, False, pcutoff=0.6, oks_bbox_margin=10.0)
+    rmse, rmse_cutoff = computed_results["rmse"], computed_results["rmse_pcutoff"]
     assert_almost_equal(rmse, expected_rmse)
     assert_almost_equal(rmse_cutoff, expected_rmse_cutoff)
 
@@ -117,7 +119,8 @@ def test_rmse_with_nans(gt: list, pred: list, result: tuple[float, float]):
     data = [(np.asarray(gt), np.asarray(pred))]
     expected_rmse, expected_rmse_cutoff = result
 
-    rmse, rmse_cutoff = compute_rmse(data, False, pcutoff=0.6, oks_bbox_margin=10.0)
+    results = compute_rmse(data, False, pcutoff=0.6, oks_bbox_margin=10.0)
+    rmse, rmse_cutoff = results["rmse"], results["rmse_pcutoff"]
     assert_almost_equal(rmse, expected_rmse)
     assert_almost_equal(rmse_cutoff, expected_rmse_cutoff)
 
@@ -199,3 +202,141 @@ def test_detection_rmse(gt: list, pred: list, result: tuple[float, float]):
     rmse, rmse_cutoff = compute_detection_rmse(data, pcutoff=0.6)
     assert_almost_equal(rmse, expected_rmse)
     assert_almost_equal(rmse_cutoff, expected_rmse_cutoff)
+
+
+@pytest.mark.parametrize(
+    "gt, pred, unique_gt, unique_pred, result",
+    [
+        (
+            [  # ground truth pose
+                [[10.0, 10.0, 2], [10.0, 10.0, 2], [10.0, 10.0, 2]],
+                [[20.0, 20.0, 2], [20.0, 20.0, 2], [20.0, 20.0, 2]],
+            ],
+            [  # predicted pose
+                [[10.0, 10.0, 0.9], [10.0, 10.0, 0.9], [10.0, 10.0, 0.9]],
+                [[20.0, 24.0, 0.2], [20.0, 24.0, 0.2], [20.0, 20.0, 0.2]],
+            ],
+            [  # Unique GT
+                [[10.0, 10.0, 2], [10.0, 10.0, 2]],
+            ],
+            [  # Unique Pred
+                [[10.0, 10.0, 0.9], [10.0, 10.0, 0.9]],
+            ],
+            # 4 pixel error on 2 keypoints, 0 error on 5 keypoints
+            (1.0, 0.0),
+        ),
+        (
+            [np.zeros((0, 3, 2))],  # no GT pose
+            [  # predicted pose
+                [[10.0, 10.0, 0.9], [10.0, 10.0, 0.9], [10.0, 10.0, 0.9]],
+            ],
+            [  # Unique GT
+                [[10.0, 10.0, 2], [10.0, 10.0, 2]],
+            ],
+            [  # Unique Pred
+                [[15.0, 10.0, 0.5], [11.0, 10.0, 0.9]],
+            ],
+            # 5 pixel error on 1 keypoint, 1 pixel error on the other
+            (3.0, 1.0),
+        ),
+    ],
+)
+def test_rmse_with_unique(
+    gt: list,
+    pred: list,
+    unique_gt: list,
+    unique_pred: list,
+    result: tuple[float, float]
+) -> None:
+    data = [(np.asarray(gt), np.asarray(pred))]
+    data_unique = [(np.asarray(unique_gt), np.asarray(unique_pred))]
+    expected_rmse, expected_rmse_cutoff = result
+
+    results = compute_rmse(
+        data, False, pcutoff=0.6, data_unique=data_unique, oks_bbox_margin=10.0,
+    )
+    rmse, rmse_cutoff = results["rmse"], results["rmse_pcutoff"]
+    assert_almost_equal(rmse, expected_rmse)
+    assert_almost_equal(rmse_cutoff, expected_rmse_cutoff)
+
+
+@pytest.mark.parametrize(
+    "gt, pred, unique_gt, unique_pred, result",
+    [
+        (
+            [  # ground truth pose
+                [[10.0, 10.0, 2], [10.0, 10.0, 2], [10.0, 10.0, 2]],
+                [[20.0, 20.0, 2], [20.0, 20.0, 2], [20.0, 20.0, 2]],
+            ],
+            [  # predicted pose
+                [[10.0, 10.0, 0.9], [10.0, 10.0, 0.9], [10.0, 10.0, 0.9]],
+                [[20.0, 24.0, 0.2], [20.0, 24.0, 0.2], [20.0, 20.0, 0.2]],
+            ],
+            [  # Unique GT
+                [[10.0, 10.0, 2], [10.0, 10.0, 2]],
+            ],
+            [  # Unique Pred
+                [[10.0, 10.0, 0.9], [10.0, 10.0, 0.9]],
+            ],
+            # 4 pixel error on 2 keypoints, 0 error on 5 keypoints
+            [
+                (1.0, 0.0),
+                [2.0, 2.0, 0.0],
+                [0.0, 0.0]
+            ],
+        ),
+        (
+            [  # ground truth pose
+                [[10.0, 10.0, 2], [10.0, 10.0, 2], [10.0, 10.0, 2]],
+                [[20.0, 20.0, 2], [20.0, 20.0, 2], [20.0, 20.0, 2]],
+            ],
+            [  # predicted pose
+                [[10.0, 12.0, 0.9], [10.0, 10.0, 0.9], [10.0, 10.0, 0.9]],
+                [[20.0, 24.0, 0.7], [20.0, 24.0, 0.6], [20.0, 20.0, 0.8]],
+            ],
+            [  # Unique GT
+                [[10.0, 10.0, 2], [10.0, 10.0, 2]],
+            ],
+            [  # Unique Pred
+                [[12.0, 10.0, 0.9], [11.0, 10.0, 0.9]],
+            ],
+            [  # errors: 3 with 0px, 1 with 1px, 2 with 2px, 2 with 4px => 13/8
+                (1.625, 1.625),
+                [3.0, 2.0, 0.0],
+                [2.0, 1.0]
+            ],
+        ),
+    ],
+)
+def test_rmse_per_bodypart_with_unique(
+    gt: list,
+    pred: list,
+    unique_gt: list,
+    unique_pred: list,
+    result: tuple[tuple[float, float], list[float], list[float]]
+) -> None:
+    data = [(np.asarray(gt), np.asarray(pred))]
+    data_unique = [(np.asarray(unique_gt), np.asarray(unique_pred))]
+    expected_rmse, expected_rmse_cutoff = result[0]
+    bodypart_rmse = result[1]
+    unique_rmse = result[2]
+
+    results = compute_rmse(
+        data,
+        single_animal=False,
+        pcutoff=0.6,
+        data_unique=data_unique,
+        per_keypoint_results=True,
+        oks_bbox_margin=10.0,
+    )
+    assert_almost_equal(results["rmse"], expected_rmse)
+    assert_almost_equal(results["rmse_pcutoff"], expected_rmse_cutoff)
+    for bpt_index, bpt_rmse in enumerate(bodypart_rmse):
+        key = f"rmse_keypoint_{bpt_index}"
+        assert key in results
+        assert_almost_equal(results[key], bpt_rmse)
+
+    for bpt_index, bpt_rmse in enumerate(unique_rmse):
+        key = f"rmse_unique_keypoint_{bpt_index}"
+        assert key in results
+        assert_almost_equal(results[key], bpt_rmse)


### PR DESCRIPTION
This pull request implements the `per_keypoint_evaluation` and `comparisonbodyparts` parameters for PyTorch pose estimation models.

## Updates

- New `per_keypoint_evaluation ` argument for `deeplabcut.pose_estimation_pytorch.apis.evaluation.evaluate_network` to compute the errors (RMSE and mAP) based on a subset of bodyparts, as done for `tensorflow` models
- New `comparisonbodyparts` argument for `deeplabcut.pose_estimation_pytorch.apis.evaluation.evaluate_network` to compute RMSE per-bodypart and store the results in a CSV file, as done for `tensorflow` models
- Inclusion of unique bodypart RMSE in the "main" RMSE computation to match the `tensorflow` RMSE computation
- Additional tests to verify that RMSE computation is correct
- Updates the functional PyTorch tests to compute per-bodypart RMSE
- Update `docs/pytorch/user_guide.md` so that methods where parameters still need to be implemented are labeled orange and not green
- Update `docs/pytorch/user_guide.md` to reflect that `comparisonbodyparts` and `per_keypoint_evaluation` can now be used with PyTorch models
