### PR TITLE
Fix check version timeout Version 2 (compatible with Windows and MacOS)

### DIFF
--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import List
 from urllib.error import URLError
 import qdarkstyle
-import multiprocessing
 
 import deeplabcut
 from deeplabcut import auxiliaryfunctions, VERSION, compat
@@ -25,6 +24,7 @@ from deeplabcut.core.engine import Engine
 from deeplabcut.gui import BASE_DIR, components, utils
 from deeplabcut.gui.tabs import *
 from deeplabcut.gui.widgets import StreamReceiver, StreamWriter
+from deeplabcut.utils.multiprocessing import call_with_timeout
 from napari_deeplabcut import misc
 from PySide6.QtWidgets import (
     QMessageBox,
@@ -39,33 +39,6 @@ from PySide6 import QtCore
 from PySide6.QtGui import QIcon, QAction, QPixmap
 from PySide6 import QtWidgets, QtGui
 from PySide6.QtCore import Qt, QTimer
-
-
-def call_with_timeout(func, timeout, *args, **kwargs):
-    def wrapper(queue, *args, **kwargs):
-        try:
-            result = func(*args, **kwargs)
-            queue.put(result)  # Pass the result back via the queue
-        except Exception as e:
-            queue.put(e)  # Pass any exception back via the queue
-
-    queue = multiprocessing.Queue()
-    process = multiprocessing.Process(target=wrapper, args=(queue, *args), kwargs=kwargs)
-    process.start()
-    process.join(timeout)
-
-    if process.is_alive():
-        process.terminate()  # Forcefully terminate the process
-        process.join()
-        raise TimeoutError(f"Function {func.__name__} did not complete within {timeout} seconds.")
-
-    if not queue.empty():
-        result = queue.get()
-        if isinstance(result, Exception):
-            raise result  # Re-raise the exception if it occurred in the function
-        return result
-    else:
-        raise TimeoutError(f"Function {func.__name__} completed but did not return a result.")
 
 
 def _check_for_updates(silent=True):

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -44,10 +44,10 @@ from PySide6.QtCore import Qt, QTimer
 def _check_for_updates(silent=True):
     try:
         is_latest, latest_version = call_with_timeout(
-            utils.is_latest_deeplabcut_version, 1
+            utils.is_latest_deeplabcut_version, 5
         )
         is_latest_plugin, latest_plugin_version = call_with_timeout(
-            misc.is_latest_version, 1
+            misc.is_latest_version, 5
         )
     except (URLError, TimeoutError):  # Handle internet connectivity issues
         is_latest = is_latest_plugin = True

--- a/deeplabcut/utils/multiprocessing.py
+++ b/deeplabcut/utils/multiprocessing.py
@@ -27,16 +27,21 @@ def _wrapper(func, queue, *args, **kwargs):
     except Exception as e:
         queue.put(e)  # Pass any exception back via the queue
 
+
 def call_with_timeout(func, timeout, *args, **kwargs):
     queue = multiprocessing.Queue()
-    process = multiprocessing.Process(target=_wrapper, args=(func, queue, *args), kwargs=kwargs)
+    process = multiprocessing.Process(
+        target=_wrapper, args=(func, queue, *args), kwargs=kwargs
+    )
     process.start()
     process.join(timeout)
 
     if process.is_alive():
         process.terminate()  # Forcefully terminate the process
         process.join()
-        raise TimeoutError(f"Function {func.__name__} did not complete within {timeout} seconds.")
+        raise TimeoutError(
+            f"Function {func.__name__} did not complete within {timeout} seconds."
+        )
 
     if not queue.empty():
         result = queue.get()
@@ -44,6 +49,6 @@ def call_with_timeout(func, timeout, *args, **kwargs):
             raise result  # Re-raise the exception if it occurred in the function
         return result
     else:
-        raise TimeoutError(f"Function {func.__name__} completed but did not return a result.")
-
-
+        raise TimeoutError(
+            f"Function {func.__name__} completed but did not return a result."
+        )

--- a/deeplabcut/utils/multiprocessing.py
+++ b/deeplabcut/utils/multiprocessing.py
@@ -1,0 +1,50 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/master/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""
+DeepLabCut2.2 Toolbox (deeplabcut.org)
+© A. & M. Mathis Labs
+https://github.com/DeepLabCut/DeepLabCut
+Please see AUTHORS for contributors.
+
+https://github.com/DeepLabCut/DeepLabCut/blob/master/AUTHORS
+Licensed under GNU Lesser General Public License v3.0
+"""
+import multiprocessing
+
+
+
+def call_with_timeout(func, timeout, *args, **kwargs):
+    def wrapper(queue, *args, **kwargs):
+        try:
+            result = func(*args, **kwargs)
+            queue.put(result)  # Pass the result back via the queue
+        except Exception as e:
+            queue.put(e)  # Pass any exception back via the queue
+
+    queue = multiprocessing.Queue()
+    process = multiprocessing.Process(target=wrapper, args=(queue, *args), kwargs=kwargs)
+    process.start()
+    process.join(timeout)
+
+    if process.is_alive():
+        process.terminate()  # Forcefully terminate the process
+        process.join()
+        raise TimeoutError(f"Function {func.__name__} did not complete within {timeout} seconds.")
+
+    if not queue.empty():
+        result = queue.get()
+        if isinstance(result, Exception):
+            raise result  # Re-raise the exception if it occurred in the function
+        return result
+    else:
+        raise TimeoutError(f"Function {func.__name__} completed but did not return a result.")
+
+

--- a/deeplabcut/utils/multiprocessing.py
+++ b/deeplabcut/utils/multiprocessing.py
@@ -20,17 +20,16 @@ Licensed under GNU Lesser General Public License v3.0
 import multiprocessing
 
 
+def _wrapper(func, queue, *args, **kwargs):
+    try:
+        result = func(*args, **kwargs)
+        queue.put(result)  # Pass the result back via the queue
+    except Exception as e:
+        queue.put(e)  # Pass any exception back via the queue
 
 def call_with_timeout(func, timeout, *args, **kwargs):
-    def wrapper(queue, *args, **kwargs):
-        try:
-            result = func(*args, **kwargs)
-            queue.put(result)  # Pass the result back via the queue
-        except Exception as e:
-            queue.put(e)  # Pass any exception back via the queue
-
     queue = multiprocessing.Queue()
-    process = multiprocessing.Process(target=wrapper, args=(queue, *args), kwargs=kwargs)
+    process = multiprocessing.Process(target=_wrapper, args=(func, queue, *args), kwargs=kwargs)
     process.start()
     process.join(timeout)
 

--- a/tests/gui/test_gui_window.py
+++ b/tests/gui/test_gui_window.py
@@ -1,0 +1,33 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/master/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+import pytest
+import time
+from deeplabcut.gui.window import call_with_timeout
+
+def test_call_with_timeout():
+    def succeeding_method(parameter):
+        return parameter
+
+    parameter = (10, "Hello test")
+    assert call_with_timeout(succeeding_method, 1, parameter) == parameter
+
+    def failing_method():
+        raise ValueError("Raise value error on purpose")
+
+    with pytest.raises(ValueError):
+        call_with_timeout(failing_method, timeout=1)
+
+    def hanging_method():
+        while True:
+            time.sleep(1)
+
+    with pytest.raises(TimeoutError):
+        call_with_timeout(hanging_method, timeout=1)

--- a/tests/utils/test_multiprocessing.py
+++ b/tests/utils/test_multiprocessing.py
@@ -10,7 +10,7 @@
 #
 import pytest
 import time
-from deeplabcut.gui.window import call_with_timeout
+from deeplabcut.utils.multiprocessing import call_with_timeout
 
 def test_call_with_timeout():
     def succeeding_method(parameter):

--- a/tests/utils/test_multiprocessing.py
+++ b/tests/utils/test_multiprocessing.py
@@ -12,6 +12,7 @@ import pytest
 import time
 from deeplabcut.utils.multiprocessing import call_with_timeout
 
+
 def test_call_with_timeout():
     def succeeding_method(parameter):
         return parameter

--- a/tests/utils/test_multiprocessing.py
+++ b/tests/utils/test_multiprocessing.py
@@ -13,22 +13,25 @@ import time
 from deeplabcut.utils.multiprocessing import call_with_timeout
 
 
+def _succeeding_method(parameter):
+    return parameter
+
+
+def _failing_method():
+    raise ValueError("Raise value error on purpose")
+
+
+def _hanging_method():
+    while True:
+        time.sleep(5)
+
+
 def test_call_with_timeout():
-    def succeeding_method(parameter):
-        return parameter
-
     parameter = (10, "Hello test")
-    assert call_with_timeout(succeeding_method, 1, parameter) == parameter
-
-    def failing_method():
-        raise ValueError("Raise value error on purpose")
+    assert call_with_timeout(_succeeding_method, 30, parameter) == parameter
 
     with pytest.raises(ValueError):
-        call_with_timeout(failing_method, timeout=1)
-
-    def hanging_method():
-        while True:
-            time.sleep(1)
+        call_with_timeout(_failing_method, timeout=30)
 
     with pytest.raises(TimeoutError):
-        call_with_timeout(hanging_method, timeout=1)
+        call_with_timeout(_hanging_method, timeout=1)


### PR DESCRIPTION
In my [previous attempt](https://github.com/DeepLabCut/DeepLabCut/pull/2805) to add a timeout to `deeplabcut.gui.window._check_for_updates()`, the tests were failing on Windows and MacOS due to a difference in the `multiprocessing` package workflow across these different OSes. This attempt has therefore [been reverted](https://github.com/DeepLabCut/DeepLabCut/pull/2807).

This Pull Requests proposes an addition of timeout to `_check_for_updates()` with tests that should be compatible with all 3 OS families (tested on Ubuntu 24.04 and Windows, @n-poulsen could you confirm this also works on MacOS please?). 