### PR TITLE
Fix reading filtered state

### DIFF
--- a/deeplabcut/gui/tabs/analyze_videos.py
+++ b/deeplabcut/gui/tabs/analyze_videos.py
@@ -269,15 +269,15 @@ class AnalyzeVideos(DefaultTab):
         shuffle = self.root.shuffle_value
 
         videos = list(self.files)
-        save_as_csv = self.save_as_csv.checkState() == Qt.Checked
+        save_as_csv = self.save_as_csv.isChecked()
         videotype = self.video_selection_widget.videotype_widget.currentText()
 
         if self.root.is_multianimal:
             calibrate_assembly = (
-                self.calibrate_assembly_checkbox.checkState() == Qt.Checked
+                self.calibrate_assembly_checkbox.isChecked()
             )
             assemble_with_ID_only = (
-                self.assemble_with_ID_only_checkbox.checkState() == Qt.Checked
+                self.assemble_with_ID_only_checkbox.isChecked()
             )
             track_method = self.tracker_type_widget.currentText()
             edit_config(self.root.config, {"default_track_method": track_method})
@@ -332,13 +332,13 @@ class AnalyzeVideos(DefaultTab):
         shuffle = self.root.shuffle_value
 
         videos = list(self.files)
-        save_as_csv = self.save_as_csv.checkState() == Qt.Checked
-        save_as_nwb = self.save_as_nwb.checkState() == Qt.Checked
-        filter_data = self.filter_predictions.checkState() == Qt.Checked
+        save_as_csv = self.save_as_csv.isChecked()
+        save_as_nwb = self.save_as_nwb.isChecked()
+        filter_data = self.filter_predictions.isChecked()
         videotype = self.video_selection_widget.videotype_widget.currentText()
         try:
             create_video_all_detections = (
-                self.create_detections_video_checkbox.checkState() == Qt.Checked
+                self.create_detections_video_checkbox.isChecked()
             )
         except AttributeError:
             create_video_all_detections = False
@@ -361,12 +361,12 @@ class AnalyzeVideos(DefaultTab):
                 save_as_csv=save_as_csv,
             )
 
-        if self.plot_trajectories.checkState() == Qt.Checked:
+        if self.plot_trajectories.isChecked():
             bdpts = self.bodyparts_list_widget.selected_bodyparts
             self.root.logger.debug(
                 f"Selected body parts for plot_trajectories: {bdpts}"
             )
-            showfig = self.show_trajectory_plots.checkState() == Qt.Checked
+            showfig = self.show_trajectory_plots.isChecked()
             deeplabcut.plot_trajectories(
                 config,
                 videos=videos,

--- a/deeplabcut/gui/tabs/create_videos.py
+++ b/deeplabcut/gui/tabs/create_videos.py
@@ -243,7 +243,7 @@ class CreateVideos(DefaultTab):
             # Single animal scenario.
             # Color is based on bodypart.
             color_by = "bodypart"
-        filtered = bool(self.use_filtered_data_checkbox.checkState())
+        filtered = self.use_filtered_data_checkbox.isChecked()
 
         bodyparts = "all"
         if (
@@ -258,9 +258,9 @@ class CreateVideos(DefaultTab):
             videos=videos,
             shuffle=shuffle,
             filtered=filtered,
-            save_frames=bool(self.create_high_quality_video.checkState()),
+            save_frames=self.create_high_quality_video.isChecked(),
             displayedbodyparts=bodyparts,
-            draw_skeleton=bool(self.draw_skeleton_checkbox.checkState()),
+            draw_skeleton=self.draw_skeleton_checkbox.isChecked(),
             trailpoints=trailpoints,
             color_by=color_by,
         )
@@ -273,7 +273,7 @@ class CreateVideos(DefaultTab):
             failed_videos_str = ", ".join(failed_videos)
             self.root.writer.write(f"Failed to create videos from {failed_videos_str}.")
 
-        if self.plot_trajectories.checkState():
+        if self.plot_trajectories.isChecked():
             deeplabcut.plot_trajectories(
                 config=config,
                 videos=videos,

--- a/deeplabcut/gui/tabs/create_videos.py
+++ b/deeplabcut/gui/tabs/create_videos.py
@@ -248,7 +248,7 @@ class CreateVideos(DefaultTab):
         bodyparts = "all"
         if (
             len(self.bodyparts_to_use) != 0
-            and self.plot_all_bodyparts.checkState() != Qt.Checked
+            and not self.plot_all_bodyparts.isChecked()
         ):
             self.update_selected_bodyparts()
             bodyparts = self.bodyparts_to_use

--- a/deeplabcut/gui/tabs/evaluate_network.py
+++ b/deeplabcut/gui/tabs/evaluate_network.py
@@ -186,7 +186,7 @@ class EvaluateNetwork(DefaultTab):
         config = self.root.config
 
         Shuffles = [self.root.shuffle_value]
-        plotting = self.plot_predictions.checkState() == Qt.Checked
+        plotting = self.plot_predictions.isChecked()
 
         bodyparts_to_use = "all"
         if (

--- a/deeplabcut/gui/tabs/evaluate_network.py
+++ b/deeplabcut/gui/tabs/evaluate_network.py
@@ -192,7 +192,7 @@ class EvaluateNetwork(DefaultTab):
         if (
             len(self.root.all_bodyparts)
             != len(self.bodyparts_list_widget.selected_bodyparts)
-        ) and self.use_all_bodyparts.checkState() == False:
+        ) and not self.use_all_bodyparts.isChecked():
             bodyparts_to_use = self.bodyparts_list_widget.selected_bodyparts
 
         deeplabcut.evaluate_network(


### PR DESCRIPTION
In the Create Video tab in the GUI, unfiltered videos could not be created because of an incorrect reading of the "Use filtered data" checkbox state.
This PR fixes this bug