### PR TITLE
ReID Tracking dataset creation for PyTorch models

### DIFF
--- a/deeplabcut/compat.py
+++ b/deeplabcut/compat.py
@@ -711,7 +711,6 @@ def analyze_videos(
         By default, the models are assumed to exist in the project folder.
 
     robust_nframes: bool, optional, default=False
-        Currently not supported by the PyTorch engine.
         Evaluate a video's number of frames in a robust manner.
         This option is slower (as the whole video is read frame-by-frame),
         but does not rely on metadata, hence its robustness against file corruption.
@@ -923,12 +922,80 @@ def create_tracking_dataset(
     batchsize: int | None = None,
     cropping: list[int] | None = None,
     TFGPUinference: bool = True,
-    dynamic: tuple[bool, float, int] = (False, 0.5, 10),
     modelprefix: str = "",
     robust_nframes: bool = False,
     n_triplets: int = 1000,
     engine: Engine | None = None,
-):
+) -> str:
+    """Creates a tracking dataset to train a ReID tracklet stitcher.
+
+    Parameters
+    ----------
+    config: str
+        Full path of the config.yaml file.
+
+    videos: list[str]
+        A list of strings containing the full paths to videos from which to create a
+        tracking dataset, or a path to the directory where all the videos with same
+        extension are stored.
+
+    track_method: str
+        Specifies the tracker used to generate the pose estimation data. Must be either
+        'box', 'skeleton', or 'ellipse'.
+
+    videotype: str, optional, default=""
+        Checks for the extension of the video in case the input to the video is a
+        directory. Only videos with this extension are analyzed. If left unspecified,
+        videos with common extensions ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
+
+    shuffle: int, optional, default=1
+        An integer specifying the shuffle index of the training dataset used for
+        training the network.
+
+    trainingsetindex: int, optional, default=0
+        Integer specifying which TrainingsetFraction to use.
+        By default the first (note that TrainingFraction is a list in config.yaml).
+
+    gputouse: int or None, optional, default=None
+        Only for the TensorFlow engine (for the PyTorch engine use ``device``).
+        Indicates the GPU to use (see number in ``nvidia-smi``). If you do not have a
+        GPU put ``None``. See:
+            https://nvidia.custhelp.com/app/answers/detail/a_id/3751/~/useful-nvidia-smi-queries
+
+    TFGPUinference: bool, optional, default=True
+        Only for the TensorFlow engine.
+        Perform inference on GPU with TensorFlow code. Introduced in "Pretraining
+        boosts out-of-domain robustness for pose estimation" by Alexander Mathis,
+        Mert Yüksekgönül, Byron Rogers, Matthias Bethge, Mackenzie W. Mathis.
+        Source: https://arxiv.org/abs/1909.11229
+
+    destfolder:
+        Specifies the destination folder for analysis data. If ``None``, the path of
+        the video is used. Note that for subsequent analysis this folder also needs to
+        be passed.
+
+    modelprefix: str, optional, default=""
+        Directory containing the deeplabcut models to use when evaluating the network.
+        By default, the models are assumed to exist in the project folder.
+
+    robust_nframes: bool, optional, default=False
+        Evaluate a video's number of frames in a robust manner.
+        This option is slower (as the whole video is read frame-by-frame),
+        but does not rely on metadata, hence its robustness against file corruption.
+
+    n_triplets: int, default=1000
+        The number of triplets to extract for the dataset.
+
+    engine: Engine, optional, default = None.
+        The default behavior loads the engine for the shuffle from the metadata. You can
+        overwrite this by passing the engine as an argument, but this should generally
+        not be done.
+
+    Returns
+    -------
+    DLCScorer: str
+        the scorer used to analyze the videos
+    """
     if engine is None:
         engine = get_shuffle_engine(
             _load_config(config),
@@ -948,12 +1015,26 @@ def create_tracking_dataset(
             shuffle=shuffle,
             trainingsetindex=trainingsetindex,
             gputouse=gputouse,
-            save_as_csv=False,  # not used in method
             destfolder=destfolder,
             batchsize=batchsize,
             cropping=cropping,
             TFGPUinference=TFGPUinference,
-            dynamic=dynamic,
+            modelprefix=modelprefix,
+            robust_nframes=robust_nframes,
+            n_triplets=n_triplets,
+        )
+    elif engine == Engine.PYTORCH:
+        from deeplabcut.pose_estimation_pytorch.apis import create_tracking_dataset
+        return create_tracking_dataset(
+            config,
+            videos,
+            track_method,
+            videotype=videotype,
+            shuffle=shuffle,
+            trainingsetindex=trainingsetindex,
+            destfolder=destfolder,
+            batch_size=batchsize,
+            cropping=cropping,
             modelprefix=modelprefix,
             robust_nframes=robust_nframes,
             n_triplets=n_triplets,

--- a/deeplabcut/pose_estimation_pytorch/__init__.py
+++ b/deeplabcut/pose_estimation_pytorch/__init__.py
@@ -15,6 +15,7 @@ from deeplabcut.pose_estimation_pytorch.apis import (
     analyze_videos,
     build_predictions_dataframe,
     create_labeled_images,
+    create_tracking_dataset,
     convert_detections2tracklets,
     evaluate,
     evaluate_network,

--- a/deeplabcut/pose_estimation_pytorch/apis/__init__.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/__init__.py
@@ -30,6 +30,9 @@ from deeplabcut.pose_estimation_pytorch.apis.evaluate import (
     visualize_predictions,
 )
 from deeplabcut.pose_estimation_pytorch.apis.export import export_model
+from deeplabcut.pose_estimation_pytorch.apis.tracking_dataset import (
+    create_tracking_dataset,
+)
 from deeplabcut.pose_estimation_pytorch.apis.train import (
     train,
     train_network,

--- a/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/analyze_videos.py
@@ -617,6 +617,11 @@ def _generate_assemblies_file(
         # reshape to (num_preds, num_bpts, 4)
         preds = np.concatenate([preds, keypoint_pred_ids], axis=-1)
         preds = preds.transpose((1, 0, 2))
+
+        # remove all-missing predictions
+        mask = ~np.all(preds < 0, axis=(1, 2))
+        preds = preds[mask]
+
         assemblies[frame_index] = preds
 
         if num_unique_bodyparts > 0:

--- a/deeplabcut/pose_estimation_pytorch/apis/tracking_dataset.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/tracking_dataset.py
@@ -1,0 +1,273 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Code to create tracking datasets for ReID model training"""
+from pathlib import Path
+
+from tqdm import tqdm
+
+import deeplabcut.pose_estimation_pytorch.apis.utils as utils
+import deeplabcut.pose_estimation_pytorch.data as data
+import deeplabcut.pose_estimation_pytorch.data.postprocessor as postprocessing
+import deeplabcut.pose_estimation_pytorch.models as models
+import deeplabcut.pose_estimation_pytorch.runners as runners
+import deeplabcut.pose_estimation_pytorch.runners.shelving as shelving
+from deeplabcut.pose_estimation_pytorch.config import read_config_as_dict
+from deeplabcut.pose_estimation_pytorch.task import Task
+from deeplabcut.pose_estimation_pytorch.apis.analyze_videos import VideoIterator
+from deeplabcut.pose_tracking_pytorch import create_triplets_dataset
+
+
+def build_feature_extraction_runner(
+    loader: data.Loader,
+    snapshot_path: str | Path,
+    device: str,
+    batch_size: int = 1,
+) -> runners.PoseInferenceRunner:
+    """Builds a runner to extract backbone features for poses of individuals
+
+    Args:
+        loader: The loader for the model to use.
+        snapshot_path: The path of the snapshot to use.
+        device: The device on which to run pose estimation.
+        batch_size: The batch size to run pose estimation with.
+
+    Returns:
+        A PoseInferenceRunner that will return features for extracted pose.
+    """
+    num_features = loader.model_cfg["model"]["backbone_output_channels"]
+    num_bodyparts = len(loader.model_cfg["metadata"]["bodyparts"])
+    top_down = loader.pose_task != Task.BOTTOM_UP
+    rescale_mode = postprocessing.RescaleAndOffset.Mode.KEYPOINT
+    if top_down:
+        rescale_mode = postprocessing.RescaleAndOffset.Mode.KEYPOINT_TD
+
+    preprocessor = data.build_bottom_up_preprocessor(
+        loader.model_cfg["data"]["colormode"],
+        data.build_transforms(loader.model_cfg["data"]["inference"])
+    )
+    postprocessor = postprocessing.ComposePostprocessor(
+        [
+            postprocessing.PrepareBackboneFeatures(top_down=top_down),
+            postprocessing.ConcatenateOutputs(
+                keys_to_concatenate={
+                    "bodyparts": ("bodypart", "poses"),
+                    "features": ("backbone", "bodypart_features"),
+                },
+                empty_shapes={
+                    "bodyparts": (num_bodyparts, 3),
+                    "features": (num_bodyparts, num_features),
+                },
+                create_empty_outputs=True,
+            ),
+            postprocessing.RescaleAndOffset(["bodyparts"], rescale_mode),
+        ]
+    )
+
+    runner = runners.build_inference_runner(
+        task=loader.pose_task,
+        model=models.PoseModel.build(loader.model_cfg["model"]),
+        device=device,
+        snapshot_path=snapshot_path,
+        batch_size=batch_size,
+        preprocessor=preprocessor,
+        postprocessor=postprocessor,
+        load_weights_only=loader.model_cfg["runner"].get("load_weights_only", None),
+    )
+    assert isinstance(runner, runners.PoseInferenceRunner), (
+        f"Failed to build inference runner: got type {type(runner)}"
+    )
+
+    # Set the model to output backbone features
+    runner.model.output_features = True
+
+    return runner
+
+
+def extract_features_for_video(
+    runner: runners.PoseInferenceRunner,
+    video: VideoIterator,
+    shelf_writer: shelving.FeatureShelfWriter,
+    detector_runner: runners.DetectorInferenceRunner | None = None,
+) -> None:
+    """Extracts backbone features for predicted keypoints in a video.
+
+    Args:
+        video: The video for which to extract backbone features.
+        runner: The inference runner with which to extract backbone features.
+        shelf_writer: The ShelfWriter used to extract features.
+        detector_runner: For top-down models, the detector to use to predict bboxes.
+    """
+    if detector_runner is not None:
+        print(f"Running detector with batch size {detector_runner.batch_size}")
+        bbox_predictions = detector_runner.inference(images=tqdm(video))
+        video.set_context(bbox_predictions)
+
+    shelf_writer.open()
+    runner.inference(tqdm(video), shelf_writer=shelf_writer)
+    shelf_writer.close()
+
+
+def create_tracking_dataset(
+    config: str,
+    videos: list[str] | list[Path],
+    track_method: str,
+    videotype: str = "",
+    shuffle: int = 1,
+    trainingsetindex: int = 0,
+    destfolder: str | None = None,
+    batch_size: int | None = None,
+    detector_batch_size: int | None = None,
+    cropping: list[int] | None = None,
+    modelprefix: str = "",
+    robust_nframes: bool = False,
+    n_triplets: int = 1000,
+) -> str:
+    """Creates a tracking dataset to train a ReID tracklet stitcher.
+
+    Args:
+        config: Full path of the config.yaml file for the project
+        videos: A str (or list of strings) containing the full paths to videos from
+            which to create the tracking dataset or a path to the directory, where all
+            the videos with same extension are stored.
+        track_method: Specifies the tracker used to generate the pose estimation data.
+            Must be either 'box', 'skeleton', or 'ellipse'.
+        videotype: Checks for the extension of the video in case the input to the video
+            is a directory. Only videos with this extension are analyzed. If left
+            unspecified, keeps videos with extensions ('avi', 'mp4', 'mov', 'mpeg',
+            'mkv').
+        shuffle: An integer specifying the shuffle index of the training dataset used
+            for training the network.
+        trainingsetindex: Integer specifying which TrainingsetFraction to use.
+        destfolder: Specifies the destination folder for the tracking data. If ``None``,
+            the path of the video is used. Note that for subsequent analysis this
+            folder also needs to be passed.
+        batch_size: The batch size to use for inference. Takes the value from the
+            project config as a default.
+        detector_batch_size: The batch size to use for detector inference. Takes the
+            value from the project config as a default.
+        cropping: List of cropping coordinates as [x1, x2, y1, y2]. Note that the same
+            cropping parameters will then be used for all videos. If different video
+            crops are desired, run ``analyze_videos`` on individual videos with the
+            corresponding cropping coordinates.
+        modelprefix: Directory containing the deeplabcut models to use when evaluating
+            the network. By default, they are assumed to exist in the project folder.
+        robust_nframes: Evaluate a video's number of frames in a robust manner. This
+            option is slower (as the whole video is read frame-by-frame), but does not
+            rely on metadata, hence its robustness against file corruption.
+        n_triplets: The number of triplets to extract for the dataset.
+
+    Returns:
+        The scorer used to analyze the videos.
+    """
+    loader = data.DLCLoader(
+        config,
+        trainset_index=trainingsetindex,
+        shuffle=shuffle,
+        modelprefix=modelprefix,
+    )
+    if loader.pose_task == Task.TOP_DOWN:
+        raise ValueError(
+            "Currently, only bottom-up models can be used to train ReID trackers."
+        )
+
+    test_cfg_path = loader.model_folder.parent / "test" / "pose_cfg.yaml"
+    test_cfg = read_config_as_dict(test_cfg_path)
+
+    snapshot_index, detector_snapshot_index = utils.parse_snapshot_index_for_analysis(
+        loader.project_cfg, loader.model_cfg, None, None,
+    )
+    snapshot = utils.get_model_snapshots(
+        snapshot_index, loader.model_folder, loader.pose_task,
+    )[0]
+
+    if cropping is None and loader.project_cfg.get("cropping", False):
+        cropping = (
+            loader.project_cfg["x1"],
+            loader.project_cfg["x2"],
+            loader.project_cfg["y1"],
+            loader.project_cfg["y2"],
+        )
+
+    output_folder = None
+    if destfolder is not None and destfolder != "":
+        output_folder = Path(destfolder)
+
+    if batch_size is None:
+        batch_size = loader.project_cfg["batch_size"]
+
+    device = utils.resolve_device(loader.model_cfg)
+    runner = build_feature_extraction_runner(
+        loader, snapshot.path, device, batch_size=batch_size
+    )
+
+    detector_runner = None
+    detector_snapshot = None
+    if loader.pose_task == Task.TOP_DOWN:
+        if detector_batch_size is None:
+            detector_batch_size = loader.project_cfg.get("detector_batch_size", 1)
+
+        detector_snapshot = utils.get_model_snapshots(
+            detector_snapshot_index, loader.model_folder, Task.DETECT,
+        )[0]
+        detector_runner = utils.get_detector_inference_runner(
+            model_config=loader.model_cfg,
+            snapshot_path=detector_snapshot.path,
+            batch_size=detector_batch_size,
+            device=device,
+        )
+
+    dlc_scorer = utils.get_scorer_name(
+        loader.project_cfg,
+        shuffle,
+        loader.train_fraction,
+        snapshot_uid=utils.get_scorer_uid(snapshot, detector_snapshot),
+        modelprefix=modelprefix,
+    )
+
+    videos = utils.list_videos_in_folder(videos, videotype)
+    for video_path in videos:
+        print(f"Loading {video_path}")
+        video = VideoIterator(video_path, cropping=cropping)
+
+        nx, ny = video.dimensions
+        nframes = video.get_n_frames(robust=robust_nframes)
+        duration = video.calc_duration(robust=robust_nframes)
+        fps = video.fps
+        if robust_nframes:
+            fps = nframes / duration
+
+        print(f"Duration of video [s]: {duration:.2f}, recorded with {fps:.2f} fps!")
+        print(f"Overall # of frames: {nframes} found with (before cropping)")
+        print(f"Frame dimensions: {nx} x {ny}")
+
+        if output_folder is None:
+            output_folder = Path(video.video_path).parent
+        output_folder.mkdir(parents=True, exist_ok=True)
+        output_prefix = Path(video_path).stem + dlc_scorer
+        output_filepath = output_folder / f"{output_prefix}_bpt_features.pickle"
+
+        shelf_writer = shelving.FeatureShelfWriter(
+            test_cfg,
+            output_filepath,
+            num_frames=video.get_n_frames(robust=robust_nframes),
+        )
+        extract_features_for_video(
+            runner, video, shelf_writer, detector_runner=detector_runner
+        )
+
+    create_triplets_dataset(
+        videos,
+        dlc_scorer,
+        track_method,
+        n_triplets=n_triplets,
+        destfolder=destfolder,
+    )
+    return dlc_scorer

--- a/deeplabcut/pose_estimation_pytorch/data/postprocessor.py
+++ b/deeplabcut/pose_estimation_pytorch/data/postprocessor.py
@@ -133,7 +133,9 @@ def build_top_down_postprocessor(
         max_individuals: the maximum number of individuals in a single image
         num_bodyparts: the number of bodyparts output by the model
         num_unique_bodyparts: the number of unique_bodyparts output by the model
-        with_backbone_features:
+        with_backbone_features: When True, the backbone features are extracted from
+            the output and saved in a `features` key. The `PoseModel` must have its
+            `output_features` attribute set to True, or this will raise an Exception.
 
     Returns:
         A default top-down Postprocessor

--- a/deeplabcut/pose_estimation_pytorch/data/postprocessor.py
+++ b/deeplabcut/pose_estimation_pytorch/data/postprocessor.py
@@ -55,7 +55,9 @@ def build_bottom_up_postprocessor(
         num_bodyparts: the number of bodyparts output by the model
         num_unique_bodyparts: the number of unique_bodyparts output by the model
         with_identity: whether the model has an identity head
-        with_backbone_features:
+        with_backbone_features: When True, the backbone features are extracted from
+            the output and saved in a `features` key. The `PoseModel` must have its
+            `output_features` attribute set to True, or this will raise an Exception.
 
     Returns:
         A default bottom-up Postprocessor

--- a/deeplabcut/pose_estimation_pytorch/data/preprocessor.py
+++ b/deeplabcut/pose_estimation_pytorch/data/preprocessor.py
@@ -141,6 +141,8 @@ class LoadImage(Preprocessor):
         else:
             image_ = image
 
+        h, w = image_.shape[:2]
+        context["image_size"] = w, h
         return image_, context
 
 
@@ -347,4 +349,5 @@ class TopDownCrop(Preprocessor):
         else:
             images = np.stack(images, axis=0)
 
+        context["top_down_crop_size"] = self.output_size
         return images, context

--- a/deeplabcut/pose_estimation_pytorch/runners/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/inference.py
@@ -194,6 +194,7 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
                     bodyparts=image_predictions["bodyparts"],
                     unique_bodyparts=image_predictions.get("unique_bodyparts"),
                     identity_scores=image_predictions.get("identity_scores"),
+                    features=image_predictions.get("features"),
                 )
             else:
                 results.append(image_predictions)

--- a/deeplabcut/pose_tracking_pytorch/apis.py
+++ b/deeplabcut/pose_tracking_pytorch/apis.py
@@ -11,30 +11,30 @@
 
 
 def transformer_reID(
-    config,
-    videos,
-    videotype="",
-    shuffle=1,
-    trainingsetindex=0,
-    track_method="ellipse",
-    n_tracks=None,
-    n_triplets=1000,
-    train_epochs=100,
-    train_frac=0.8,
-    modelprefix="",
-    destfolder=None,
+    config: str,
+    videos: list[str],
+    videotype: str = "",
+    shuffle: int = 1,
+    trainingsetindex: int = 0,
+    track_method: str = "ellipse",
+    n_tracks: int | None = None,
+    n_triplets: int = 1000,
+    train_epochs: int = 100,
+    train_frac: float = 0.8,
+    modelprefix: str = "",
+    destfolder: str = None,
 ):
     """
     Enables tracking with transformer.
 
     Substeps include:
+        - Mines triplets from tracklets in videos (from another tracker)
+        - These triplets are later used to tran a transformer with triplet loss
+        - The transformer derived appearance similarity is then used as a stitching loss
+            when tracklets are stitched during tracking.
 
-    - Mines triplets from tracklets in videos (from another tracker)
-    - These triplets are later used to tran a transformer with triplet loss
-    - The transformer derived appearance similarity is then used as a stitching loss when tracklets are
-    stitched during tracking.
-
-    Outputs: The tracklet file is saved in the same folder where the non-transformer tracklet file is stored.
+    Outputs: The tracklet file is saved in the same folder where the non-transformer
+    tracklet file is stored.
 
     Parameters
     ----------
@@ -42,11 +42,14 @@ def transformer_reID(
         Full path of the config.yaml file as a string.
 
     videos: list
-        A list of strings containing the full paths to videos for analysis or a path to the directory, where all the videos with same extension are stored.
+        A list of strings containing the full paths to videos for analysis or a path to
+        the directory, where all the videos with same extension are stored.
 
     videotype: string, optional
-        Checks for the extension of the video in case the input to the video is a directory.\n Only videos with this extension are analyzed.
-        If left unspecified, videos with common extensions ('avi', 'mp4', 'mov', 'mpeg', 'mkv') are kept.
+        Checks for the extension of the video in case the input to the video is a
+        directory. Only videos with this extension are analyzed.
+        If left unspecified, videos with common extensions ('avi', 'mp4', 'mov', 'mpeg',
+        'mkv') are kept.
 
     shuffle : int, optional
         which shuffle to use
@@ -74,8 +77,15 @@ def transformer_reID(
     --------
 
     Training model for one video based on ellipse-tracker derived tracklets
-    >>> deeplabcut.transformer_reID(path_config_file,[''/home/alex/video.mp4'],track_method="ellipse")
-
+    >>> config = "/home/users/.../dlc-project-2025-01-01/config.yaml"
+    >>> videos = ['/home/alex/video.mp4']
+    >>> deeplabcut.transformer_reID(config, videos, shuffle=1, track_method="ellipse")
+    >>> deeplabcut.create_labeled_video(
+    >>>     config,
+    >>>     videos,
+    >>>     shuffle=1,
+    >>>     track_method="transformer",
+    >>> )
     --------
 
     """

--- a/deeplabcut/pose_tracking_pytorch/create_dataset.py
+++ b/deeplabcut/pose_tracking_pytorch/create_dataset.py
@@ -33,8 +33,7 @@ def save_train_triplets(feature_fname, triplets, out_name):
 
     feature_dict = shelve.open(feature_fname, protocol=pickle.DEFAULT_PROTOCOL)
 
-    nframes = len(feature_dict.keys())
-
+    nframes = max(len(feature_dict.keys()), 2)
     zfill_width = int(np.ceil(np.log10(nframes)))
 
     for triplet in triplets:

--- a/deeplabcut/pose_tracking_pytorch/tracking_utils/preprocessing.py
+++ b/deeplabcut/pose_tracking_pytorch/tracking_utils/preprocessing.py
@@ -58,6 +58,6 @@ def query_feature_by_coord_in_img_space(feature_dict, frame_id, ref_coord):
 
     diff = coordinates - ref_coord
     diff[np.where(np.logical_or(diff > 9000, diff < 0))] = np.nan
-    match_id = np.argmin(np.nanmean(diff, axis=(1, 2)))
-
+    masked_means = np.ma.masked_invalid(np.nanmean(diff, axis=(1, 2)))
+    match_id = np.argmin(masked_means)
     return features[match_id]

--- a/docs/pytorch/user_guide.md
+++ b/docs/pytorch/user_guide.md
@@ -1,5 +1,5 @@
 (dlc3-user-guide)=
-# DeepLabCut 3.0 - Pytorch User Guide
+# DeepLabCut 3.0 - PyTorch User Guide
 
 ## Using DeepLabCut 3.0
 
@@ -24,6 +24,7 @@ set `engine: tensorflow`.
 During the alpha phase, you can use the `yaml` we provide, or create a new `env`. 
 - If you are a beginner user, [please see these docs!](https://deeplabcut.github.io/DeepLabCut/docs/beginner-guides/beginners-guide.html)
 - If you are an advanced user, here is a quick start. [“Install PyTorch”](https://pytorch.org/get-started/locally/), then:
+
 ```
 conda install -c conda-forge pytables==3.8.0
 pip install git+https://github.com/DeepLabCut/DeepLabCut.git@pytorch_dlc#egg=deeplabcut[gui,modelzoo,wandb]
@@ -81,7 +82,7 @@ parameters are not valid for the DLC 3.0 PyTorch API.
 | `evaluate_network`             |     🟢      |                                                                                                     |                                                     |
 | `return_evaluate_network_data` |     🔴      |                                                                                                     | `TFGPUinference`, `allow_growth`                    |
 | `analyze_videos`               |     🟠      | `greedy`, `calibrate`, `window_size`                                                                |                                                     |
-| `create_tracking_dataset`      |     🔴      |                                                                                                     |                                                     |
+| `create_tracking_dataset`      |     🟢      |                                                                                                     |                                                     |
 | `analyze_time_lapse_frames`    |     🟢      | the name has changed to  `analyze_images` to better reflect what it actually does (no video needed) |                                                     |
 | `convert_detections2tracklets` |     🟠      | `greedy`, `calibrate`, `window_size`                                                                |                                                     |
 | `extract_maps`                 |     🟢      |                                                                                                     |                                                     |

--- a/tests/pose_estimation_pytorch/apis/test_create_tracking_dataset.py
+++ b/tests/pose_estimation_pytorch/apis/test_create_tracking_dataset.py
@@ -1,0 +1,72 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Tests method to create the tracking dataset in PyTorch"""
+from pathlib import Path
+
+import torch
+
+import deeplabcut.pose_estimation_pytorch as dlc_torch
+import deeplabcut.pose_estimation_pytorch.apis.tracking_dataset as tracking_dataset
+import deeplabcut.pose_estimation_pytorch.models as models
+
+
+class MockLoader(dlc_torch.Loader):
+    """Mock loader for data"""
+
+    def __init__(self, tmp_folder: Path, bodyparts: list[str] | None = None):
+        if bodyparts is None:
+            bodyparts = ["nose", "left_eye", "right_eye", "tail_base"]
+        self.bodyparts = bodyparts
+
+        model_config_path = tmp_folder / "pytorch_config.yaml"
+        dlc_torch.config.make_pytorch_pose_config(
+            project_config=dlc_torch.config.make_basic_project_config(
+                dataset_path=str(tmp_folder),
+                bodyparts=self.bodyparts,
+                max_individuals=3,
+            ),
+            pose_config_path=tmp_folder / "pytorch_config.yaml",
+            net_type="resnet_50",
+            save=True,
+        )
+        super().__init__(model_config_path)
+
+    def load_data(self, mode: str = "train") -> dict[str, list[dict]]:
+        return {
+            "annotations": [],
+            "categories": [],
+            "images": [],
+        }
+
+    def get_dataset_parameters(self) -> dlc_torch.PoseDatasetParameters:
+        return dlc_torch.PoseDatasetParameters(
+            bodyparts=self.bodyparts,
+            unique_bpts=[],
+            individuals=self.model_cfg["metadata"]["individuals"],
+        )
+
+
+def test_build_feature_extraction_runner(tmp_path_factory):
+    tmp_folder = Path(tmp_path_factory.mktemp("tmp-project"))
+
+    loader = MockLoader(tmp_folder=tmp_folder)
+    model = models.PoseModel.build(loader.model_cfg["model"])
+    snapshot_path = loader.model_folder / "snapshot.pt"
+    torch.save(dict(model=model.state_dict()), snapshot_path)
+    _ = tracking_dataset.build_feature_extraction_runner(
+        loader=loader,
+        snapshot_path=snapshot_path,
+        device="cpu",
+        batch_size=1,
+    )
+
+
+


### PR DESCRIPTION
Implements the creation of ReID transformer dataset creation for PyTorch pose estimation models.

- implements `deeplabcut.create_tracking_dataset` for PyTorch models
  - Closes #2794
  - Closes #2809
  - Creates a `FeatureShelfWriter` to save ReID features

Other changes

- removes the `dynamic` parameter from `deeplabcut.create_tracking_dataset` as it cannot be used there
- adds a docstring for `deeplabcut.create_tracking_dataset`
- correctly pulls the `pcutoff` from the inference config when creating assemblies in `convert_detections2tracklets`
- adds an `image_size` key to the context when running inference, and a `top_down_crop_size` for top-down models
