### PR TITLE
Fixed `dropimagesduetolackofannotation` to work with single-animal data

### DIFF
--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -223,6 +223,7 @@ def dropimagesduetolackofannotation(config):
         except FileNotFoundError:
             print("Attention:", folder, "does not appear to have labeled data!")
             continue
+        conversioncode.guarantee_multiindex_rows(DC)
         annotatedimages = [fn[-1] for fn in DC.index]
         imagelist = [fns for fns in os.listdir(str(folder)) if ".png" in fns]
         print("Annotated images: ", len(annotatedimages), " In folder:", len(imagelist))


### PR DESCRIPTION
Merged main into #2822 to resolve conflicts.

Fixes `dropimagesduetolackofannotation` to work with older single-animal data CollectedData files that do not have split multiindex rows. no longer deletes all images instead of just the ones with no annotations. Closes #2821.

Thanks to @aspence for the contribution!