### PR TITLE
`get_detector_inference_runner`: resolve the device from the model config when None

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/apis/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/utils.py
@@ -589,7 +589,9 @@ def get_detector_inference_runner(
     Returns:
         an inference runner for object detection
     """
-    if device == "mps":  # FIXME(niels): Cannot run detectors on MPS
+    if device is None:
+        device = resolve_device(model_config)
+    elif device == "mps":  # FIXME(niels): Cannot run detectors on MPS
         device = "cpu"
 
     if max_individuals is None:


### PR DESCRIPTION
Fixes #2840 where get_detector_inference_runner was not able to get device from model_cfg, leaving all detector inference to be done on CPU