### PR TITLE
Improved loading of snapshot weights with` torch.load(..., weights_only=True)`

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/__init__.py
+++ b/deeplabcut/pose_estimation_pytorch/__init__.py
@@ -29,6 +29,10 @@ from deeplabcut.pose_estimation_pytorch.data.dataset import (
     PoseDatasetParameters,
 )
 from deeplabcut.pose_estimation_pytorch.data.dlcloader import DLCLoader
+from deeplabcut.pose_estimation_pytorch.runners.base import (
+    get_load_weights_only,
+    set_load_weights_only,
+)
 from deeplabcut.pose_estimation_pytorch.runners.snapshots import TorchSnapshotManager
 from deeplabcut.pose_estimation_pytorch.task import Task
 from deeplabcut.pose_estimation_pytorch.utils import fix_seeds

--- a/deeplabcut/pose_estimation_pytorch/apis/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/utils.py
@@ -549,7 +549,7 @@ def get_inference_runners(
                     max_individuals=max_individuals,
                 ),
                 load_weights_only=model_config["detector"]["runner"].get(
-                    "load_weights_only", True,
+                    "load_weights_only", None,
                 ),
             )
 
@@ -562,7 +562,7 @@ def get_inference_runners(
         preprocessor=pose_preprocessor,
         postprocessor=pose_postprocessor,
         dynamic=dynamic,
-        load_weights_only=model_config["runner"].get("load_weights_only", True),
+        load_weights_only=model_config["runner"].get("load_weights_only", None),
     )
     return pose_runner, detector_runner
 
@@ -612,7 +612,7 @@ def get_detector_inference_runner(
         batch_size=batch_size,
         preprocessor=preprocessor,
         postprocessor=postprocessor,
-        load_weights_only=det_cfg["runner"].get("load_weights_only", True),
+        load_weights_only=det_cfg["runner"].get("load_weights_only", None),
     )
 
     if not isinstance(runner, DetectorInferenceRunner):
@@ -699,7 +699,7 @@ def get_pose_inference_runner(
         preprocessor=pose_preprocessor,
         postprocessor=pose_postprocessor,
         dynamic=dynamic,
-        load_weights_only=model_config["runner"].get("load_weights_only", True),
+        load_weights_only=model_config["runner"].get("load_weights_only", None),
     )
     if not isinstance(runner, PoseInferenceRunner):
         raise RuntimeError(f"Failed to build PoseInferenceRunner for {model_config}")

--- a/deeplabcut/pose_estimation_pytorch/runners/__init__.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/__init__.py
@@ -9,15 +9,21 @@
 # Licensed under GNU Lesser General Public License v3.0
 #
 
-from deeplabcut.pose_estimation_pytorch.runners.base import Runner
+from deeplabcut.pose_estimation_pytorch.runners.base import (
+    attempt_snapshot_load,
+    get_load_weights_only,
+    fix_snapshot_metadata,
+    Runner,
+    set_load_weights_only,
+)
 from deeplabcut.pose_estimation_pytorch.runners.dynamic_cropping import DynamicCropper
-from deeplabcut.pose_estimation_pytorch.runners.logger import LOGGER
 from deeplabcut.pose_estimation_pytorch.runners.inference import (
     build_inference_runner,
     DetectorInferenceRunner,
     InferenceRunner,
     PoseInferenceRunner,
 )
