### PR TITLE
[wip] Fix create_video() argument default value handling

### DIFF
--- a/deeplabcut/benchmark/mot.py
+++ b/deeplabcut/benchmark/mot.py
@@ -150,7 +150,7 @@ def reconstruct_all_bboxes(
     return bboxes
 
 
-def compute_mot_metrics(
+def compute_mot_metrics( # there is this method!!
     h5_file_gt: str,
     h5_file_pred: str,
     tracker_type: str = "bbox",
@@ -172,7 +172,7 @@ def compute_mot_metrics(
     )
 
 
-def _compute_mot_metrics(
+def _compute_mot_metrics( # there is this method!!
     trackers_ground_truth: NDArray,
     trackers: NDArray,
     tracker_type: str = "bbox",

--- a/deeplabcut/core/trackingutils.py
+++ b/deeplabcut/core/trackingutils.py
@@ -770,7 +770,7 @@ def calc_bboxes_from_keypoints(data, slack=0, offset=0):
     bboxes = np.full((data.shape[0], 5), np.nan)
     bboxes[:, :2] = np.nanmin(data[..., :2], axis=1) - slack  # X1, Y1
     bboxes[:, 2:4] = np.nanmax(data[..., :2], axis=1) + slack  # X2, Y2
-    bboxes[:, -1] = np.nanmean(data[..., 2])  # Average confidence
+    bboxes[:, -1] = np.nanmean(data[..., 2], axis=1)  # Average confidence
     bboxes[:, [0, 2]] += offset
     return bboxes
 

--- a/deeplabcut/core/trackingutils.py
+++ b/deeplabcut/core/trackingutils.py
@@ -178,20 +178,7 @@ class EllipseFitter:
             self._coeffs = self._fit(self.x, self.y)
             self.params = self.calc_parameters(self._coeffs)
         if not np.isnan(self.params).any():
-            el = Ellipse(*self.params)
-            # Regularize by forcing AR <= 5
-            # max_ar = 5
-            # if el.aspect_ratio >= max_ar:
-            #     if el.height > el.width:
-            #         el.width = el.height / max_ar
-            #     else:
-            #         el.height = el.width / max_ar
-            # Orient the ellipse such that it encompasses most points
-            # n_inside = el.contains_points(np.c_[self.x, self.y]).sum()
-            # el.theta += 0.5 * np.pi
-            # if el.contains_points(np.c_[self.x, self.y]).sum() < n_inside:
-            #     el.theta -= 0.5 * np.pi
-            return el
+            return Ellipse(*self.params)
         return None
 
     @staticmethod

--- a/deeplabcut/pose_estimation_pytorch/apis/convert_detections_to_tracklets.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/convert_detections_to_tracklets.py
@@ -152,7 +152,7 @@ def convert_detections2tracklets(
                 mot_tracker = trackingutils.SORTBox(
                     inference_cfg["max_age"],
                     inference_cfg["min_hits"],
-                    inference_cfg.get("oks_threshold", 0.3),
+                    inference_cfg.get("iou_threshold", 0.3),
                 )
             elif track_method == "skeleton":
                 mot_tracker = trackingutils.SORTSkeleton(

--- a/deeplabcut/pose_estimation_pytorch/apis/convert_detections_to_tracklets.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/convert_detections_to_tracklets.py
@@ -133,97 +133,31 @@ def convert_detections2tracklets(
             print(f"Tracklets already computed at {track_filename}")
             print("Set overwrite = True to overwrite.")
         else:
-            joints = data["metadata"]["all_joints_names"]
-            n_joints = len(joints)
-
-            df_index = _create_tracklets_header(joints, metadata["data"]["Scorer"])
-
-            if track_method == "box":
-                mot_tracker = trackingutils.SORTBox(
-                    inference_cfg["max_age"],
-                    inference_cfg["min_hits"],
-                    inference_cfg.get("iou_threshold", 0.3),
-                )
-            elif track_method == "skeleton":
-                mot_tracker = trackingutils.SORTSkeleton(
-                    n_joints,
-                    inference_cfg["max_age"],
-                    inference_cfg["min_hits"],
-                    inference_cfg.get("oks_threshold", 0.5),
-                )
-            else:
-                mot_tracker = trackingutils.SORTEllipse(
-                    inference_cfg.get("max_age", 1),
-                    inference_cfg.get("min_hits", 1),
-                    inference_cfg.get("iou_threshold", 0.6),
-                )
-
-            tracklets = {}
-            multi_bpts = cfg["multianimalbodyparts"]
-
-            ass_filename = data_filename.with_stem(
+            assemblies_path = data_filename.with_stem(
                 data_filename.stem + "_assemblies"
             ).with_suffix(".pickle")
-            if not ass_filename.exists():
+            if not assemblies_path.exists():
                 raise FileNotFoundError(
-                    f"Could not find the assembles file {ass_filename}. You're "
+                    f"Could not find the assembles file {assemblies_path}. You're "
                     f"converting detections to tracklets using PyTorch, which "
                     "means the assemblies file must be created by the model when "
                     "analyzing the video!"
                 )
+            assemblies_data = auxiliaryfunctions.read_pickle(assemblies_path)
 
-            num_frames = data["metadata"]["nframes"]
-            ass = auxiliaryfunctions.read_pickle(ass_filename)
+            tracklets = build_tracklets(
+                assemblies_data=assemblies_data,
+                track_method=track_method,
+                inference_cfg=inference_cfg,
+                joints=data["metadata"]["all_joints_names"],
+                multi_bpts=cfg["multianimalbodyparts"],
+                scorer=metadata["data"]["Scorer"],
+                num_frames=data["metadata"]["nframes"],
+                ignore_bodyparts=ignore_bodyparts,
+                unique_bodyparts=cfg["uniquebodyparts"],
+                identity_only=identity_only
+            )
 
-            # Initialize storage of the 'single' individual track
-            if cfg["uniquebodyparts"]:
-                tracklets["single"] = {}
-                _single = {}
-                for index in range(num_frames):
-                    single_detection = ass["single"].get(index)
-                    if single_detection is None:
-                        continue
-                    _single[index] = np.asarray(single_detection)
-                tracklets["single"].update(_single)
-
-            if inference_cfg["topktoretain"] == 1:
-                tracklets[0] = {}
-                for index in tqdm(range(num_frames)):
-                    assemblies = ass.get(index)
-                    if assemblies is None:
-                        continue
-
-                    tracklets[0][index] = np.asarray(assemblies[0].data)
-            else:
-                keep = set(multi_bpts).difference(ignore_bodyparts or [])
-                keep_inds = sorted(multi_bpts.index(bpt) for bpt in keep)
-                for index in tqdm(range(num_frames)):
-                    assemblies = ass.get(index)
-                    if assemblies is None or len(assemblies) == 0:
-                        continue
-
-                    animals = np.stack([a for a in assemblies])
-                    if identity_only:
-                        # Optimal identity assignment based on soft voting
-                        mat = np.zeros((len(assemblies), inference_cfg["topktoretain"]))
-                        for row, a in enumerate(assemblies):
-                            assembly = Assembly.from_array(a)
-                            for k, v in assembly.soft_identity.items():
-                                mat[row, k] = v
-                        inds = linear_sum_assignment(mat, maximize=True)
-                        trackers = np.c_[inds][:, ::-1]
-                    else:
-                        if track_method == "box":
-                            xy = trackingutils.calc_bboxes_from_keypoints(
-                                animals[:, keep_inds], inference_cfg["boundingboxslack"]
-                            )  # TODO: get cropping parameters and utilize!
-                        else:
-                            xy = animals[:, keep_inds, :2]
-                        trackers = mot_tracker.track(xy)
-
-                    trackingutils.fill_tracklets(tracklets, trackers, animals, index)
-
-            tracklets["header"] = df_index
             with open(track_filename, "wb") as f:
                 pickle.dump(tracklets, f, pickle.HIGHEST_PROTOCOL)
 
@@ -233,6 +167,95 @@ def convert_detections2tracklets(
         "deeplabcut.convert_detections2tracklets was run). Now you can "
         "'refine_tracklets' in the GUI, or run 'deeplabcut.stitch_tracklets'."
     )
+
+
+def build_tracklets(
+    assemblies_data: dict,
+    track_method: str,
+    inference_cfg: dict,
+    joints: list[str],
+    multi_bpts: list[str],
+    scorer: str,
+    num_frames: int,
+    ignore_bodyparts: list[str]|None = None,
+    uniquebodyparts: list|None = None,
+    identity_only: bool = False
+) -> dict :
+
+    if track_method == "box":
+        mot_tracker = trackingutils.SORTBox(
+            inference_cfg["max_age"],
+            inference_cfg["min_hits"],
+            inference_cfg.get("iou_threshold", 0.3),
+        )
+    elif track_method == "skeleton":
+        mot_tracker = trackingutils.SORTSkeleton(
+            len(joints),
+            inference_cfg["max_age"],
+            inference_cfg["min_hits"],
+            inference_cfg.get("oks_threshold", 0.5),
+        )
+    else:
+        mot_tracker = trackingutils.SORTEllipse(
+            inference_cfg.get("max_age", 1),
+            inference_cfg.get("min_hits", 1),
+            inference_cfg.get("iou_threshold", 0.6),
+        )
+
+    tracklets = {}
+
+    df_index = _create_tracklets_header(joints, scorer)
+    tracklets["header"] = df_index
+
+    # Initialize storage of the 'single' individual track
+    if unique_bodyparts:
+        tracklets["single"] = {}
+        _single = {}
+        for index in range(num_frames):
+            single_detection = assemblies_data["single"].get(index)
+            if single_detection is None:
+                continue
+            _single[index] = np.asarray(single_detection)
+        tracklets["single"].update(_single)
+
+    if inference_cfg["topktoretain"] == 1:
+        tracklets[0] = {}
+        for index in tqdm(range(num_frames)):
+            assemblies = assemblies_data.get(index)
+            if assemblies is None:
+                continue
+
+            tracklets[0][index] = np.asarray(assemblies[0].data)
+    else:
+        keep = set(multi_bpts).difference(ignore_bodyparts or [])
+        keep_inds = sorted(multi_bpts.index(bpt) for bpt in keep)
+        for index in tqdm(range(num_frames)):
+            assemblies = assemblies_data.get(index)
+            if assemblies is None or len(assemblies) == 0:
+                continue
+
+            animals = np.stack([a for a in assemblies])
+            if identity_only:
+                # Optimal identity assignment based on soft voting
+                mat = np.zeros((len(assemblies), inference_cfg["topktoretain"]))
+                for row, a in enumerate(assemblies):
+                    assembly = Assembly.from_array(a)
+                    for k, v in assembly.soft_identity.items():
+                        mat[row, k] = v
+                inds = linear_sum_assignment(mat, maximize=True)
+                trackers = np.c_[inds][:, ::-1]
+            else:
+                if track_method == "box":
+                    xy = trackingutils.calc_bboxes_from_keypoints(
+                        animals[:, keep_inds], inference_cfg["boundingboxslack"]
+                    )  # TODO: get cropping parameters and utilize!
+                else:
+                    xy = animals[:, keep_inds, :2]
+                trackers = mot_tracker.track(xy)
+
+            trackingutils.fill_tracklets(tracklets, trackers, animals, index)
+
+    return tracklets
 
 
 def _create_tracklets_header(joints, dlc_scorer):

--- a/deeplabcut/pose_estimation_pytorch/apis/convert_detections_to_tracklets.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/convert_detections_to_tracklets.py
@@ -169,6 +169,7 @@ def convert_detections2tracklets(
     )
 
 
+# todo remove multi_bpts and use joints instead?
 def build_tracklets(
     assemblies_data: dict,
     track_method: str,
@@ -218,6 +219,7 @@ def build_tracklets(
             _single[index] = np.asarray(single_detection)
         tracklets["single"].update(_single)
 
+    # todo what is this topktoretain? Why 1? why if-else?
     if inference_cfg["topktoretain"] == 1:
         tracklets[0] = {}
         for index in tqdm(range(num_frames)):

--- a/deeplabcut/pose_estimation_pytorch/apis/convert_detections_to_tracklets.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/convert_detections_to_tracklets.py
@@ -133,20 +133,10 @@ def convert_detections2tracklets(
             print(f"Tracklets already computed at {track_filename}")
             print("Set overwrite = True to overwrite.")
         else:
-            dlc_scorer = metadata["data"]["Scorer"]
             joints = data["metadata"]["all_joints_names"]
             n_joints = len(joints)
 
-            # TODO: adjust this for multi + unique bodyparts!
-            # this is only for multianimal parts and unique bodyparts as one (not one
-            # unique bodyparts guy tracked etc.)
-            bodypart_labels = [bpt for bpt in joints for _ in range(3)]
-            scorers = len(bodypart_labels) * [dlc_scorer]
-            xyl_value = int(len(bodypart_labels) / 3) * ["x", "y", "likelihood"]
-            df_index = pd.MultiIndex.from_arrays(
-                np.vstack([scorers, bodypart_labels, xyl_value]),
-                names=["scorer", "bodyparts", "coords"],
-            )
+            df_index = _create_tracklets_header(joints, metadata["data"]["Scorer"])
 
             if track_method == "box":
                 mot_tracker = trackingutils.SORTBox(
@@ -242,6 +232,16 @@ def convert_detections2tracklets(
         "The tracklets were created (i.e., under the hood "
         "deeplabcut.convert_detections2tracklets was run). Now you can "
         "'refine_tracklets' in the GUI, or run 'deeplabcut.stitch_tracklets'."
+    )
+
+
+def _create_tracklets_header(joints, dlc_scorer):
+    bodypart_labels = [bpt for bpt in joints for _ in range(3)]
+    scorers = len(bodypart_labels) * [dlc_scorer]
+    xyl_value = int(len(bodypart_labels) / 3) * ["x", "y", "likelihood"]
+    return pd.MultiIndex.from_arrays(
+        np.vstack([scorers, bodypart_labels, xyl_value]),
+        names=["scorer", "bodyparts", "coords"],
     )
 
 

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1435,7 +1435,7 @@ def _convert_detections_to_tracklets(
         mot_tracker = trackingutils.SORTBox(
             inference_cfg["max_age"],
             inference_cfg["min_hits"],
-            inference_cfg.get("oks_threshold", 0.3),
+            inference_cfg.get("iou_threshold", 0.3),
         )
     elif track_method == "skeleton":
         mot_tracker = trackingutils.SORTSkeleton(
@@ -1728,7 +1728,7 @@ def convert_detections2tracklets(
                     mot_tracker = trackingutils.SORTBox(
                         inferencecfg["max_age"],
                         inferencecfg["min_hits"],
-                        inferencecfg.get("oks_threshold", 0.3),
+                        inferencecfg.get("iou_threshold", 0.3),
                     )
                 elif track_method == "skeleton":
                     mot_tracker = trackingutils.SORTSkeleton(

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -1048,23 +1048,21 @@ def create_video(
         s = "_id" if color_by == "individual" else "_bp"
         output_path = h5file.replace(".h5", f"{s}_labeled.mp4")
 
-    x1, x2, y1, y2 = bbox
-    if display_cropped:
-        sw = x2 - x1
-        sh = y2 - y1
-    else:
-        sw = sh = ""
-
     clip = vp(
         fname=video,
         sname=output_path,
         codec=codec,
-        sw=sw,
-        sh=sh,
+        sw=bbox[1]-bbox[0] if display_cropped else "",
+        sh=bbox[3]-bbox[2] if display_cropped else "",
         fps=fps,
     )
+
     cropping = bbox != (0, clip.w, 0, clip.h)
+
+    x1, x2, y1, y2 = bbox if bbox is not None else (0, clip.w, 0, clip.h)
+
     df = pd.read_hdf(h5file)
+
     try:
         animals = df.columns.get_level_values("individuals").unique().to_list()
         if animals2show != "all" and isinstance(animals, Iterable):
@@ -1072,9 +1070,12 @@ def create_video(
         df = df.loc(axis=1)[:, animals]
     except KeyError:
         pass
+
     kpts = df.columns.get_level_values("bodyparts").unique().to_list()
+
     if keypoints2show != "all" and isinstance(keypoints2show, Iterable):
         kpts = [kpt for kpt in kpts if kpt in keypoints2show]
+
     CreateVideo(
         clip,
         df,


### PR DESCRIPTION
In `make_labeled_video.create_video()`, [bbox value is by default None](https://github.com/DeepLabCut/DeepLabCut/blob/9687dcb2ae7c396c4de5e84f0919c4452ca0782e/deeplabcut/utils/make_labeled_video.py#L1033). However, if no value is specified for this parameter, the method crashes [when unpacking it](https://github.com/DeepLabCut/DeepLabCut/blob/9687dcb2ae7c396c4de5e84f0919c4452ca0782e/deeplabcut/utils/make_labeled_video.py#L1051).

This PR sets a valid value to `bbox` if it is `None`.