### PR TITLE
Reading apply_prob for augmentation pipeline from config

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
@@ -395,6 +395,7 @@ class ImgaugPoseDataset(BasePoseDataset):
         }
 
     def next_batch(self):
+        cfg = self.cfg
         while True:
             (
                 batch_images,
@@ -406,7 +407,8 @@ class ImgaugPoseDataset(BasePoseDataset):
             ) = self.get_batch()
 
             pipeline = self.build_augmentation_pipeline(
-                height=target_size[0], width=target_size[1], apply_prob=0.5
+                height=target_size[0], width=target_size[1],
+                apply_prob=cfg.get("apply_prob", 0.5),
             )
 
             batch_images, batch_joints = pipeline(


### PR DESCRIPTION
The image augmentation pipeline always uses a value 0.5 for apply_prob.

This change allows the augmentation building pipeline for single animal projects to use the probability of applying augmentations (apply_prob) from the pose config file.

Curiously, this issue only exists for the single animal DLC. pose_multianimal_aug.py reads the apply_prob from the pose_config file.

OS Tested - Windows 10 Enterprise Python 3.10.4
[testscript_log.txt](https://github.com/user-attachments/files/18521303/testscript_log.txt)