+from deeplabcut.pose_estimation_pytorch.runners.logger import LOGGER
 from deeplabcut.pose_estimation_pytorch.runners.snapshots import TorchSnapshotManager
 from deeplabcut.pose_estimation_pytorch.runners.train import (
     build_training_runner,

--- a/deeplabcut/pose_estimation_pytorch/runners/base.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/base.py
@@ -10,15 +10,43 @@
 #
 from __future__ import annotations
 
+import logging
+import os
 import pickle
 from abc import ABC
 from pathlib import Path
 from typing import Generic, TypeVar
 
+import numpy as np
 import torch
 import torch.nn as nn
 
 ModelType = TypeVar("ModelType", bound=nn.Module)
+
+_load_weights_only: bool = (
+    os.getenv("TORCH_LOAD_WEIGHTS_ONLY", "true").lower() in ("true", "1")
+)
+
+
+def get_load_weights_only() -> bool:
+    """Gets the default value to use when loading snapshots with `torch.load(...)`.
+
+    Returns:
+        The default `weights_only` value when loading snapshots using `torch.load(...)`.
+    """
+    global _load_weights_only
+    return _load_weights_only
+
+
+def set_load_weights_only(value: bool) -> None:
+    """Sets the default value to use when loading snapshots with `torch.load(...)`.
+
+    Args:
+        value: The default `weights_only` value to use when loading snapshots using
+            `torch.load(...)`.
+    """
+    global _load_weights_only
+    _load_weights_only = value
 
 
 class Runner(ABC, Generic[ModelType]):
@@ -63,7 +91,7 @@ class Runner(ABC, Generic[ModelType]):
         snapshot_path: str | Path,
         device: str,
         model: ModelType,
-        weights_only: bool = True,
+        weights_only: bool | None = None,
     ) -> dict:
         """Loads the state dict for a model from a file
 
@@ -74,11 +102,13 @@ class Runner(ABC, Generic[ModelType]):
             snapshot_path: The path containing the model weights to load
             device: The device on which the model should be loaded
             model: The model for which the weights are loaded
-            weights_only: Value for torch.load() `weights_only` parameter. If False, the
-                python pickle module is used implicitly, which is known to be insecure.
-                Only set to False if you're loading data that you trust (e.g. snapshots
-                that you created yourself). For more information, see:
+            weights_only: Value for torch.load() `weights_only` parameter.
+                If False, the python pickle module is used implicitly, which is known to
+                be insecure. Only set to False if you're loading data that you trust
+                (e.g. snapshots that you created yourself). For more information, see:
                     https://pytorch.org/docs/stable/generated/torch.load.html
+                If None, the default value is used:
+                    `deeplabcut.pose_estimation_pytorch.get_load_weights_only()`
 
         Returns:
             The content of the snapshot file.
@@ -88,17 +118,23 @@ class Runner(ABC, Generic[ModelType]):
         return snapshot
 
 
-def attempt_snapshot_load(path: str | Path, device: str, weights_only: bool) -> dict:
+def attempt_snapshot_load(
+    path: str | Path,
+    device: str,
+    weights_only: bool | None = None,
+) -> dict:
     """Attempts to load a snapshot using `torch.load(...)`.
 
     Args:
         path: The path of the snapshot to try to load..
         device: The device to use for the `map_location`.
-        weights_only: Value for torch.load() `weights_only` parameter. If False, the
-            python pickle module is used implicitly, which is known to be insecure.
-            Only set to False if you're loading data that you trust (e.g. snapshots
-            that you created yourself). For more information, see:
+        weights_only: Value for torch.load() `weights_only` parameter.
+            If False, the python pickle module is used implicitly, which is known to be
+            insecure. Only set to False if you're loading data that you trust (e.g.
+            snapshots that you created yourself). For more information, see:
                 https://pytorch.org/docs/stable/generated/torch.load.html
+            If None, the default value is used:
+                `deeplabcut.pose_estimation_pytorch.get_load_weights_only()`
 
     Returns:
         The loaded snapshot.
