### PR TITLE
Fix - setting cropping parameters in `analyze_videos` for PyTorch models 

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
@@ -50,6 +50,14 @@ class VideoIterator(VideoReader):
         if self._crop:
             self.set_bbox(*cropping)
 
+    def set_crop(self, cropping: list[int] | None = None) -> None:
+        """Sets the cropping parameters for the video."""
+        self._crop = cropping is not None
+        if self._crop:
+            self.set_bbox(*cropping)
+        else:
+            self.set_bbox(0, 1, 0, 1, relative=True)
+
     def get_context(self) -> list[dict[str, Any]] | None:
         if self._context is None:
             return None
@@ -157,6 +165,8 @@ def video_inference(
     """
     if not isinstance(video, VideoIterator):
         video = VideoIterator(str(video), cropping=cropping)
+    elif cropping is not None:
+        video.set_crop(cropping)
 
     n_frames = video.get_n_frames(robust=robust_nframes)
     vid_w, vid_h = video.dimensions

--- a/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
@@ -421,7 +421,7 @@ def analyze_videos(
         output_prefix = video.stem + dlc_scorer
         output_pkl = output_path / f"{output_prefix}_full.pickle"
 
-        video_iterator = VideoIterator(video)
+        video_iterator = VideoIterator(video, cropping=cropping)
 
         shelf_writer = None
         if use_shelve:
@@ -439,7 +439,6 @@ def analyze_videos(
                 video=video_iterator,
                 pose_runner=pose_runner,
                 detector_runner=detector_runner,
-                cropping=cropping,
                 shelf_writer=shelf_writer,
                 robust_nframes=robust_nframes,
             )

--- a/deeplabcut/pose_estimation_pytorch/models/predictors/single_predictor.py
+++ b/deeplabcut/pose_estimation_pytorch/models/predictors/single_predictor.py
@@ -74,8 +74,6 @@ class HeatmapPredictor(BasePredictor):
             >>> poses = predictor.forward(stride, output)
         """
         heatmaps = outputs["heatmap"]
-        # print("---")
-        # print(f"HEATMAPS SHAPE: {heatmaps.shape}")
         scale_factors = stride, stride
 
         if self.apply_sigmoid:
@@ -83,12 +81,6 @@ class HeatmapPredictor(BasePredictor):
 
         heatmaps = heatmaps.permute(0, 2, 3, 1)
         batch_size, height, width, num_joints = heatmaps.shape
-        # print(f"HEATMAPS SHAPE: {heatmaps.shape}")
-        # print(f"STRIDE: {stride}")
-        # for i in range(heatmaps.shape[-1]):
-        #     hm = heatmaps[0, :, :, i]
-        #     y0, x0 = stride * (hm == torch.max(hm)).nonzero()[0]
-        #     print(i, f"({x0}, {y0}):", torch.max(heatmaps[..., i]))
 
         locrefs = None
         if self.location_refinement:
@@ -99,16 +91,10 @@ class HeatmapPredictor(BasePredictor):
             locrefs = locrefs * self.locref_std
 
         poses = self.get_pose_prediction(heatmaps, locrefs, scale_factors)
-        # print(f"PREDICTION: {poses.shape}")
-        # for p in poses[0]:
-        #     for kpt in p:
-        #         print(kpt)
-        #     print("---")
 
         if self.clip_scores:
             poses[..., 2] = torch.clip(poses[..., 2], min=0, max=1)
 
-        # raise ValueError("")
         return {"poses": poses}
 
     def get_top_values(


### PR DESCRIPTION
Addresses issue #2847 - the cropping parameter wasn't given to the video iterator correctly.

Additionally, an issue was noted when predicting pose from heatmaps on an `MPS` device:
- the device for the `pose` array was not set, while the device for the `x`, `y` and `dz` arrays could be either `cpu`, `cuda` or `mps`
- this could lead to issues where the assignment `pose[:, :, :, 0] = x` would silently fail, with only a portion of the `x` array being assigned to the `pose` array

This issue was also resolved.