### PR TITLE
fix evaluation for ma models, following change in 'deeplabcut/core/metrics/api.py'

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/apis/evaluate.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/evaluate.py
@@ -189,6 +189,7 @@ def evaluate(
         unique_bodypart_poses=unique_poses,
         unique_bodypart_gt=gt_unique_keypoints,
         per_keypoint_rmse=per_keypoint_evaluation,
+        compute_detection_rmse=False,
     )
 
     if loader.model_cfg["metadata"]["with_identity"]:


### PR DESCRIPTION
This is a supplemental fix for Commit 40465e1 "fix - evaluation during training for ma models".

Following the principles of the previous fix, this minor change passed "compute_detection_rmse" argument to "compute_metrics()". To me, this fixed the assertion error in my multi-animal project which was comparable to what caused the 40465e1 fix.

