### PR TITLE
Fix video addition in VideoSelectionWidget

### DIFF
--- a/deeplabcut/gui/components.py
+++ b/deeplabcut/gui/components.py
@@ -117,7 +117,7 @@ class VideoSelectionWidget(QtWidgets.QWidget):
         # Select videos
         self.select_video_button = QtWidgets.QPushButton("Select videos")
         self.select_video_button.setMaximumWidth(200)
-        self.select_video_button.clicked.connect(self.select_videos)
+        self.select_video_button.clicked.connect(self.update_videos)
         self.root.video_files_.connect(self._update_video_selection)
 
         # Number of selected videos text
@@ -153,7 +153,7 @@ class VideoSelectionWidget(QtWidgets.QWidget):
             self.selected_videos_text.setText("")
             self.select_video_button.setText("Select videos")
 
-    def select_videos(self):
+    def update_videos(self):
         cwd = self.root.project_folder
 
         # Create a filter string with both lowercase and uppercase extensions
@@ -172,10 +172,10 @@ class VideoSelectionWidget(QtWidgets.QWidget):
 
         if filenames[0]:
             # Qt returns a tuple (list of files, filetype)
-            self.root.video_files = [os.path.abspath(vid) for vid in filenames[0]]
+            self.root.add_video_files([os.path.abspath(vid) for vid in filenames[0]])
 
     def clear_selected_videos(self):
-        self.root.video_files = set()
+        self.root.clear_video_files()
         self.root.logger.info(f"Cleared selected videos")
 
 

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -223,11 +223,23 @@ class MainWindow(QMainWindow):
     def video_files(self):
         return self.files
 
-    @video_files.setter
-    def video_files(self, video_files):
-        self.files = set(video_files)
-        self.video_files_.emit(self.files)
-        self.logger.info(f"Videos selected to analyze:\n{self.files}")
+    def add_video_files(self, new_video_files):
+        """
+        Add new video files to the existing set of files. This method ensures no duplicates are added.
+        Emits a signal to notify about the updated set of files.
+        """
+        new_video_files = set(new_video_files)
+        self.files.update(new_video_files) # Add new items to the existing set
+        self.video_files_.emit(self.files) # Emit the updated set of files
+        self.logger.info(f"Videos added to analyze:\n{new_video_files}\nCurrent video files:\n{self.files}")
+
+    def clear_video_files(self):
+        """
+        Clear all video files from the existing set. Emits a signal to notify the change.
+        """
+        self.files.clear()  # Reset the set to be empty
+        self.video_files_.emit(self.files)  # Emit the empty set
+        self.logger.info("All video files have been cleared.")
 
     def window_set(self):
         self.setWindowTitle("DeepLabCut")


### PR DESCRIPTION
[This topic](https://forum.image.sc/t/k-means-labeling-network-selection-and-more-q3-selecting-additional-videos-for-analysis/107888/5) reports a bug with the `select_video_button` ("Select videos" / "Add more videos" button) in the `VideoSelectionWidget` (present in the Analyze videos and Create labeled videos tabs): the button always overwrites the selected videos, instead of adding new videos (as the text of the button suggests).

This PR solves this bug.