### PR TITLE
Remove pickle5 dependency from madlc Colab

### DIFF
--- a/examples/COLAB/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb
+++ b/examples/COLAB/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb
@@ -75,8 +75,7 @@
    "outputs": [],
    "source": [
     "#a few colab specific things needed:\n",
-    "!pip install --upgrade scikit-image\n",
-    "!pip3 install pickle5"
+    "!pip install --upgrade scikit-image"
    ]
   },
   {
@@ -108,8 +107,7 @@
     }
    ],
    "source": [
-    "import deeplabcut\n",
-    "import pickle5 as pickle"
+    "import deeplabcut"
    ]
   },
   {


### PR DESCRIPTION
Remove pickle5 dependency from examples/COLAB/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb
It is useless there and creates dependency conflicts.