### PR TITLE
Set `weights_only=True` as a default when loading snapshot weights.

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/apis/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/utils.py
@@ -516,6 +516,9 @@ def get_inference_runners(
                 postprocessor=build_detector_postprocessor(
                     max_individuals=max_individuals,
                 ),
+                load_weights_only=model_config["detector"]["runner"].get(
+                    "load_weights_only", True,
+                ),
             )
 
     pose_runner = build_inference_runner(
@@ -526,6 +529,7 @@ def get_inference_runners(
         batch_size=batch_size,
         preprocessor=pose_preprocessor,
         postprocessor=pose_postprocessor,
+        load_weights_only=model_config["runner"].get("load_weights_only", True),
     )
     return pose_runner, detector_runner
 
@@ -575,6 +579,7 @@ def get_detector_inference_runner(
         batch_size=batch_size,
         preprocessor=preprocessor,
         postprocessor=postprocessor,
+        load_weights_only=det_cfg["runner"].get("load_weights_only", True),
     )
 
     if not isinstance(runner, DetectorInferenceRunner):
@@ -650,6 +655,7 @@ def get_pose_inference_runner(
         batch_size=batch_size,
         preprocessor=pose_preprocessor,
         postprocessor=pose_postprocessor,
+        load_weights_only=model_config["runner"].get("load_weights_only", True),
     )
     if not isinstance(runner, PoseInferenceRunner):
         raise RuntimeError(f"Failed to build PoseInferenceRunner for {model_config}")

--- a/deeplabcut/pose_estimation_pytorch/runners/base.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/base.py
@@ -10,7 +10,6 @@
 #
 from __future__ import annotations
 
-import logging
 import pickle
 from abc import ABC
 from pathlib import Path

--- a/deeplabcut/pose_estimation_pytorch/runners/base.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/base.py
@@ -19,7 +19,6 @@ from typing import Generic, TypeVar
 import torch
 import torch.nn as nn
 
-
 ModelType = TypeVar("ModelType", bound=nn.Module)
 
 
@@ -87,7 +86,9 @@ class Runner(ABC, Generic[ModelType]):
         """
         try:
             snapshot = torch.load(
-                snapshot_path, map_location=device, weights_only=weights_only,
+                snapshot_path,
+                map_location=device,
+                weights_only=weights_only,
             )
         except pickle.UnpicklingError as err:
             print(

--- a/deeplabcut/pose_estimation_pytorch/runners/base.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/base.py
@@ -10,6 +10,8 @@
 #
 from __future__ import annotations
 
+import logging
+import pickle
 from abc import ABC
 from pathlib import Path
 from typing import Generic, TypeVar
@@ -63,6 +65,7 @@ class Runner(ABC, Generic[ModelType]):
         snapshot_path: str | Path,
         device: str,
         model: ModelType,
+        weights_only: bool = True,
     ) -> dict:
         """Loads the state dict for a model from a file
 
@@ -70,13 +73,34 @@ class Runner(ABC, Generic[ModelType]):
         a given device, and sets the model weights using the state_dict.
 
         Args:
-            snapshot_path: the path containing the model weights to load
-            device: the device on which the model should be loaded
-            model: the model for which the weights are loaded
+            snapshot_path: The path containing the model weights to load
+            device: The device on which the model should be loaded
+            model: The model for which the weights are loaded
+            weights_only: Value for torch.load() `weights_only` parameter. If False, the
+                python pickle module is used implicitly, which is known to be insecure.
+                Only set to False if you're loading data that you trust (e.g. snapshots
+                that you created yourself). For more information, see:
+                    https://pytorch.org/docs/stable/generated/torch.load.html
 
         Returns:
             The content of the snapshot file.
         """
-        snapshot = torch.load(snapshot_path, map_location=device)
+        try:
+            snapshot = torch.load(
+                snapshot_path, map_location=device, weights_only=weights_only,
+            )
+        except pickle.UnpicklingError as err:
+            print(
+                f"\nFailed to load the snapshot: {snapshot_path}.\n"
+                "If you trust the snapshot that you're trying to load, you can try "
+                "calling `Runner.load_snapshot` with `weights_only=False`. See "
+                "the message below for more information and warnings.\n"
+                "You can set the `weights_only` parameter in the model configuration ("
+                "the content of the pytorch_config.yaml), as:\n```\n"
+                "runner:\n"
+                "  load_weights_only: False\n```\n"
+            )
+            raise err
+
         model.load_state_dict(snapshot["model"])
         return snapshot

--- a/deeplabcut/pose_estimation_pytorch/runners/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/inference.py
@@ -92,8 +92,10 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
     @torch.no_grad()
     def inference(
         self,
-        images: Iterable[str | Path | np.ndarray]
-        | Iterable[tuple[str | Path | np.ndarray, dict[str, Any]]],
+        images: (
+            Iterable[str | Path | np.ndarray]
+            | Iterable[tuple[str | Path | np.ndarray, dict[str, Any]]]
+        ),
         shelf_writer: shelving.ShelfWriter | None = None,
     ) -> list[dict[str, np.ndarray]]:
         """Run model inference on the given dataset
