### PR TITLE
Fix assert in compute_detection_rmse()

### DIFF
--- a/deeplabcut/core/metrics/distance_metrics.py
+++ b/deeplabcut/core/metrics/distance_metrics.py
@@ -363,14 +363,15 @@ def compute_detection_rmse(
 
     if data_unique is not None:
         for image_gt, image_pred in data_unique:
-            assert len(image_gt) == len(image_pred) == 1, (
-                f"Unique GT an predictions must have length 1! Found {image_gt.shape}, "
+            assert len(image_gt) <= 1 and len(image_pred) <= 1, (
+                f"Unique GT an predictions must have length 0 or 1! Found {image_gt.shape}, "
                 f"{image_pred.shape}."
             )
-            unique_gt, unique_pred = image_gt[0], image_pred[0]
-            for gt, pred in zip(unique_gt, unique_pred):
-                distances.append(np.linalg.norm(gt[:2] - pred[:2]))
-                scores.append(pred[2])
+            if len(image_gt) == 1 and len(image_pred) == 1:
+                unique_gt, unique_pred = image_gt[0], image_pred[0]
+                for gt, pred in zip(unique_gt, unique_pred):
+                    distances.append(np.linalg.norm(gt[:2] - pred[:2]))
+                    scores.append(pred[2])
 
     rmse, rmse_cutoff = float("nan"), float("nan")
     if len(distances) == 0:


### PR DESCRIPTION
Bug reported by a [post](https://forum.image.sc/t/deeplabcut-colab-installation-issues/107559/15) on the forum:

[This assertion](https://github.com/DeepLabCut/DeepLabCut/blob/5b6c22a89a9115203d277d9c570ed5c7ad750888/deeplabcut/core/metrics/distance_metrics.py#L366) is too restrictive, since the unique bodyparts might be missing in the ground truth annotations. 

This PR fixes this and adds a test for this case.