@@ -108,18 +144,83 @@ def attempt_snapshot_load(path: str | Path, device: str, weights_only: bool) -> 
             with `weights_only=True`.
     """
     try:
+        if weights_only is None:
+            weights_only = get_load_weights_only()
+
         snapshot = torch.load(path, map_location=device, weights_only=weights_only)
     except pickle.UnpicklingError as err:
-        print(
-            f"\nFailed to load the snapshot: {path}.\n"
-            "If you trust the snapshot that you're trying to load, you can try "
-            "calling `Runner.load_snapshot` with `weights_only=False`. See "
-            "the message below for more information and warnings.\n"
-            "You can set the `weights_only` parameter in the model configuration ("
-            "the content of the pytorch_config.yaml), as:\n```\n"
+        logging.error(
+            f"\nFailed to load the snapshot: {path}.\n\n"
+            "If you trust the snapshot that you're trying to load, you can try\n"
+            "calling `Runner.load_snapshot` with `weights_only=False`. See the \n"
+            "error message below for more information and warnings.\n"
+            "You can set the `weights_only` parameter in the model configuration (\n"
+            "the content of the pytorch_config.yaml), as:\n\n```\n"
             "runner:\n"
-            "  load_weights_only: False\n```\n"
+            "  load_weights_only: False\n```\n\n"
+            "If it's the detector snapshot that's failing to load, place the\n"
+            "`load_weights_only` key under the detector runner:\n\n```\n"
+            "detector:\n"
+            "    runner:\n"
+            "      load_weights_only: False\n```\n\n"
+            "You can also set the default `load_weights_only` that will be used when\n"
+            "the `load_weights_only` variable is not set in the `pytorch_config.yaml`\n"
+            "using `deeplabcut.pose_estimation_pytorch.set_load_weights_only(value)`:\n"
+            "\n```\n"
+            "from deeplabcut.pose_estimation_pytorch import set_load_weights_only\n"
+            "set_load_weights_only(True)\n"
+            "```\n\n"
+            "You can also set the value for `load_weights_only` with a \n"
+            "`TORCH_LOAD_WEIGHTS_ONLY` environment variable. If you call \n"
+            "`TORCH_LOAD_WEIGHTS_ONLY=False python -m deeplabcut`, it will launch the\n"
+            "DeepLabCut GUI with the default `load_weights_only` value to False.\n"
+            "If you set this value to `True`, make sure you only load snapshots that\n"
+            "you trust.\n\n"
         )
         raise err
 
     return snapshot
+
+
+def fix_snapshot_metadata(path: str | Path) -> None:
+    """Replace numpy floats in snapshot metrics
+
+    Only call this method with snapshots that you trust, as torch.load(...) is called
+    with `weights_only=False`. For more information, see:
+        https://pytorch.org/docs/stable/generated/torch.load.html
+
+    DeepLabCut PyTorch snapshots trained with older releases may have `numpy` floats in
+    the stored metrics. This method opens the snapshots (with `weights_only=False`),
+    replaces the numpy floats with python floats (allowing to load with
+    `weights_only=True`), and saves the new snapshot data.
+
+    Warning: This overwrites your existing snapshot. If you want to ensure that no data
+    is lost, copy your snapshot before calling `fix_snapshot_metadata`.
+
+    Args:
+        path: The path of the snapshot to fix.
+    """
+    snapshot = torch.load(path, map_location="cpu", weights_only=False)
+    metrics = snapshot.get("metadata", {}).get("metrics")
+    if metrics is not None:
+        snapshot["metadata"]["metrics"] = {k: float(v) for k, v in metrics.items()}
+
+    torch.save(snapshot, path)
+
+
+def _add_numpy_to_torch_safe_globals():
+    """
+    Attempts tot add numpy classes allowing snapshots containing numpy floats in the
+    metrics to be loaded without needing to change the `weights_only` argument.
+
+    This fix only works for `numpy>=1.25.0`.
+    """
+    try:
+        from numpy.core.multiarray import scalar
+        from numpy.dtypes import Float64DType
+        torch.serialization.add_safe_globals([np.dtype, Float64DType, scalar])
+    except Exception:
+        pass
+
+
+_add_numpy_to_torch_safe_globals()

--- a/deeplabcut/pose_estimation_pytorch/runners/base.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/base.py
@@ -174,7 +174,7 @@ def attempt_snapshot_load(
             "`TORCH_LOAD_WEIGHTS_ONLY` environment variable. If you call \n"
             "`TORCH_LOAD_WEIGHTS_ONLY=False python -m deeplabcut`, it will launch the\n"
             "DeepLabCut GUI with the default `load_weights_only` value to False.\n"
-            "If you set this value to `True`, make sure you only load snapshots that\n"
+            "If you set this value to `False`, make sure you only load snapshots that\n"
             "you trust.\n\n"
         )
         raise err

--- a/deeplabcut/pose_estimation_pytorch/runners/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/inference.py
@@ -42,7 +42,7 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
         snapshot_path: str | Path | None = None,
         preprocessor: Preprocessor | None = None,
         postprocessor: Postprocessor | None = None,
-        load_weights_only: bool = True,
+        load_weights_only: bool | None = None,
     ):
         """
         Args:
@@ -52,11 +52,13 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
                 pretrained weights
             preprocessor: The preprocessor to use on images before inference
             postprocessor: The postprocessor to use on images after inference