@@ -135,7 +137,8 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
         return results
 
     def _prepare_inputs(
-        self, data: str | Path | np.ndarray | tuple[str | Path | np.ndarray, dict],
+        self,
+        data: str | Path | np.ndarray | tuple[str | Path | np.ndarray, dict],
     ) -> None:
         """
         Prepares inputs for an image and adds them to the data ready to be processed
@@ -203,14 +206,14 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
         Processes a batch. There must be inputs waiting to be processed before this is
         called, otherwise this method will raise an error.
         """
-        batch = self._batch[:self.batch_size]
+        batch = self._batch[: self.batch_size]
         self._predictions += self.predict(batch)
 
         # remove processed inputs from batch
         if len(self._batch) <= self.batch_size:
             self._batch = None
         else:
-            self._batch = self._batch[self.batch_size:]
+            self._batch = self._batch[self.batch_size :]
 
     def _inputs_waiting_for_processing(self) -> bool:
         """Returns: Whether there are inputs which have not yet been processed"""
@@ -282,14 +285,8 @@ class DetectorInferenceRunner(InferenceRunner[BaseDetector]):
         predictions = [
             {
                 "detection": {
-                    "bboxes": item["boxes"]
-                    .cpu()
-                    .numpy()
-                    .reshape(-1, 4),
-                    "scores": item["scores"]
-                    .cpu()
-                    .numpy()
-                    .reshape(-1),
+                    "bboxes": item["boxes"].cpu().numpy().reshape(-1, 4),
+                    "scores": item["scores"].cpu().numpy().reshape(-1),
                 }
             }
             for item in raw_predictions

--- a/deeplabcut/pose_estimation_pytorch/runners/train.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/train.py
@@ -19,8 +19,8 @@ from typing import Any, Generic
 import numpy as np
 import torch
 import torch.nn as nn
-from torch.utils.data import DataLoader
 from torch.nn.parallel import DataParallel
+from torch.utils.data import DataLoader
 
 import deeplabcut.core.metrics as metrics
 import deeplabcut.pose_estimation_pytorch.runners.schedulers as schedulers

--- a/deeplabcut/pose_estimation_pytorch/runners/train.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/train.py
@@ -63,6 +63,12 @@ class TrainingRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
             might be used.
         logger: Logger to monitor training (e.g. a WandBLogger).
         log_filename: Name of the file in which to store training stats.
+        load_weights_only: Value for the torch.load() `weights_only` parameter if
+            `snapshot_path` is not None. If False, the python pickle module is used
+            implicitly, which is known to be insecure. Only set to False if you're
+            loading data that you trust (e.g. snapshots that you created yourself). For
+            more information, see:
+                https://pytorch.org/docs/stable/generated/torch.load.html
     """
 
     def __init__(
@@ -78,6 +84,7 @@ class TrainingRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
         load_scheduler_state_dict: bool = True,
         logger: BaseLogger | None = None,
         log_filename: str = "learning_stats.csv",
+        load_weights_only: bool = True,
     ):
         super().__init__(
             model=model, device=device, gpus=gpus, snapshot_path=snapshot_path
@@ -104,7 +111,12 @@ class TrainingRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
         self._print_valid_loss = True
 
         if self.snapshot_path:
-            snapshot = self.load_snapshot(self.snapshot_path, self.device, self.model)
+            snapshot = self.load_snapshot(
+                self.snapshot_path,
+                self.device,
+                self.model,
+                weights_only=load_weights_only,
+            )
             self.starting_epoch = snapshot.get("metadata", {}).get("epoch", 0)
 
             if "optimizer" in snapshot:
@@ -639,9 +651,7 @@ def build_training_runner(
     Returns:
         the runner that was built
     """
-    optim_cfg = runner_config["optimizer"]
-    optim_cls = getattr(torch.optim, optim_cfg["type"])
-    optimizer = optim_cls(params=model.parameters(), **optim_cfg["params"])
+    optimizer = build_optimizer(model, runner_config["optimizer"])
     scheduler = schedulers.build_scheduler(runner_config.get("scheduler"), optimizer)
 
     # if no custom snapshot prefix is defined, use the default one
@@ -668,6 +678,7 @@ def build_training_runner(
         scheduler=scheduler,
         load_scheduler_state_dict=runner_config.get("load_scheduler_state_dict", True),
         logger=logger,
+        load_weights_only=runner_config.get("load_weights_only", True),
     )
     if task == Task.DETECT:
         return DetectorTrainingRunner(**kwargs)

--- a/examples/openfield-Pranav-2018-10-30/config.yaml
+++ b/examples/openfield-Pranav-2018-10-30/config.yaml
@@ -7,7 +7,7 @@ identity:
 
 
 # Project path (change when moving around)
-project_path:
+project_path: WILL BE AUTOMATICALLY UPDATED BY DEMO CODE
 
 
 # Default DeepLabCut engine to use for shuffle creation (either pytorch or tensorflow)
@@ -23,9 +23,6 @@ bodyparts:
 - leftear
 - rightear
 - tailbase
-
-
-# Fraction of video to start/stop when extracting frames for labeling/refinement
 
 
 # Fraction of video to start/stop when extracting frames for labeling/refinement

--- a/examples/openfield-Pranav-2018-10-30/config.yaml
+++ b/examples/openfield-Pranav-2018-10-30/config.yaml
@@ -7,7 +7,8 @@ identity:
 
 
 # Project path (change when moving around)
-project_path: WILL BE AUTOMATICALLY UPDATED BY DEMO CODE
+project_path: 
+  /Users/niels/Documents/upamathis/repos/DeepLabCut/examples/openfield-Pranav-2018-10-30
 
 
 # Default DeepLabCut engine to use for shuffle creation (either pytorch or tensorflow)
@@ -23,6 +24,9 @@ bodyparts:
 - leftear
 - rightear
 - tailbase
+
+
+# Fraction of video to start/stop when extracting frames for labeling/refinement
 
 
 # Fraction of video to start/stop when extracting frames for labeling/refinement

--- a/examples/openfield-Pranav-2018-10-30/config.yaml
+++ b/examples/openfield-Pranav-2018-10-30/config.yaml
@@ -7,8 +7,7 @@ identity:
 
 
 # Project path (change when moving around)
-project_path: 
-  /Users/niels/Documents/upamathis/repos/DeepLabCut/examples/openfield-Pranav-2018-10-30
+project_path:
 
 
 # Default DeepLabCut engine to use for shuffle creation (either pytorch or tensorflow)

--- a/tests/pose_estimation_pytorch/modelzoo/test_load_superanimal_models.py
+++ b/tests/pose_estimation_pytorch/modelzoo/test_load_superanimal_models.py
@@ -1,0 +1,31 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+import dlclibrary
+import pytest
+import torch
+
+from deeplabcut.pose_estimation_pytorch.modelzoo import get_super_animal_snapshot_path
+
+
+@pytest.mark.skip(reason="require-models")
+def test_load_superanimal_models_weights_only():
+    super_animal_names = dlclibrary.get_available_datasets()
+    for super_animal in super_animal_names:
+        print(f"\nTesting {super_animal}")
+        for detector in dlclibrary.get_available_detectors(super_animal):
+            print(super_animal, detector)
+            path = get_super_animal_snapshot_path(super_animal, detector)
+            snapshot = torch.load(path, map_location="cpu", weights_only=True)
+
+        for pose_model in dlclibrary.get_available_models(super_animal):
+            print(super_animal, pose_model)
+            path = get_super_animal_snapshot_path(super_animal, pose_model)
+            snapshot = torch.load(path, map_location="cpu", weights_only=True)

--- a/tests/pose_estimation_pytorch/runners/test_runners.py
+++ b/tests/pose_estimation_pytorch/runners/test_runners.py
@@ -1,0 +1,29 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+import pickle
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+import torch
+
+import deeplabcut.pose_estimation_pytorch.runners as runners
+
+
+def test_load_snapshot_weights_only_error(tmpdir_factory):
+    snapshot_dir = tmpdir_factory.mktemp("snapshot-dir")
+    snapshot_path = snapshot_dir / "snapshot.pt"
+    torch.save(dict(content=np.zeros(10)), snapshot_path)
+
+    with pytest.raises(pickle.UnpicklingError):
+        runners.Runner.load_snapshot(
+            snapshot_path, device="cpu", model=Mock(), weights_only=True
+        )

--- a/tests/pose_estimation_pytorch/runners/test_runners_inference.py
+++ b/tests/pose_estimation_pytorch/runners/test_runners_inference.py
@@ -59,8 +59,7 @@ class MockInferenceRunner(inference.InferenceRunner):
     def predict(self, inputs: torch.Tensor) -> list[dict[str, dict[str, np.ndarray]]]:
         self.batch_shapes.append(tuple(inputs.shape))
         return [  # return first elem of input
-            {"mock": {"index": i[0, 0, 0].detach().numpy()}}
-            for i in inputs
+            {"mock": {"index": i[0, 0, 0].detach().numpy()}} for i in inputs
         ]
 
 
@@ -101,8 +100,8 @@ def test_mock_bottom_up(batch_size):
         [0, 0, 0, 5, 2],
         [1, 2, 3, 4],
         [3, 4, 2, 1, 4],
-        [4, 23, 5, 20, 64, 100]
-    ]
+        [4, 23, 5, 20, 64, 100],
+    ],
 )
 def test_mock_top_down(batch_size, detections_per_image):
     h, w = 8, 8

