### PR TITLE
Dynamic update of pytorch config with dot notation

### DIFF
--- a/deeplabcut/compat.py
+++ b/deeplabcut/compat.py
@@ -86,7 +86,6 @@ def train_network(
     pose_threshold: float | None = 0.1,
     pytorch_cfg_updates: dict | None = None,
 ):
-
     """
     Trains the network with the labels in the training dataset.
 
@@ -1145,6 +1144,7 @@ def analyze_images(
 
     if engine == Engine.PYTORCH:
         from deeplabcut.pose_estimation_pytorch import analyze_images
+
         return analyze_images(
             config=config,
             images=images,
@@ -1253,6 +1253,7 @@ def analyze_time_lapse_frames(
 
     if engine == Engine.TF:
         from deeplabcut.pose_estimation_tensorflow import analyze_time_lapse_frames
+
         return analyze_time_lapse_frames(
             config,
             directory,
@@ -1265,6 +1266,7 @@ def analyze_time_lapse_frames(
         )
     elif engine == Engine.PYTORCH:
         from deeplabcut.pose_estimation_pytorch import analyze_images
+
         return analyze_images(
             config=config,
             images=directory,

--- a/deeplabcut/compat.py
+++ b/deeplabcut/compat.py
@@ -76,8 +76,17 @@ def train_network(
     superanimal_name: str = "",
     superanimal_transfer_learning: bool = False,
     engine: Engine | None = None,
-    **torch_kwargs,
+    device: str | None = None,
+    snapshot_path: str | Path | None = None,
+    detector_path: str | Path | None = None,
+    batch_size: int | None = None,
+    detector_batch_size: int | None = None,
+    detector_epochs: int | None = None,
+    detector_save_epochs: int | None = None,
+    pose_threshold: float | None = 0.1,
+    pytorch_cfg_updates: dict | None = None,
 ):
+
     """
     Trains the network with the labels in the training dataset.
 
