### PR TITLE
Rename CLI command to dlc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     entry_points="""[console_scripts]
-            deeplabcut=deeplabcut.__main__:main""",
+            dlc=deeplabcut.__main__:main""",
 )
 
 # https://www.python.org/dev/peps/pep-0440/#compatible-release


### PR DESCRIPTION
Following https://github.com/DeepLabCut/DeepLabCut/pull/2883:

Rename CLI command back from `deeplabcut` to `dlc`