--- a/tests/pose_estimation_pytorch/runners/test_runners_inference.py
+++ b/tests/pose_estimation_pytorch/runners/test_runners_inference.py
@@ -9,7 +9,7 @@
 # Licensed under GNU Lesser General Public License v3.0
 #
 """Tests inference runners"""
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import numpy as np
 import pytest
@@ -18,6 +18,25 @@ import torch
 import deeplabcut.pose_estimation_pytorch.data.postprocessor as post
 import deeplabcut.pose_estimation_pytorch.data.preprocessor as prep
 import deeplabcut.pose_estimation_pytorch.runners.inference as inference
+from deeplabcut.pose_estimation_pytorch.task import Task
+
+
+@patch("deeplabcut.pose_estimation_pytorch.runners.train.build_optimizer", Mock())
+@pytest.mark.parametrize("task", [Task.DETECT, Task.TOP_DOWN, Task.BOTTOM_UP])
+@pytest.mark.parametrize("weights_only", [True, False])
+def test_load_weights_only_with_build_training_runner(task: Task, weights_only: bool):
+    with patch("deeplabcut.pose_estimation_pytorch.runners.base.torch.load") as load:
+        snapshot = "snapshot.pt"
+        runner = inference.build_inference_runner(
+            task=task,
+            model=Mock(),
+            device="cpu",
+            snapshot_path=snapshot,
+            load_weights_only=weights_only,
+        )
+        load.assert_called_once_with(
+            snapshot, map_location="cpu", weights_only=weights_only
+        )
 
 
 class MockInferenceRunner(inference.InferenceRunner):

