### PR TITLE
`create_labeled_video` fails with single animal TensorFlow models

### DIFF
--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -888,9 +888,6 @@ def proc_video(
             df, filepath, _, _ = auxiliaryfunctions.load_analyzed_data(
                 destfolder, vname, DLCscorer, filtered, track_method
             )
-            full_data = auxiliaryfunctions.load_video_full_data(
-                destfolder, vname, DLCscorer
-            )
             metadata = auxiliaryfunctions.load_video_metadata(
                 destfolder, vname, DLCscorer
             )
@@ -916,14 +913,23 @@ def proc_video(
                 if bp in bodyparts
             ]
 
-            frames_dict = {
-                int(key.replace("frame", "")): value
-                for key, value in full_data.items()
-                if key.startswith("frame") and key[5:].isdigit()
-            }
-            bboxes_list = None
-            if "bboxes" in frames_dict.get(min(frames_dict.keys()), {}):
-                bboxes_list = [frames_dict[key] for key in sorted(frames_dict.keys())]
+            # The full data file is not created for single-animal TensorFlow models
+            try:
+                full_data = auxiliaryfunctions.load_video_full_data(
+                    destfolder, vname, DLCscorer
+                )
+                frames_dict = {
+                    int(key.replace("frame", "")): value
+                    for key, value in full_data.items()
+                    if key.startswith("frame") and key[5:].isdigit()
+                }
+                bboxes_list = None
+                if "bboxes" in frames_dict.get(min(frames_dict.keys()), {}):
+                    bboxes_list = [
+                        frames_dict[key] for key in sorted(frames_dict.keys())
+                    ]
+            except FileNotFoundError:
+                bboxes_list = None
 
             if keypoints_only:
                 # Mask rather than drop unwanted bodyparts to ensure consistent coloring

--- a/examples/testscript.py
+++ b/examples/testscript.py
@@ -232,9 +232,10 @@ if __name__ == "__main__":
     )
 
     print("CREATE VIDEO")
-    deeplabcut.create_labeled_video(
+    successful = deeplabcut.create_labeled_video(
         path_config_file, [newvideo], destfolder=DESTFOLDER, save_frames=True
     )
+    assert all(successful), f"Failed to create a labeled video!"
 
     print("Making plots")
     deeplabcut.plot_trajectories(path_config_file, [newvideo], destfolder=DESTFOLDER)
@@ -363,18 +364,20 @@ if __name__ == "__main__":
     )
     deeplabcut.filterpredictions(path_config_file, [newvideo2])
 
-    deeplabcut.create_labeled_video(
+    successful = deeplabcut.create_labeled_video(
         path_config_file,
         [newvideo2],
         destfolder=DESTFOLDER,
         displaycropped=True,
         filtered=True,
     )
+    assert all(successful), f"Failed to create a labeled video!"
 
     print("Creating a Johansson video!")
-    deeplabcut.create_labeled_video(
+    successful = deeplabcut.create_labeled_video(
         path_config_file, [newvideo2], destfolder=DESTFOLDER, keypoints_only=True
     )
+    assert all(successful), f"Failed to create a labeled video!"
 
     deeplabcut.plot_trajectories(
         path_config_file, [newvideo2], destfolder=DESTFOLDER, filtered=True


### PR DESCRIPTION
As mentioned in [this comment from issue 2796](https://github.com/DeepLabCut/DeepLabCut/issues/2796#issuecomment-2574104417), `create_labeled_video` fails to create a labeled video for TensorFlow single-animal projects, as it could not find the "full_data" file which is not created for such models. The content of the file was used to plot bounding boxes in the video for top-down PyTorch models.

This pull request fixes the issue by catching the `FileNotFoundError` when the file is not present. The functional test `examples/testscript.py` is updated to check that the videos have all videos have been created successfully. This updated test fails with the when the bug is in the code, and succeeds with the fix above.