-            load_weights_only: Value for the torch.load() `weights_only` parameter. If
-                False, the python pickle module is used implicitly, which is known to be
-                insecure. Only set to False if you're loading data that you trust (e.g.
-                snapshots that you created yourself). For more information, see:
-                    https://pytorch.org/docs/stable/generated/torch.load.html
+            load_weights_only: Value for the torch.load() `weights_only` parameter.
+                If False, the python pickle module is used implicitly, which is known to
+                    be insecure. Only set to False if you're loading data that you trust
+                    (e.g. snapshots that you created). For more information, see:
+                        https://pytorch.org/docs/stable/generated/torch.load.html
+                If None, the default value is used:
+                    `deeplabcut.pose_estimation_pytorch.get_load_weights_only()`
         """
         super().__init__(model=model, device=device, snapshot_path=snapshot_path)
         if not isinstance(batch_size, int) or batch_size <= 0:
@@ -328,7 +330,7 @@ def build_inference_runner(
     preprocessor: Preprocessor | None = None,
     postprocessor: Postprocessor | None = None,
     dynamic: DynamicCropper | None = None,
-    load_weights_only: bool = True,
+    load_weights_only: bool | None = None,
 ) -> InferenceRunner:
     """
     Build a runner object according to a pytorch configuration file
@@ -345,11 +347,13 @@ def build_inference_runner(
             cropping should not be used. Only for bottom-up pose estimation models.
             Should only be used when creating inference runners for video pose
             estimation with batch size 1.
-        load_weights_only: Value for the torch.load() `weights_only` parameter. If
-            False, the python pickle module is used implicitly, which is known to be
-            insecure. Only set to False if you're loading data that you trust (e.g.
-            snapshots that you created yourself). For more information, see:
+        load_weights_only: Value for the torch.load() `weights_only` parameter.
+            If False, the python pickle module is used implicitly, which is known to
+            be insecure. Only set to False if you're loading data that you trust (e.g.
+            snapshots that you created). For more information, see:
                 https://pytorch.org/docs/stable/generated/torch.load.html
+            If None, the default value is used:
+                `deeplabcut.pose_estimation_pytorch.get_load_weights_only()`
 
     Returns:
         The inference runner.

--- a/deeplabcut/pose_estimation_pytorch/runners/train.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/train.py
@@ -68,11 +68,13 @@ class TrainingRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
         logger: Logger to monitor training (e.g. a WandBLogger).
         log_filename: Name of the file in which to store training stats.
         load_weights_only: Value for the torch.load() `weights_only` parameter if
-            `snapshot_path` is not None. If False, the python pickle module is used
-            implicitly, which is known to be insecure. Only set to False if you're
-            loading data that you trust (e.g. snapshots that you created yourself). For
-            more information, see:
+            `snapshot_path` is not None.
+            If False, the python pickle module is used implicitly, which is known to
+            be insecure. Only set to False if you're loading data that you trust
+            (e.g. snapshots that you created yourself). For more information, see:
                 https://pytorch.org/docs/stable/generated/torch.load.html
+            If None, the default value is used:
+                `deeplabcut.pose_estimation_pytorch.get_load_weights_only()`
     """
 
     def __init__(
@@ -88,7 +90,7 @@ class TrainingRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
         load_scheduler_state_dict: bool = True,
         logger: BaseLogger | None = None,
         log_filename: str = "learning_stats.csv",
-        load_weights_only: bool = True,
+        load_weights_only: bool | None = None,
     ):
         super().__init__(
             model=model, device=device, gpus=gpus, snapshot_path=snapshot_path
@@ -368,7 +370,7 @@ class PoseTrainingRunner(TrainingRunner[PoseModel]):
         snapshot_path: str | Path,
         device: str,
         model: PoseModel,
-        weights_only: bool = True,
+        weights_only: bool | None = None,
     ) -> dict:
         """Loads the state dict for a model from a file
 
@@ -379,11 +381,13 @@ class PoseTrainingRunner(TrainingRunner[PoseModel]):
             snapshot_path: the path containing the model weights to load
             device: the device on which the model should be loaded
             model: the model for which the weights are loaded
-            weights_only: Value for torch.load() `weights_only` parameter. If False, the
-                python pickle module is used implicitly, which is known to be insecure.
-                Only set to False if you're loading data that you trust (e.g. snapshots
-                that you created yourself). For more information, see:
+            weights_only: Value for torch.load() `weights_only` parameter.
+                If False, the python pickle module is used implicitly, which is known to
+                be insecure. Only set to False if you're loading data that you trust
+                (e.g. snapshots that you created yourself). For more information, see:
                     https://pytorch.org/docs/stable/generated/torch.load.html
+                If None, the default value is used:
+                    `deeplabcut.pose_estimation_pytorch.get_load_weights_only()`
 
         Returns:
             The content of the snapshot file.