--- a/tests/pose_estimation_pytorch/runners/test_runners_train.py
+++ b/tests/pose_estimation_pytorch/runners/test_runners_train.py
@@ -55,7 +55,7 @@ TEST_SCHEDULERS = [
     SchedulerTestConfig(
         cfg=dict(
             type="LRListScheduler",
-            params=dict(milestones=[2, 5], lr_list=[[0.5], [0.1]])
+            params=dict(milestones=[2, 5], lr_list=[[0.5], [0.1]]),
         ),
         init_lr=1.0,
         expected_lrs=[1.0, 1.0, 0.5, 0.5, 0.5, 0.1, 0.1, 0.1],
@@ -79,9 +79,13 @@ TEST_SCHEDULERS = [
 
 
 @patch("deeplabcut.pose_estimation_pytorch.runners.train.CSVLogger", Mock())
-@pytest.mark.parametrize("runner_cls", [
-    train_runners.PoseTrainingRunner, train_runners.DetectorTrainingRunner,
-])
+@pytest.mark.parametrize(
+    "runner_cls",
+    [
+        train_runners.PoseTrainingRunner,
+        train_runners.DetectorTrainingRunner,
+    ],
+)
 @pytest.mark.parametrize("test_cfg", TEST_SCHEDULERS)
 def test_training_with_scheduler(runner_cls, test_cfg: SchedulerTestConfig) -> None:
     runner = _fit_runner_and_check_lrs(
@@ -94,9 +98,13 @@ def test_training_with_scheduler(runner_cls, test_cfg: SchedulerTestConfig) -> N
 
 
 @patch("deeplabcut.pose_estimation_pytorch.runners.train.CSVLogger", Mock())
-@pytest.mark.parametrize("runner_cls", [
-    train_runners.PoseTrainingRunner, train_runners.DetectorTrainingRunner,
-])
+@pytest.mark.parametrize(
+    "runner_cls",
+    [
+        train_runners.PoseTrainingRunner,
+        train_runners.DetectorTrainingRunner,
+    ],
+)
 @pytest.mark.parametrize("test_cfg", TEST_SCHEDULERS)
 def test_resuming_training_scheduler_every_epoch(
     runner_cls,
@@ -117,9 +125,13 @@ def test_resuming_training_scheduler_every_epoch(
 
 
 @patch("deeplabcut.pose_estimation_pytorch.runners.train.CSVLogger", Mock())
-@pytest.mark.parametrize("runner_cls", [
-    train_runners.PoseTrainingRunner, train_runners.DetectorTrainingRunner,
-])
+@pytest.mark.parametrize(
+    "runner_cls",
+    [
+        train_runners.PoseTrainingRunner,
+        train_runners.DetectorTrainingRunner,
+    ],
+)
 @pytest.mark.parametrize(
     "test_cfg, resume_epoch",
     [
@@ -127,7 +139,7 @@ def test_resuming_training_scheduler_every_epoch(
             SchedulerTestConfig(
                 cfg=dict(
                     type="LRListScheduler",
-                    params=dict(milestones=[2, 5], lr_list=[[0.5], [0.1]])
+                    params=dict(milestones=[2, 5], lr_list=[[0.5], [0.1]]),
                 ),
                 init_lr=1.0,
                 expected_lrs=[1.0, 1.0, 0.5, 1.0, 1.0, 0.1, 0.1, 0.1],
@@ -149,13 +161,11 @@ def test_resuming_training_scheduler_every_epoch(
                 expected_lrs=(4 * [1.0]) + [0.1, 1, 1, 1] + (4 * [0.1]),
             ),
             5,  # cut after the 5th epoch - restart at LR=1 and update again at 8
-        )
-    ]
+        ),
+    ],
 )
 def test_resuming_training_with_no_scheduler_state(
-    runner_cls,
-    test_cfg: SchedulerTestConfig,
-    resume_epoch: int
+    runner_cls, test_cfg: SchedulerTestConfig, resume_epoch: int
 ):
     """
     Without a scheduler config, there is no way to set the initial LR. All we can do is
@@ -209,13 +219,13 @@ def _fit_runner_and_check_lrs(
             snapshot_manager=Mock(),
             scheduler=scheduler,
             snapshot_path=snapshot_path,
-            **runner_kwargs
+            **runner_kwargs,
         )
 
         # Mock the step call; check that the learning rate is correct for the epoch
         def step(*args, **kwargs):
             # the current_epoch value is indexed at 1
-            total_epoch = (runner.current_epoch - 1)
+            total_epoch = runner.current_epoch - 1
             epoch = total_epoch - runner.starting_epoch
             _assert_learning_rates_match(total_epoch, optimizer, expected_lrs[epoch])
             optimizer.step()


### PR DESCRIPTION
Addresses #2725. The `torch.load` method is now called with `weights_only=True` as a default. If loading snapshot weights fails, users can set a `load_weights_only: False` key in their `pytorch_config.yaml` file to set the `weights_only` parameter to False. This is explained in the error message when loading weights fails. This should only be done when users trust the content of the snapshot they're loading, as explained in [the `torch.load` docs](https://pytorch.org/docs/stable/generated/torch.load.html).

Tests were added to ensure `torch.load` was called with the correct parameters.

To set `weights_only=False`, users can edit their `pytorch_config.yaml` files as:

```yaml
detector:
    ...
    runner:
        load_weights_only: false  # to load detector weights with `weights_only=False`

runner:
    load_weights_only: false  # to load pose model weights with `weights_only=False`
```