@@ -135,6 +144,7 @@ def train_network(
         Only for the PyTorch engine (equivalent to the `saveiters` parameter for the
         TensorFlow engine). The number of epochs between each snapshot save. If
         None, the value will be read from the `pytorch_config.yaml` file.
+
     allow_growth: bool, optional, default=True.
         Only for the TensorFlow engine.
         For some smaller GPUs the memory issues happen. If ``True``, the memory
@@ -180,18 +190,38 @@ def train_network(
         overwrite this by passing the engine as an argument, but this should generally
         not be done.
 
-    torch_kwargs:
-        You can add any keyword arguments for the deeplabcut.pose_estimation_pytorch
-        train_network method here. These arguments are passed to the downstream method.
-        Some of the parameters that can be passed are
-            * ``device`` (the CUDA device to use for training)
-            * ``batch_size`` (the batch size to use while training)
-            * ``snapshot_path`` (the pose model snapshot to resume training from)
-            * ``detector_path`` (the detector model snapshot to resume training from)
+    device: str, optional, default = None.
+        Only for the PyTorch engine. The device to run the training on (e.g. "cuda:0")
 
-        When training a top-down model, these parameters are also available for the
-        detector, with the parameters ``detector_batch_size``, ``detector_epochs`` and
-        ``detector_save_epochs``.
+    snapshot_path: str or Path, optional, default = None.
+        Only for the PyTorch engine. The path to the pose model snapshot to resume training from.
+
+    detector_path: str or Path, optional, default = None.
+        Only for the PyTorch engine. The path to the detector model snapshot to resume training from.
+
+    batch_size: int, optional, default = None.
+        Only for the PyTorch engine. The batch size to use while training.
+
+    detector_batch_size: int, optional, default = None.
+        Only for the PyTorch engine. The batch size to use while training the detector.
+
+    detector_epochs: int, optional, default = None.
+        Only for the PyTorch engine. The number of epochs to train the detector for.
+
+    detector_save_epochs: int, optional, default = None.
+        Only for the PyTorch engine. The number of epochs between each detector snapshot save.
+
+    pose_threshold: float, optional, default = 0.1.
+        Only for the PyTorch engine. Used for memory-replay. Pseudo-predictions with confidence lower
+            than this threshold are discarded for memory-replay
+
+    pytorch_cfg_updates: dict, optional, default = None.
+        A dictionary of updates to the pytorch config. The keys are the dot-separated
+        paths to the values to update in the config.
+        For example, to update the gpus to run the training on, you can use:
+        ```
+        pytorch_cfg_updates={"runner.gpus": [0,1,2,3]}
+        ```
 
     Returns
     -------
@@ -255,20 +285,25 @@ def train_network(
     elif engine == Engine.PYTORCH:
         from deeplabcut.pose_estimation_pytorch.apis import train_network
 
-        _update_device(gputouse, torch_kwargs)
-        if "display_iters" not in torch_kwargs:
-            torch_kwargs["display_iters"] = displayiters
-
         return train_network(
             config,
             shuffle=shuffle,
             trainingsetindex=trainingsetindex,
             modelprefix=modelprefix,
-            max_snapshots_to_keep=max_snapshots_to_keep,
+            device=device,
+            snapshot_path=snapshot_path,
+            detector_path=detector_path,
             load_head_weights=keepdeconvweights,
+            batch_size=batch_size,
             epochs=epochs,
             save_epochs=save_epochs,
-            **torch_kwargs,
+            detector_batch_size=detector_batch_size,
+            detector_epochs=detector_epochs,
+            detector_save_epochs=detector_save_epochs,
+            display_iters=displayiters,
+            max_snapshots_to_keep=max_snapshots_to_keep,
+            pose_threshold=pose_threshold,
+            pytorch_cfg_updates=pytorch_cfg_updates,
         )
 
     raise NotImplementedError(f"This function is not implemented for {engine}")

--- a/deeplabcut/pose_estimation_pytorch/apis/prune_paf_graph.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/prune_paf_graph.py
@@ -142,8 +142,7 @@ def benchmark_paf_graphs(
             print()
 
         # update the edges to keep in the PyTorch configuration file
-        head_update = dict(predictor=dict(edges_to_keep=best_edges))
-        loader.update_model_cfg(dict(model=dict(heads=dict(bodypart=head_update))))
+        loader.update_model_cfg({"model.heads.bodypart.predictor.edges_to_keep": best_edges})
 
         # update the edges indices
         test_config = loader.model_folder.parent / "test" / "pose_cfg.yaml"

--- a/deeplabcut/pose_estimation_pytorch/apis/prune_paf_graph.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/prune_paf_graph.py
@@ -78,7 +78,12 @@ def benchmark_paf_graphs(
 
     gt_train = loader.ground_truth_keypoints("train")
     best_paf_edges, _ = get_n_best_paf_graphs(
-        model, gt_train, preprocessor, device, predictor.graph, n_graphs=10,
+        model,
+        gt_train,
+        preprocessor,
+        device,
+        predictor.graph,
+        n_graphs=10,
     )
 
     if verbose:
@@ -142,13 +147,13 @@ def benchmark_paf_graphs(
             print()
 
         # update the edges to keep in the PyTorch configuration file
-        loader.update_model_cfg({"model.heads.bodypart.predictor.edges_to_keep": best_edges})
+        loader.update_model_cfg(
+            {"model.heads.bodypart.predictor.edges_to_keep": best_edges}
+        )
 
         # update the edges indices
         test_config = loader.model_folder.parent / "test" / "pose_cfg.yaml"
-        auxiliaryfunctions.edit_config(
-            str(test_config), dict(paf_best=best_edges)
-        )
+        auxiliaryfunctions.edit_config(str(test_config), dict(paf_best=best_edges))
 
     return results
 

--- a/deeplabcut/pose_estimation_pytorch/apis/train.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/train.py
@@ -216,7 +216,7 @@ def train_network(
     display_iters: int | None = None,
     max_snapshots_to_keep: int | None = None,
     pose_threshold: float | None = 0.1,
-    **kwargs,
+    pytorch_cfg_updates: dict | None = None,
 ) -> None:
     """Trains a network for a project
 
@@ -252,8 +252,14 @@ def train_network(
         max_snapshots_to_keep: the maximum number of snapshots to save for each model
         pose_threshold: Used for memory-replay. Pseudo-predictions with confidence lower
             than this threshold are discarded for memory-replay
-        **kwargs : could be any entry of the pytorch_config dictionary. Examples are
-            to see the full list see the pytorch_cfg.yaml file in your project folder
+        pytorch_cfg_updates: dict, optional, default = None.
+            A dictionary of updates to the pytorch config. The keys are the dot-separated
+            paths to the values to update in the config.
+            For example, to update the gpus to run the training on, you can use:
+            ```
+            pytorch_cfg_updates={"runner.gpus": [0,1,2,3]}
+            ```
+            To see the full list - check the pytorch_cfg.yaml file in your project folder
     """
     loader = DLCLoader(
         config=config,
@@ -314,7 +320,9 @@ def train_network(
         if display_iters is not None:
             detector_cfg["train_settings"]["display_iters"] = display_iters
 
-    loader.update_model_cfg(kwargs)
+    if pytorch_cfg_updates is not None:
+        loader.update_model_cfg(pytorch_cfg_updates)
+
     setup_file_logging(loader.model_folder / "train.txt")
 
     logging.info("Training with configuration:")

--- a/deeplabcut/pose_estimation_pytorch/config/__init__.py
+++ b/deeplabcut/pose_estimation_pytorch/config/__init__.py
@@ -19,5 +19,6 @@ from deeplabcut.pose_estimation_pytorch.config.utils import (
     pretty_print,
     read_config_as_dict,
     update_config,
+    update_config_by_dotpath,
     write_config,
 )

--- a/deeplabcut/pose_estimation_pytorch/config/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/config/utils.py
@@ -59,6 +59,7 @@ def replace_default_values(
         ValueError: if there is a placeholder value who's "updated" value was not
             given to the method
     """
+
     def get_updated_value(variable: str) -> int | list[int]:
         var_parts = variable.strip().split(" ")
         var_name = var_parts[0]
@@ -152,7 +153,9 @@ def update_config(config: dict, updates: dict, copy_original: bool = True) -> di
     return config
 
 
-def update_config_by_dotpath(config: dict, updates: dict, copy_original: bool = True) -> dict:
+def update_config_by_dotpath(
+    config: dict, updates: dict, copy_original: bool = True
+) -> dict:
     """Updates items in the configuration file using dot notation for nested keys
 
     The configuration dict should only be composed of primitive Python types
@@ -243,7 +246,7 @@ def read_config_as_dict(config_path: str | Path) -> dict:
         The configuration file with pure Python classes
     """
     with open(config_path, "r") as f:
-        cfg = YAML(typ='safe', pure=True).load(f)
+        cfg = YAML(typ="safe", pure=True).load(f)
 
     return cfg
 

--- a/deeplabcut/pose_estimation_pytorch/config/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/config/utils.py
@@ -152,6 +152,47 @@ def update_config(config: dict, updates: dict, copy_original: bool = True) -> di
     return config
 
 
+def update_config_by_dotpath(config: dict, updates: dict, copy_original: bool = True) -> dict:
+    """Updates items in the configuration file using dot notation for nested keys
+
+    The configuration dict should only be composed of primitive Python types
+    (dict, list and values). This is the case when reading the file using
+    `read_config_as_dict`.
+
+    Args:
+        config: the configuration dict to update
+        updates: single-level dict with dot notation keys indicating nested paths
+            e.g. {"device": "cuda", "runner.gpus": [0,1]}
+        copy_original: whether to copy the original dict before updating it
+
+    Returns:
+        the updated dictionary
+    """
+    if copy_original:
+        config = copy.deepcopy(config)
+
+    for key, value in updates.items():
+        # Split key into parts by dots
+        parts = key.split(".")
+
+        # Handle non-nested case
+        if len(parts) == 1:
+            config[key] = copy.deepcopy(value)
+            continue
+
+        # Navigate to nested location
+        current = config
+        for part in parts[:-1]:
+            if part not in current:
+                current[part] = {}
+            current = current[part]
+
+        # Set the value at final location
+        current[parts[-1]] = copy.deepcopy(value)
+
+    return config
+
+
 def get_config_folder_path() -> Path:
     """Returns: the Path to the folder containing the "configs" for DeepLabCut 3.0"""
     dlc_parent_path = Path(auxiliaryfunctions.get_deeplabcut_path())

--- a/deeplabcut/pose_estimation_pytorch/data/base.py
+++ b/deeplabcut/pose_estimation_pytorch/data/base.py
@@ -62,7 +62,7 @@ class Loader(ABC):
         Args:
             updates: the items to update in the model configuration
         """
-        self.model_cfg = config.update_config(self.model_cfg, updates)
+        self.model_cfg = config.update_config_by_dotpath(self.model_cfg, updates)
         config.write_config(self.model_config_path, self.model_cfg)
 
     @abstractmethod

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/train_from_coco.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/train_from_coco.py
@@ -48,28 +48,21 @@ def adaptation_train(
 
     utils.fix_seeds(loader.model_cfg["train_settings"]["seed"])
 
-    updates = dict(
-        detector=dict(
-            model=dict(freeze_bn_stats=True),
-            runner=dict(snapshots=dict(max_snapshots=5, save_epochs=1)),
-            train_settings=dict(batch_size=detector_batch_size, epochs=4),
-        ),
-        model=dict(backbone=dict(freeze_bn_stats=True)),
-        runner=dict(snapshots=dict(max_snapshots=5, save_epochs=1)),
-        train_settings=dict(batch_size=batch_size, epochs=4),
-    )
-
-    if epochs is not None:
-        updates["train_settings"]["epochs"] = epochs
-    if save_epochs is not None:
-        updates["runner"]["snapshots"]["save_epochs"] = save_epochs
-    if detector_epochs is not None:
-        updates["detector"]["train_settings"]["epochs"] = detector_epochs
-    if detector_save_epochs is not None:
-        updates["detector"]["runner"]["snapshots"]["save_epochs"] = detector_save_epochs
+    updates = {
+        "detector.model.freeze_bn_stats": True,
+        "detector.runner.snapshots.max_snapshots": 5,
+        "detector.runner.snapshots.save_epochs": detector_save_epochs or 1,
+        "detector.train_settings.batch_size": detector_batch_size,
+        "detector.train_settings.epochs": detector_epochs or 4,
+        "model.backbone.freeze_bn_stats": True,
+        "runner.snapshots.max_snapshots": 5,
+        "runner.snapshots.save_epochs": save_epochs or 1,
+        "train_settings.batch_size": batch_size,
+        "train_settings.epochs": epochs or 4,
+        }
 
     if eval_interval is not None:
-        updates["runner"]["eval_interval"] = eval_interval
+        updates["runner.eval_interval"] = eval_interval
 
     loader.update_model_cfg(updates)
 

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/train_from_coco.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/train_from_coco.py
@@ -59,7 +59,7 @@ def adaptation_train(
         "runner.snapshots.save_epochs": save_epochs or 1,
         "train_settings.batch_size": batch_size,
         "train_settings.epochs": epochs or 4,
-        }
+    }
 
     if eval_interval is not None:
         updates["runner.eval_interval"] = eval_interval

--- a/examples/testscript_pytorch_multi_animal.py
+++ b/examples/testscript_pytorch_multi_animal.py
@@ -8,7 +8,7 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
-""" Testscript for single animal PyTorch projects """
+"""Testscript for single animal PyTorch projects"""
 from __future__ import annotations
 
 from pathlib import Path
@@ -17,7 +17,11 @@ import deeplabcut.utils.auxiliaryfunctions as af
 from deeplabcut.compat import Engine
 
 from utils import (
-    cleanup, create_fake_project, log_step, run, SyntheticProjectParameters,
+    cleanup,
+    create_fake_project,
+    log_step,
+    run,
+    SyntheticProjectParameters,
 )
 
 

--- a/examples/testscript_pytorch_multi_animal.py
+++ b/examples/testscript_pytorch_multi_animal.py
@@ -57,35 +57,21 @@ def main(
                     net_type=net_type,
                     videos=[str(project_path / "videos" / "video.mp4")],
                     device=device,
-                    train_kwargs=dict(
-                        train_settings=dict(
-                            display_iters=50,
-                            epochs=epochs_,
-                            batch_size=batch_size,
-                        ),
-                        runner=dict(
-                            device=device,
-                            snapshots=dict(
-                                save_epochs=save_epochs,
-                                max_snapshots=max_snapshots_to_keep,
-                            )
-                        ),
-                        detector=dict(
-                            train_settings=dict(
-                                display_iters=1,
-                                epochs=detector_epochs,
-                                batch_size=detector_batch_size,
-                            ),
-                            runner=dict(
-                                snapshots=dict(
-                                    save_epochs=save_epochs,
-                                    max_snapshots=max_snapshots_to_keep,
-                                )
-                            )
-                        ),
-                        logger=logger,
-                    ),
                     engine=engine,
+                    pytorch_cfg_updates={
+                        "train_settings.display_iters": 50,
+                        "train_settings.epochs": epochs_,
+                        "train_settings.batch_size": batch_size,
+                        "runner.device": device,
+                        "runner.snapshots.save_epochs": save_epochs,
+                        "runner.snapshots.max_snapshots": max_snapshots_to_keep,
+                        "detector.train_settings.display_iters": 1,
+                        "detector.train_settings.epochs": detector_epochs,
+                        "detector.train_settings.batch_size": detector_batch_size,
+                        "detector.runner.snapshots.save_epochs": save_epochs,
+                        "detector.runner.snapshots.max_snapshots": max_snapshots_to_keep,
+                        "logger": logger,
+                    },
                     create_labeled_videos=create_labeled_videos,
                 )
             except Exception as err:

--- a/examples/testscript_pytorch_single_animal.py
+++ b/examples/testscript_pytorch_single_animal.py
@@ -55,22 +55,16 @@ def main(
                     net_type=net_type,
                     videos=videos,
                     device=device,
-                    train_kwargs=dict(
-                        train_settings=dict(
-                            display_iters=50,
-                            epochs=epochs,
-                            batch_size=batch_size,
-                        ),
-                        runner=dict(
-                            device=device,
-                            snapshots=dict(
-                                save_epochs=save_epochs,
-                                max_snapshots=max_snapshots_to_keep,
-                            )
-                        ),
-                        logger=logger,
-                    ),
                     engine=engine,
+                    pytorch_cfg_updates={
+                        "train_settings.display_iters": 50,
+                        "train_settings.epochs": epochs,
+                        "train_settings.batch_size": batch_size,
+                        "runner.device": device,
+                        "runner.snapshots.save_epochs": save_epochs,
+                        "runner.snapshots.max_snapshots": max_snapshots_to_keep,
+                        "logger": logger,
+                    },
                     create_labeled_videos=create_labeled_videos,
                 )
 

--- a/examples/testscript_pytorch_single_animal.py
+++ b/examples/testscript_pytorch_single_animal.py
@@ -1,4 +1,5 @@
-""" Testscript for single animal PyTorch projects """
+"""Testscript for single animal PyTorch projects"""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -26,7 +27,8 @@ def main(
     device: str = "cpu",
     logger: dict | None = None,
     synthetic_data_params: SyntheticProjectParameters = SyntheticProjectParameters(
-        multianimal=False, num_bodyparts=6,
+        multianimal=False,
+        num_bodyparts=6,
     ),
     create_labeled_videos: bool = False,
     delete_after_test_run: bool = False,

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -343,8 +343,8 @@ def run(
     net_type: str,
     videos: list[str],
     device: str,
-    train_kwargs: dict,
     engine: Engine = Engine.PYTORCH,
+    pytorch_cfg_updates: dict | None = None,
     create_labeled_videos: bool = False,
 ) -> None:
     times = [time.time()]
@@ -362,7 +362,7 @@ def run(
         shuffle=shuffle_index,
         trainingsetindex=trainset_index,
         device=device,
-        **train_kwargs,
+        pytorch_cfg_updates=pytorch_cfg_updates,
     )
     times.append(time.time())
     log_step(f"Train time: {times[-1] - times[-2]} seconds")

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -49,10 +49,10 @@ class SyntheticProjectParameters:
     frame_shape: tuple[int, int] = (480, 640)
 
     def bodyparts(self) -> list[str]:
-        return [i for i in string.ascii_lowercase[:self.num_bodyparts]]
+        return [i for i in string.ascii_lowercase[: self.num_bodyparts]]
 
     def unique(self) -> list[str]:
-        return [f"unique_{i}" for i in string.ascii_lowercase[:self.num_unique]]
+        return [f"unique_{i}" for i in string.ascii_lowercase[: self.num_unique]]
 
     def individuals(self) -> list[str]:
         return [f"animal_{i}" for i in range(self.num_individuals)]
@@ -76,9 +76,9 @@ def sample_pose_random(
         unique_pose = np.stack(
             [
                 gen.choice(img_w, size=(1, num_unique), replace=False),
-                gen.choice(img_h, size=(1, num_unique), replace=False)
+                gen.choice(img_h, size=(1, num_unique), replace=False),
             ],
-            axis=-1
+            axis=-1,
         )
         image_data = np.concatenate([image_data, unique_pose.reshape(-1)])
     return image_data
@@ -350,13 +350,17 @@ def run(
     times = [time.time()]
     log_step(f"Testing with net type {net_type}")
     log_step("Creating the training dataset")
-    deeplabcut.create_training_dataset(str(config_path), net_type=net_type, engine=engine)
+    deeplabcut.create_training_dataset(
+        str(config_path), net_type=net_type, engine=engine
+    )
     existing_shuffles = get_existing_shuffle_indices(
         config_path, train_fraction=train_fraction, engine=engine
     )
     shuffle_index = existing_shuffles[-1]
 
-    log_step(f"Starting training for train_frac {train_fraction}, shuffle {shuffle_index}")
+    log_step(
+        f"Starting training for train_frac {train_fraction}, shuffle {shuffle_index}"
+    )
     deeplabcut.train_network(
         config=str(config_path),
         shuffle=shuffle_index,
@@ -367,7 +371,9 @@ def run(
     times.append(time.time())
     log_step(f"Train time: {times[-1] - times[-2]} seconds")
 
-    log_step(f"Starting evaluation for train_frac {train_fraction}, shuffle {shuffle_index}")
+    log_step(
+        f"Starting evaluation for train_frac {train_fraction}, shuffle {shuffle_index}"
+    )
     deeplabcut.evaluate_network(
         config=str(config_path),
         Shuffles=[shuffle_index],

--- a/tests/pose_estimation_pytorch/config/test_make_pose_config.py
+++ b/tests/pose_estimation_pytorch/config/test_make_pose_config.py
@@ -16,7 +16,11 @@ from deeplabcut.pose_estimation_pytorch.config.make_pose_config import (
     make_basic_project_config,
     make_pytorch_pose_config,
 )
-from deeplabcut.pose_estimation_pytorch.config.utils import pretty_print, update_config, update_config_by_dotpath
+from deeplabcut.pose_estimation_pytorch.config.utils import (
+    pretty_print,
+    update_config,
+    update_config_by_dotpath,
+)
 
 
 @pytest.mark.parametrize("bodyparts", [["nose"], ["nose", "ear", "eye"]])
@@ -92,9 +96,7 @@ def test_backbone_plus_paf_config(
     pretty_print(pytorch_pose_config)
 
     graph = [
-        [i, j]
-        for i in range(len(bodyparts))
-        for j in range(i + 1, len(bodyparts))
+        [i, j] for i in range(len(bodyparts)) for j in range(i + 1, len(bodyparts))
     ]
     num_limbs = len(graph) * 2
 
@@ -109,7 +111,7 @@ def test_backbone_plus_paf_config(
     for name, output_channels in [
         ("heatmap_config", len(bodyparts)),
         ("locref_config", len(bodyparts) * 2),
-        ("paf_config", num_limbs)
+        ("paf_config", num_limbs),
     ]:
         print(name, bodypart_head[name]["channels"])
         assert name in bodypart_head
@@ -142,7 +144,7 @@ def test_backbone_plus_paf_config(
         ("ssdlite", "SSDLite"),
         ("fasterrcnn_mobilenet_v3_large_fpn", "FasterRCNN"),
         ("fasterrcnn_resnet50_fpn_v2", "FasterRCNN"),
-    ]
+    ],
 )
 @pytest.mark.parametrize("individuals", [["single"], ["bugs", "daffy"]])
 @pytest.mark.parametrize("bodyparts", [["nose"], ["nose", "ear", "eye"]])
@@ -215,7 +217,7 @@ def test_make_dekr_config(
         identity=identity,
         individuals=individuals,
         bodyparts=bodyparts,
-        unique_bodyparts=unique_bodyparts
+        unique_bodyparts=unique_bodyparts,
     )
     pytorch_pose_config = make_pytorch_pose_config(
         project_config,
@@ -275,7 +277,7 @@ def test_make_dlcrnet_config(
         identity=identity,
         individuals=individuals,
         bodyparts=bodyparts,
-        unique_bodyparts=unique_bodyparts
+        unique_bodyparts=unique_bodyparts,
     )
     pytorch_pose_config = make_pytorch_pose_config(
         project_config,
@@ -284,9 +286,7 @@ def test_make_dlcrnet_config(
     )
     pretty_print(pytorch_pose_config)
     paf_graph = [
-        [i, j]
-        for i in range(len(bodyparts))
-        for j in range(i + 1, len(bodyparts))
+        [i, j] for i in range(len(bodyparts)) for j in range(i + 1, len(bodyparts))
     ]
     num_limbs = len(paf_graph)
 
@@ -340,7 +340,7 @@ def test_make_tokenpose_config(
         identity=identity,
         individuals=individuals,
         bodyparts=bodyparts,
-        unique_bodyparts=unique_bodyparts
+        unique_bodyparts=unique_bodyparts,
     )
 
     if identity or len(unique_bodyparts) > 0:
@@ -369,28 +369,37 @@ def test_make_tokenpose_config(
         assert "data" in pytorch_pose_config["detector"]
 
 
-@pytest.mark.parametrize("data", [
-    {
-        "config": {"a": 0, "b": 0},
-        "updates": {"b": 1},
-        "expected_result": {"a": 0, "b": 1},
-    },
-    {
-        "config": {"a": 0, "b": {"i0": 1, "i1": 2}},
-        "updates": {"b": 1},
-        "expected_result": {"a": 0, "b": 1},
-    },
-    {
-        "config": {"a": 0, "b": {"i0": 1, "i1": 2}},
-        "updates": {"b": {"i0": [1, 2, 3]}},
-        "expected_result": {"a": 0, "b": {"i0": [1, 2, 3], "i1": 2}},
-    },
-    {
-        "config": {"detector": {"batch_size": 1, "epochs": 10, "save_epochs": 5}},
-        "updates": {"batch_size": 1, "detector": {"batch_size": 8, "save_epochs": 1}},
-        "expected_result": {"batch_size": 1, "detector": {"batch_size": 8, "epochs": 10, "save_epochs": 1}},
-    },
-])
+@pytest.mark.parametrize(
+    "data",
+    [
+        {
+            "config": {"a": 0, "b": 0},
+            "updates": {"b": 1},
+            "expected_result": {"a": 0, "b": 1},
+        },
+        {
+            "config": {"a": 0, "b": {"i0": 1, "i1": 2}},
+            "updates": {"b": 1},
+            "expected_result": {"a": 0, "b": 1},
+        },
+        {
+            "config": {"a": 0, "b": {"i0": 1, "i1": 2}},
+            "updates": {"b": {"i0": [1, 2, 3]}},
+            "expected_result": {"a": 0, "b": {"i0": [1, 2, 3], "i1": 2}},
+        },
+        {
+            "config": {"detector": {"batch_size": 1, "epochs": 10, "save_epochs": 5}},
+            "updates": {
+                "batch_size": 1,
+                "detector": {"batch_size": 8, "save_epochs": 1},
+            },
+            "expected_result": {
+                "batch_size": 1,
+                "detector": {"batch_size": 8, "epochs": 10, "save_epochs": 1},
+            },
+        },
+    ],
+)
 def test_update_config(data: dict):
     result = update_config(config=data["config"], updates=data["updates"])
     print("\nResult")
@@ -398,28 +407,38 @@ def test_update_config(data: dict):
     assert result == data["expected_result"]
 
 
-@pytest.mark.parametrize("data", [
-    {
-        "config": {"a": 0, "b": 0},
-        "updates": {"b": 1},
-        "expected_result": {"a": 0, "b": 1},
-    },
-    {
-        "config": {"a": 0, "b": {"i0": 1, "i1": 2}},
-        "updates": {"b": 1},
-        "expected_result": {"a": 0, "b": 1},
-    },
-    {
-        "config": {"a": 0, "b": {"i0": 1, "i1": 2}},
-        "updates": {"b.i0": [1, 2, 3]},
-        "expected_result": {"a": 0, "b": {"i0": [1, 2, 3], "i1": 2}},
-    },
-    {
-        "config": {"detector": {"batch_size": 1, "epochs": 10, "save_epochs": 5}},
-        "updates": {"batch_size": 1, "detector.batch_size": 8, "detector.save_epochs": 1},
-        "expected_result": {"batch_size": 1, "detector": {"batch_size": 8, "epochs": 10, "save_epochs": 1}},
-    },
-])
+@pytest.mark.parametrize(
+    "data",
+    [
+        {
+            "config": {"a": 0, "b": 0},
+            "updates": {"b": 1},
+            "expected_result": {"a": 0, "b": 1},
+        },
+        {
+            "config": {"a": 0, "b": {"i0": 1, "i1": 2}},
+            "updates": {"b": 1},
+            "expected_result": {"a": 0, "b": 1},
+        },
+        {
+            "config": {"a": 0, "b": {"i0": 1, "i1": 2}},
+            "updates": {"b.i0": [1, 2, 3]},
+            "expected_result": {"a": 0, "b": {"i0": [1, 2, 3], "i1": 2}},
+        },
+        {
+            "config": {"detector": {"batch_size": 1, "epochs": 10, "save_epochs": 5}},
+            "updates": {
+                "batch_size": 1,
+                "detector.batch_size": 8,
+                "detector.save_epochs": 1,
+            },
+            "expected_result": {
+                "batch_size": 1,
+                "detector": {"batch_size": 8, "epochs": 10, "save_epochs": 1},
+            },
+        },
+    ],
+)
 def test_update_config_by_dotpath(data: dict):
     result = update_config_by_dotpath(config=data["config"], updates=data["updates"])
     print("\nResult")

--- a/tests/pose_estimation_pytorch/config/test_make_pose_config.py
+++ b/tests/pose_estimation_pytorch/config/test_make_pose_config.py
@@ -16,7 +16,7 @@ from deeplabcut.pose_estimation_pytorch.config.make_pose_config import (
     make_basic_project_config,
     make_pytorch_pose_config,
 )
-from deeplabcut.pose_estimation_pytorch.config.utils import pretty_print, update_config
+from deeplabcut.pose_estimation_pytorch.config.utils import pretty_print, update_config, update_config_by_dotpath
 
 
 @pytest.mark.parametrize("bodyparts", [["nose"], ["nose", "ear", "eye"]])
@@ -393,6 +393,35 @@ def test_make_tokenpose_config(
 ])
 def test_update_config(data: dict):
     result = update_config(config=data["config"], updates=data["updates"])
+    print("\nResult")
+    pretty_print(result)
+    assert result == data["expected_result"]
+
+
+@pytest.mark.parametrize("data", [
+    {
+        "config": {"a": 0, "b": 0},
+        "updates": {"b": 1},
+        "expected_result": {"a": 0, "b": 1},
+    },
+    {
+        "config": {"a": 0, "b": {"i0": 1, "i1": 2}},
+        "updates": {"b": 1},
+        "expected_result": {"a": 0, "b": 1},
+    },
+    {
+        "config": {"a": 0, "b": {"i0": 1, "i1": 2}},
+        "updates": {"b.i0": [1, 2, 3]},
+        "expected_result": {"a": 0, "b": {"i0": [1, 2, 3], "i1": 2}},
+    },
+    {
+        "config": {"detector": {"batch_size": 1, "epochs": 10, "save_epochs": 5}},
+        "updates": {"batch_size": 1, "detector.batch_size": 8, "detector.save_epochs": 1},
+        "expected_result": {"batch_size": 1, "detector": {"batch_size": 8, "epochs": 10, "save_epochs": 1}},
+    },
+])
+def test_update_config_by_dotpath(data: dict):
+    result = update_config_by_dotpath(config=data["config"], updates=data["updates"])
     print("\nResult")
     pretty_print(result)
     assert result == data["expected_result"]


### PR DESCRIPTION
In this Pull Request, in order to facilitate the dynamic update of pytorch_config.yaml (when calling `deeplabcut.train_network()`), I:

- Implement the `update_config_by_dotpath()` method. This method is easier to use than the previous `update_config()`. With `update_config()`, you needed to pass a nested dictionary as argument to target nested arguments in the pytorch_config.yaml, and it wasn't explicit how the nested dict was processed. With `update_config_by_dotpath()`, you target nested arguments by using a single-level dictionary with dot-notation path access. For example to update the `gpus` list in the `runner` section, you pass `{"runner.gpus": [0,1]}` (instead of `dict(runner=dict(gpus=[0,1]))`)
- Pass updates to the pytorch configuration with the `pytorch_cfg_updates: dict` argument instead of using the `kwargs` in `train_network()`.
- Make explicit all the other arguments that can be passed to `train_network()` (that were passed through the `kwargs` before) for more transparency, and remove the `kwargs` argument from `train_network()`.
- Implement a test for the new `update_config_by_dotpath()` method, update integration tests.