@@ -733,7 +737,7 @@ def build_training_runner(
         scheduler=scheduler,
         load_scheduler_state_dict=runner_config.get("load_scheduler_state_dict", True),
         logger=logger,
-        load_weights_only=runner_config.get("load_weights_only", True),
+        load_weights_only=runner_config.get("load_weights_only", None),
     )
     if task == Task.DETECT:
         return DetectorTrainingRunner(**kwargs)

--- a/examples/openfield-Pranav-2018-10-30/config.yaml
+++ b/examples/openfield-Pranav-2018-10-30/config.yaml
@@ -7,7 +7,8 @@ identity:
 
 
 # Project path (change when moving around)
-project_path: WILL BE AUTOMATICALLY UPDATED BY DEMO CODE
+project_path: 
+  /Users/niels/Documents/upamathis/repos/DeepLabCut/examples/openfield-Pranav-2018-10-30
 
 
 # Default DeepLabCut engine to use for shuffle creation (either pytorch or tensorflow)
@@ -23,6 +24,9 @@ bodyparts:
 - leftear
 - rightear
 - tailbase
+
+
+# Fraction of video to start/stop when extracting frames for labeling/refinement
 
 
 # Fraction of video to start/stop when extracting frames for labeling/refinement

--- a/examples/openfield-Pranav-2018-10-30/config.yaml
+++ b/examples/openfield-Pranav-2018-10-30/config.yaml
@@ -7,9 +7,7 @@ identity:
 
 
 # Project path (change when moving around)
-project_path: 
-  /Users/niels/Documents/upamathis/repos/DeepLabCut/examples/openfield-Pranav-2018-10-30
-
+project_path: WILL BE AUTOMATICALLY UPDATED BY DEMO CODE
 
 # Default DeepLabCut engine to use for shuffle creation (either pytorch or tensorflow)
 engine: pytorch
@@ -24,9 +22,6 @@ bodyparts:
 - leftear
 - rightear
 - tailbase
-
-
-# Fraction of video to start/stop when extracting frames for labeling/refinement
 
 
 # Fraction of video to start/stop when extracting frames for labeling/refinement

--- a/tests/pose_estimation_pytorch/runners/test_runners.py
+++ b/tests/pose_estimation_pytorch/runners/test_runners.py
@@ -19,11 +19,21 @@ import torch
 import deeplabcut.pose_estimation_pytorch.runners as runners
 
 
+@pytest.mark.parametrize("value", [True, False])
+def test_set_load_weights_only(value: bool):
+    print(f"\nget_load_weights_only: {runners.get_load_weights_only()}")
+    print(f"setting value to {value}")
+    runners.set_load_weights_only(value)
+    print(f"get_load_weights_only: {runners.get_load_weights_only()}\n")
+    assert runners.get_load_weights_only() == value
+
+
 def test_load_snapshot_weights_only_error(tmpdir_factory):
     snapshot_dir = Path(tmpdir_factory.mktemp("snapshot-dir"))
     snapshot_path = snapshot_dir / "snapshot.pt"
     torch.save(dict(content=np.zeros(10)), str(snapshot_path))
 
