### PR TITLE
Pin TensorFlow according to OS; Fix DeepLabCut install in Colab to deal with new requirements.

### DIFF
--- a/examples/COLAB/COLAB_3miceDemo.ipynb
+++ b/examples/COLAB/COLAB_3miceDemo.ipynb
@@ -32,7 +32,9 @@
     "- a quick guide to maDLC: https://deeplabcut.github.io/DeepLabCut/docs/tutorial.html\n",
     "- a demo COLAB for how to use maDLC on your own data: https://github.com/DeepLabCut/DeepLabCut/blob/main/examples/COLAB/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb\n",
     "\n",
-    "### To get started, please go to \"Runtime\" ->\"change runtime type\"->select \"Python3\", and then select \"GPU\"\n"
+    "### To get started, please go to \"Runtime\" ->\"change runtime type\"->select \"Python3\", and then select \"GPU\"\n",
+    "\n",
+    "As the COLAB environments were updated to CUDA 12.X and Python 3.11, we need to install DeepLabCut and TensorFlow in a distinct way to get TensorFlow to connect to the GPU."
    ]
   },
   {
@@ -43,11 +45,49 @@
    },
    "outputs": [],
    "source": [
-    "# Installs a CUDA version compatible with tensorflow on COLAB\n",
-    "!apt update && apt install cuda-11-8\n",
+    "# Install TensorFlow, tensorpack and tf_slim versions compatible with DeepLabCut\n",
+    "!pip install \"tensorflow==2.12.1\" \"tensorpack>=0.11\" \"tf_slim>=1.1.0\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Downgrade PyTorch to a version using CUDA 11.8 and cudnn 8\n",
+    "# This will also install the required CUDA libraries, for both PyTorch and TensorFlow\n",
+    "!pip install torch==2.3.1 torchvision --index-url https://download.pytorch.org/whl/cu118"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install the latest version of DeepLabCut\n",
+    "!pip install \"git+https://github.com/DeepLabCut/DeepLabCut.git\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# As described in https://www.tensorflow.org/install/pip#step-by-step_instructions, \n",
+    "# create symbolic links to NVIDIA shared libraries:\n",
+    "!ln -svf /usr/local/lib/python3.11/dist-packages/nvidia/*/lib/*.so* /usr/local/lib/python3.11/dist-packages/tensorflow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Important - Restart the Runtime for the updated packages to be imported!\n",
     "\n",
-    "# Install the latest DeepLabCut version:\n",
-    "!pip install \"deeplabcut[tf]\""
+    "PLEASE, click \"restart runtime\" from the output above before proceeding!"
    ]
   },
   {

--- a/examples/COLAB/COLAB_DEMO_SuperAnimal.ipynb
+++ b/examples/COLAB/COLAB_DEMO_SuperAnimal.ipynb
@@ -43,19 +43,51 @@
         "\n",
         "## **Let's get going: install DeepLabCut into COLAB:**\n",
         "\n",
-        "*Also, be sure you are connected to a GPU: go to menu, click Runtime > Change Runtime Type > select \"GPU\"*\n"
+        "*Also, be sure you are connected to a GPU: go to menu, click Runtime > Change Runtime Type > select \"GPU\"*\n",
+        "\n",
+        "As the COLAB environments were updated to CUDA 12.X and Python 3.11, we need to install DeepLabCut and TensorFlow in a distinct way to get TensorFlow to connect to the GPU.\n"
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "03ylSyQ4O9Ee"
-      },
+      "metadata": {},
       "outputs": [],
       "source": [
-        "!apt update && apt install cuda-11-8\n",
-        "!pip install deeplabcut[tf,modelzoo]"
+        "# Cell 1 - Install TensorFlow, tensorpack and tf_slim versions compatible with DeepLabCut\n",
+        "!pip install \"tensorflow==2.12.1\" \"tensorpack>=0.11\" \"tf_slim>=1.1.0\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Downgrade PyTorch to a version using CUDA 11.8 and cudnn 8\n",
+        "# This will also install the required CUDA libraries, for both PyTorch and TensorFlow\n",
+        "!pip install torch==2.3.1 torchvision --index-url https://download.pytorch.org/whl/cu118"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Install the latest version of DeepLabCut\n",
+        "!pip install \"git+https://github.com/DeepLabCut/DeepLabCut.git[modelzoo]\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# As described in https://www.tensorflow.org/install/pip#step-by-step_instructions, \n",
+        "# create symbolic links to NVIDIA shared libraries:\n",
+        "!ln -svf /usr/local/lib/python3.11/dist-packages/nvidia/*/lib/*.so* /usr/local/lib/python3.11/dist-packages/tensorflow"
       ]
     },
     {

--- a/examples/COLAB/COLAB_DEMO_SuperAnimal.ipynb
+++ b/examples/COLAB/COLAB_DEMO_SuperAnimal.ipynb
@@ -76,7 +76,7 @@
       "outputs": [],
       "source": [
         "# Install the latest version of DeepLabCut\n",
-        "!pip install \"git+https://github.com/DeepLabCut/DeepLabCut.git[modelzoo]\""
+        "!pip install \"git+https://github.com/DeepLabCut/DeepLabCut.git#egg=deeplabcut[modelzoo]\""
       ]
     },
     {

--- a/examples/COLAB/COLAB_DEMO_mouse_openfield.ipynb
+++ b/examples/COLAB/COLAB_DEMO_mouse_openfield.ipynb
@@ -42,7 +42,9 @@
     "id": "txoddlM8hLKm"
    },
    "source": [
-    "## First, go to \"Runtime\" ->\"change runtime type\"->select \"Python3\", and then select \"GPU\""
+    "## First, go to \"Runtime\" ->\"change runtime type\"->select \"Python3\", and then select \"GPU\"\n",
+    "\n",
+    "As the COLAB environments were updated to CUDA 12.X and Python 3.11, we need to install DeepLabCut and TensorFlow in a distinct way to get TensorFlow to connect to the GPU."
    ]
   },
   {
@@ -51,8 +53,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Installs a CUDA version compatible with tensorflow on COLAB\n",
-    "!apt update && apt install cuda-11-8"
+    "# Install TensorFlow, tensorpack and tf_slim versions compatible with DeepLabCut\n",
+    "!pip install \"tensorflow==2.12.1\" \"tensorpack>=0.11\" \"tf_slim>=1.1.0\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Downgrade PyTorch to a version using CUDA 11.8 and cudnn 8\n",
+    "# This will also install the required CUDA libraries, for both PyTorch and TensorFlow\n",
+    "!pip install torch==2.3.1 torchvision --index-url https://download.pytorch.org/whl/cu118"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# As described in https://www.tensorflow.org/install/pip#step-by-step_instructions, \n",
+    "# create symbolic links to NVIDIA shared libraries:\n",
+    "!ln -svf /usr/local/lib/python3.11/dist-packages/nvidia/*/lib/*.so* /usr/local/lib/python3.11/dist-packages/tensorflow"
    ]
   },
   {
@@ -91,7 +115,7 @@
    "source": [
     "# Install the latest DeepLabCut version (this will take a few minutes to install all the dependencies!)\n",
     "%cd /content/cloned-DLC-repo/\n",
-    "!pip install \".[tf]\""
+    "!pip install \".\""
    ]
   },
   {

--- a/examples/COLAB/COLAB_DLC_ModelZoo.ipynb
+++ b/examples/COLAB/COLAB_DLC_ModelZoo.ipynb
@@ -78,7 +78,7 @@
       "outputs": [],
       "source": [
         "# Install the latest version of DeepLabCut\n",
-        "!pip install \"git+https://github.com/DeepLabCut/DeepLabCut.git[modelzoo]\""
+        "!pip install \"git+https://github.com/DeepLabCut/DeepLabCut.git#egg=deeplabcut[modelzoo]\""
       ]
     },
     {

--- a/examples/COLAB/COLAB_DLC_ModelZoo.ipynb
+++ b/examples/COLAB/COLAB_DLC_ModelZoo.ipynb
@@ -45,29 +45,60 @@
         "\n",
         "## **Let's get going: install DeepLabCut into COLAB:**\n",
         "\n",
-        "*Also, be sure you are connected to a GPU: go to menu, click Runtime > Change Runtime Type > select \"GPU\"*"
+        "*Also, be sure you are connected to a GPU: go to menu, click Runtime > Change Runtime Type > select \"GPU\"*\n",
+        "\n",
+        "As the COLAB environments were updated to CUDA 12.X and Python 3.11, we need to install DeepLabCut and TensorFlow in a distinct way to get TensorFlow to connect to the GPU."
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "q23BzhA6CXxu"
-      },
+      "metadata": {},
       "outputs": [],
       "source": [
-        "#click the play icon (this will take a few minutes to install all the dependencies!)\n",
-        "!apt update && apt install cuda-11-8\n",
-        "!pip install deeplabcut[tf,modelzoo]"
+        "# Install TensorFlow, tensorpack and tf_slim versions compatible with DeepLabCut\n",
+        "!pip install \"tensorflow==2.12.1\" \"tensorpack>=0.11\" \"tf_slim>=1.1.0\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Downgrade PyTorch to a version using CUDA 11.8 and cudnn 8\n",
+        "# This will also install the required CUDA libraries, for both PyTorch and TensorFlow\n",
+        "!pip install torch==2.3.1 torchvision --index-url https://download.pytorch.org/whl/cu118"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Install the latest version of DeepLabCut\n",
+        "!pip install \"git+https://github.com/DeepLabCut/DeepLabCut.git[modelzoo]\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# As described in https://www.tensorflow.org/install/pip#step-by-step_instructions, \n",
+        "# create symbolic links to NVIDIA shared libraries:\n",
+        "!ln -svf /usr/local/lib/python3.11/dist-packages/nvidia/*/lib/*.so* /usr/local/lib/python3.11/dist-packages/tensorflow"
       ]
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "zYm6DljQB0Y7"
-      },
+      "metadata": {},
       "source": [
-        "###proTip: be sure to click \"restart runtime button\" if it appears above ^"
+        "### Important - Restart the Runtime for the updated packages to be imported!\n",
+        "\n",
+        "PLEASE, click \"restart runtime\" from the output above before proceeding!"
       ]
     },
     {

--- a/examples/COLAB/COLAB_YOURDATA_TrainNetwork_VideoAnalysis.ipynb
+++ b/examples/COLAB/COLAB_YOURDATA_TrainNetwork_VideoAnalysis.ipynb
@@ -48,22 +48,51 @@
     "id": "txoddlM8hLKm"
    },
    "source": [
-    "## First, go to \"Runtime\" ->\"change runtime type\"->select \"Python3\", and then select \"GPU\"\n"
+    "## First, go to \"Runtime\" ->\"change runtime type\"->select \"Python3\", and then select \"GPU\"\n",
+    "\n",
+    "As the COLAB environments were updated to CUDA 12.X and Python 3.11, we need to install DeepLabCut and TensorFlow in a distinct way to get TensorFlow to connect to the GPU."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "colab": {},
-    "colab_type": "code",
-    "id": "q23BzhA6CXxu"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "#(this will take a few minutes to install all the dependences!)\n",
-    "!apt update && apt install cuda-11-8\n",
-    "!pip install \"deeplabcut[tf]\""
+    "# Install TensorFlow, tensorpack and tf_slim versions compatible with DeepLabCut\n",
+    "!pip install \"tensorflow==2.12.1\" \"tensorpack>=0.11\" \"tf_slim>=1.1.0\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Downgrade PyTorch to a version using CUDA 11.8 and cudnn 8\n",
+    "# This will also install the required CUDA libraries, for both PyTorch and TensorFlow\n",
+    "!pip install torch==2.3.1 torchvision --index-url https://download.pytorch.org/whl/cu118"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install the latest version of DeepLabCut\n",
+    "!pip install \"git+https://github.com/DeepLabCut/DeepLabCut.git\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# As described in https://www.tensorflow.org/install/pip#step-by-step_instructions, \n",
+    "# create symbolic links to NVIDIA shared libraries:\n",
+    "!ln -svf /usr/local/lib/python3.11/dist-packages/nvidia/*/lib/*.so* /usr/local/lib/python3.11/dist-packages/tensorflow"
    ]
   },
   {

--- a/examples/COLAB/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb
+++ b/examples/COLAB/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb
@@ -46,36 +46,51 @@
     "id": "txoddlM8hLKm"
    },
    "source": [
-    "## First, go to \"Runtime\" ->\"change runtime type\"->select \"Python3\", and then select \"GPU\"\n"
+    "## First, go to \"Runtime\" ->\"change runtime type\"->select \"Python3\", and then select \"GPU\"\n",
+    "\n",
+    "As the COLAB environments were updated to CUDA 12.X and Python 3.11, we need to install DeepLabCut and TensorFlow in a distinct way to get TensorFlow to connect to the GPU."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "q23BzhA6CXxu"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "#(this will take a few minutes to install all the dependences!)\n",
-    "!apt update && apt install cuda-11-8\n",
-    "!pip install \"deeplabcut[tf]\"\n",
-    "%reload_ext numpy\n",
-    "%reload_ext scipy\n",
-    "%reload_ext matplotlib\n",
-    "%reload_ext mpl_toolkits"
+    "# Install TensorFlow, tensorpack and tf_slim versions compatible with DeepLabCut\n",
+    "!pip install \"tensorflow==2.12.1\" \"tensorpack>=0.11\" \"tf_slim>=1.1.0\""
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "-MVvZ13_FMvP"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "#a few colab specific things needed:\n",
-    "!pip install --upgrade scikit-image"
+    "# Downgrade PyTorch to a version using CUDA 11.8 and cudnn 8\n",
+    "# This will also install the required CUDA libraries, for both PyTorch and TensorFlow\n",
+    "!pip install torch==2.3.1 torchvision --index-url https://download.pytorch.org/whl/cu118"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install the latest version of DeepLabCut\n",
+    "!pip install \"git+https://github.com/DeepLabCut/DeepLabCut.git\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# As described in https://www.tensorflow.org/install/pip#step-by-step_instructions, \n",
+    "# create symbolic links to NVIDIA shared libraries:\n",
+    "!ln -svf /usr/local/lib/python3.11/dist-packages/nvidia/*/lib/*.so* /usr/local/lib/python3.11/dist-packages/tensorflow"
    ]
   },
   {

--- a/examples/COLAB/COLAB_transformer_reID.ipynb
+++ b/examples/COLAB/COLAB_transformer_reID.ipynb
@@ -32,20 +32,51 @@
     "- a quick guide to maDLC: https://deeplabcut.github.io/DeepLabCut/docs/tutorial.html\n",
     "- a demo COLAB for how to use maDLC on your own data: https://github.com/DeepLabCut/DeepLabCut/blob/main/examples/COLAB/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb\n",
     "\n",
-    "### To get started, please go to \"Runtime\" ->\"change runtime type\"->select \"Python3\", and then select \"GPU\"\n"
+    "### To get started, please go to \"Runtime\" ->\"change runtime type\"->select \"Python3\", and then select \"GPU\"\n",
+    "\n",
+    "As the COLAB environments were updated to CUDA 12.X and Python 3.11, we need to install DeepLabCut and TensorFlow in a distinct way to get TensorFlow to connect to the GPU."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "HoNN2_0Z9rr_"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "# Install the latest DeepLabCut version:\n",
-    "!apt update && apt install cuda-11-8\n",
-    "!pip install \"deeplabcut[tf]\""
+    "# Install TensorFlow, tensorpack and tf_slim versions compatible with DeepLabCut\n",
+    "!pip install \"tensorflow==2.12.1\" \"tensorpack>=0.11\" \"tf_slim>=1.1.0\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Downgrade PyTorch to a version using CUDA 11.8 and cudnn 8\n",
+    "# This will also install the required CUDA libraries, for both PyTorch and TensorFlow\n",
+    "!pip install torch==2.3.1 torchvision --index-url https://download.pytorch.org/whl/cu118"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install the latest version of DeepLabCut\n",
+    "!pip install \"git+https://github.com/DeepLabCut/DeepLabCut.git\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# As described in https://www.tensorflow.org/install/pip#step-by-step_instructions, \n",
+    "# create symbolic links to NVIDIA shared libraries:\n",
+    "!ln -svf /usr/local/lib/python3.11/dist-packages/nvidia/*/lib/*.so* /usr/local/lib/python3.11/dist-packages/tensorflow"
    ]
   },
   {

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ setuptools.setup(
         "openvino": ["openvino-dev==2022.1.0"],
         "docs": ["numpydoc"],
         "tf": [
-            "tensorflow>=2.0,<=2.10",
+            "tensorflow>=2.0,<=2.10;platform_system=='Windows'",
+            "tensorflow>=2.0,<=2.12;platform_system!='Windows'",
             "tensorpack>=0.11",
             "tf_slim>=1.1.0",
         ],  # Last supported TF version on Windows Native is 2.10


### PR DESCRIPTION
This pull request sets the TensorFlow pin to version `2.10` for windows, and version `<=2.12` for other OSs. It also updates the installation method for DeepLabCut in COLAB notebooks, to match current requirements. The updated install is faster than the old install. To `TensorFlow 2.12` working with the GPU in COLAB, one needs to run (in this order):

```bash
# Cell 1 - Install the desired TensorFlow version, built for CUDA 11.8 and cudnn 8
!pip install "tensorflow==2.12.1" "tensorpack>=0.11" "tf_slim>=1.1.0"

# Cell 2 - Downgrade PyTorch to a version using CUDA 11.8 and cudnn 8
#   This should also install the required CUDA libraries, for both PyTorch and TensorFlow
!pip install torch==2.3.1 torchvision --index-url https://download.pytorch.org/whl/cu118

# Cell 3
# As described in https://www.tensorflow.org/install/pip#step-by-step_instructions:
# Create symbolic links to NVIDIA shared libraries
!ln -svf /usr/local/lib/python3.11/dist-packages/nvidia/*/lib/*.so* /usr/local/lib/python3.11/dist-packages/tensorflow
```

Then DeepLabCut can be installed with the desired version (e.g. `pip install deeplabcut` or `pip install "git+https://github.com/DeepLabCut/DeepLabCut.git`)

Closes #2839 