### PR TITLE
fix broken `train_network` argument `display_iters` in the GUI

### DIFF
--- a/deeplabcut/gui/tabs/train_network.py
+++ b/deeplabcut/gui/tabs/train_network.py
@@ -320,7 +320,7 @@ def get_train_attributes(engine: Engine) -> list[TrainAttributeRow]:
                 attributes=[
                     IntTrainAttribute(
                         label="Display iterations",
-                        fn_key="display_iters",
+                        fn_key="displayiters",
                         default=1_000,
                         min=1,
                         max=100_000,


### PR DESCRIPTION
Fixes the `displayiters` parameter when `train_network` is called from the GUI.