+    runners.set_load_weights_only(False)
     with pytest.raises(pickle.UnpicklingError):
         runners.Runner.load_snapshot(
             snapshot_path, device="cpu", model=Mock(), weights_only=True

--- a/tests/pose_estimation_pytorch/runners/test_runners_inference.py
+++ b/tests/pose_estimation_pytorch/runners/test_runners_inference.py
@@ -18,12 +18,13 @@ import torch
 import deeplabcut.pose_estimation_pytorch.data.postprocessor as post
 import deeplabcut.pose_estimation_pytorch.data.preprocessor as prep
 import deeplabcut.pose_estimation_pytorch.runners.inference as inference
+from deeplabcut.pose_estimation_pytorch import get_load_weights_only
 from deeplabcut.pose_estimation_pytorch.task import Task
 
 
 @patch("deeplabcut.pose_estimation_pytorch.runners.train.build_optimizer", Mock())
 @pytest.mark.parametrize("task", [Task.DETECT, Task.TOP_DOWN, Task.BOTTOM_UP])
-@pytest.mark.parametrize("weights_only", [True, False])
+@pytest.mark.parametrize("weights_only", [None, True, False])
 def test_load_weights_only_with_build_training_runner(task: Task, weights_only: bool):
     with patch("deeplabcut.pose_estimation_pytorch.runners.base.torch.load") as load:
         snapshot = "snapshot.pt"
@@ -34,6 +35,8 @@ def test_load_weights_only_with_build_training_runner(task: Task, weights_only: 
             snapshot_path=snapshot,
             load_weights_only=weights_only,
         )
+        if weights_only is None:
+            weights_only = get_load_weights_only()
         load.assert_called_once_with(
             snapshot, map_location="cpu", weights_only=weights_only
         )


### PR DESCRIPTION
This pull request offers Improved handling of loading snapshot weights with `torch.load(..., weights_only=True)`. PyTorch snapshots saved with older release candidates could contain some `numpy` floats, which failed to load with `weights_only=True`, which can make it annoying to use them as the `pytorch_config.yaml` needed to be modified with `load_weights_only: true` keys for both detectors and pose models. In this pull request: the following improvements are made:

## Fix the issue with `numpy>=1.25`

For users with `numpy>=1.25` installed, the issue is fixed as the `float64` class causing issues can be added to the `safe_globals`, as done in `_add_numpy_to_torch_safe_globals`. Current snapshots will be loaded without error, as they are with `weights_only=False`. 

```
torch.serialization.add_safe_globals([np.dtype, Float64DType, scalar])
```

This doesn't work in `numpy<1.25`, as the `Float64Dtype` did not yet exist (it was a dtype that could only be used internally), and there is no easy way to add `np.dtype[np.float64]` to the safe globals.

## A global variable is set to handle the default `weights_only` value

The global variable sets the default value given to `load_weights_only`, when none is specified in the `pytorch_config.yaml`. This value is controlled through the `get_load_weights_only` and `set_load_weights_only` methods, which can be imported through `deeplabcut.pose_estimation_pytorch`:

```python
>>> from deeplabcut.pose_estimation_pytorch import get_load_weights_only, set_load_weights_only
>>> print(get_load_weights_only())
True
>>> set_load_weights_only(False)
>>> print(get_load_weights_only())
False
```

When calling `torch.load` without `load_weights_only` being specified, `get_load_weights_only()` is used to get the default value. So when loading snapshots that are known to be safe, `set_load_weights_only(False)` can be called at the start of a script so that all snapshots are loaded with `weights_only=False`.

So for users using `numpy<1.25` with snapshots that have issues, they can load the snapshots without having to modify the `pytorch_config.yaml` by just calling `from deeplabcut.pose_estimation_pytorch import set_load_weights_only` and `set_load_weights_only(False)` before loading their snapshots.

The initial default `load_weights_only ` value can also be set with an `TORCH_LOAD_WEIGHTS_ONLY ` environment variable, which makes it easier to set this value when working with the GUI. The DeepLabCut GUI can just be launched with `TORCH_LOAD_WEIGHTS_ONLY=False python -m deeplabcut`, which will set the default `load_weights_only` value to `False`.

## Function to fix snapshots containing numpy float values

A new `fix_snapshot_metadata` method is added to replace numpy floats with python floats in existing snapshots.

## Improved error message when a snapshot fails to load

The error message when a snapshot fails to load is improved and more descriptive. It now says:

```
ERROR:root:
Failed to load the snapshot: snapshot-best-200.pt.

If you trust the snapshot that you're trying to load, you can try
calling `Runner.load_snapshot` with `weights_only=False`. See the 
error message below for more information and warnings.
You can set the `weights_only` parameter in the model configuration (
the content of the pytorch_config.yaml), as:

'''
runner:
  load_weights_only: False
'''

If it's the detector snapshot that's failing to load, place the
`load_weights_only` key under the detector runner:

'''
detector:
    runner:
      load_weights_only: False
'''

You can also set the default `load_weights_only` that will be used when
the `load_weights_only` variable is not set in the `pytorch_config.yaml`
using `deeplabcut.pose_estimation_pytorch.set_load_weights_only(value)`:

'''
from deeplabcut.pose_estimation_pytorch import set_load_weights_only
set_load_weights_only(True)
'''

You can also set the value for `load_weights_only` with a 
`TORCH_LOAD_WEIGHTS_ONLY` environment variable. If you call 
`TORCH_LOAD_WEIGHTS_ONLY=False python -m deeplabcut`, it will launch the
DeepLabCut GUI with the default `load_weights_only` value to False.
If you set this value to `False`, make sure you only load snapshots that
you trust.
```