### PR TITLE
Pins `numpy<2`, fix svd for `scipy>=1.11.0`

### DIFF
--- a/deeplabcut/refine_training_dataset/stitch.py
+++ b/deeplabcut/refine_training_dataset/stitch.py
@@ -412,7 +412,7 @@ class Tracklet:
             The optimal hard threshold for singular values is 4/sqrt(3)
         """
         mat = self.to_hankelet()
-        if np.all(mat == 0):
+        if not np.any(mat):  # check if the matrix only contains zeros
             s = np.zeros(min(10, min(mat.shape)))
         else:
             # nrows, ncols = mat.shape

--- a/deeplabcut/refine_training_dataset/stitch.py
+++ b/deeplabcut/refine_training_dataset/stitch.py
@@ -412,10 +412,14 @@ class Tracklet:
             The optimal hard threshold for singular values is 4/sqrt(3)
         """
         mat = self.to_hankelet()
-        # nrows, ncols = mat.shape
-        # beta = nrows / ncols
-        # omega = 0.56 * beta ** 3 - 0.95 * beta ** 2 + 1.82 * beta + 1.43
-        _, s, _ = sli.svd(mat, min(10, min(mat.shape)))
+        if np.all(mat == 0):
+            s = np.zeros(min(10, min(mat.shape)))
+        else:
+            # nrows, ncols = mat.shape
+            # beta = nrows / ncols
+            # omega = 0.56 * beta ** 3 - 0.95 * beta ** 2 + 1.82 * beta + 1.43
+            _, s, _ = sli.svd(mat, min(10, min(mat.shape)))
+
         # return np.argmin(s > omega * np.median(s))
         eigen = s**2
         diff = np.abs(np.diff(eigen / eigen[0]))

--- a/deeplabcut/refine_training_dataset/stitch.py
+++ b/deeplabcut/refine_training_dataset/stitch.py
@@ -412,13 +412,13 @@ class Tracklet:
             The optimal hard threshold for singular values is 4/sqrt(3)
         """
         mat = self.to_hankelet()
-        if not np.any(mat):  # check if the matrix only contains zeros
-            s = np.zeros(min(10, min(mat.shape)))
-        else:
+        if np.any(mat):  # check that the matrix contains non-zero entries
             # nrows, ncols = mat.shape
             # beta = nrows / ncols
             # omega = 0.56 * beta ** 3 - 0.95 * beta ** 2 + 1.82 * beta + 1.43
             _, s, _ = sli.svd(mat, min(10, min(mat.shape)))
+        else:
+            s = np.zeros(min(10, min(mat.shape)))
 
         # return np.argmin(s > omega * np.median(s))
         eigen = s**2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ imgaug==0.4.0
 numba>=0.54.0
 matplotlib<=3.5.2
 networkx>=2.6
-numpy>=1.18.5
+numpy>=1.18.5,<2.0.0
 pandas>=1.0.1,!=1.5.0
 pyyaml
 scikit-image>=0.17

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
         "numba>=0.54",
         "matplotlib>=3.3,<3.9,!=3.7.0,!=3.7.1",
         "networkx>=2.6",
-        "numpy>=1.18.5",
+        "numpy>=1.18.5,<2.0.0",
         "pandas>=1.0.1,!=1.5.0",
         "scikit-image>=0.17",
         "scikit-learn>=1.0",


### PR DESCRIPTION
This pull request pins the numpy version required for DeepLabCut to `numpy<2.0.0` and fixes SVD computation in `Tracklet.estimate_rank` for `scipy>=1.11.0`.

## scipy SVD computation

With `scipy<1.11.0`, computation of the SVD of an all-zero matrix would be successful, returning an all-zero array for the singular values. With `scipy>=1.11.0`, this fails with a `ValueError`. Hence, we first check if the matrice is the zero matrix before computing the SVD. If it is, we return a zero-vector to match the behavior of `scipy<1.11.0`.

This can be verified with the following script:

```python
import numpy as np
from scipy.linalg.interpolative import svd

mat = np.ones((100, 100))
u, s, v = svd(mat, 10)
print(s.shape)
print(s)

mat = np.zeros((100, 100))
u, s, v = svd(mat, 10)
print(s.shape)
print(s)
```

With `scipy==1.10.1` this succeeds with the output:

```
# Installed packages
# 
# Package    Version
# ---------- -------
# numpy      1.26.4
# pip        24.2
# scipy      1.10.1
# setuptools 75.1.0
# wheel      0.44.0

(10,)
[1.00000000e+002 2.00894856e-014 9.74976675e-030 1.87711978e-044
 3.36274201e-059 7.64750134e-074 6.78987388e-089 1.85753577e-103
 5.94236148e-118 5.94807826e-133]
(10,)
[0. 0. 0. 0. 0. 0. 0. 0. 0. 0.]
```

While with `scipy==1.15.0` this fails with the output:

```
# Installed packages
# 
# Package    Version
# ---------- -------
# numpy      1.26.4
# pip        24.2
# scipy      1.15.0
# setuptools 75.1.0
# wheel      0.44.0

(10,)
[1.00000000e+002 1.97841743e-014 2.33093502e-029 3.08938377e-044
 4.24604188e-059 6.43087871e-074 1.13626229e-088 8.36470319e-104
 1.62555162e-118 3.13271339e-133]
Traceback (most recent call last):
  File "sktest.py", line 11, in <module>
    u, s, v = svd(mat, 10)
  File "/miniconda/envs/sk15/lib/python3.10/site-packages/scipy/linalg/interpolative.py", line 905, in svd
    U, S, V = _backend.iddr_asvd(A, k, rng=rng)
  File "_decomp_interpolative.pyx", line 933, in scipy.linalg._decomp_interpolative.iddr_asvd
  File "/miniconda/envs/sk15/lib/python3.10/site-packages/scipy/linalg/_decomp_svd.py", line 106, in svd
    a1 = _asarray_validated(a, check_finite=check_finite)
  File "/miniconda/envs/sk15/lib/python3.10/site-packages/scipy/_lib/_util.py", line 537, in _asarray_validated
    a = toarray(a)
  File "/miniconda/envs/sk15/lib/python3.10/site-packages/numpy/lib/function_base.py", line 630, in asarray_chkfinite
    raise ValueError(
ValueError: array must not contain infs or NaNs
```
