### PR TITLE
Set pcutoff per-bodypart when evaluating PyTorch models

### DIFF
--- a/deeplabcut/compat.py
+++ b/deeplabcut/compat.py
@@ -386,6 +386,7 @@ def evaluate_network(
     modelprefix: str = "",
     per_keypoint_evaluation: bool = False,
     snapshots_to_evaluate: list[str] | None = None,
+    pcutoff: float | list[float] | dict[str, float] | None = None,
     engine: Engine | None = None,
     **torch_kwargs,
 ):
@@ -448,6 +449,16 @@ def evaluate_network(
 
     snapshots_to_evaluate: List[str], optional, default=None
         List of snapshot names to evaluate (e.g. ["snapshot-5000", "snapshot-7500"]).
+
+    pcutoff: float | list[float] | dict[str, float] | None, default=None
+        Only for the PyTorch engine. For the TensorFlow engine, please set the pcutoff
+        in the `config.yaml` file.
+        The cutoff to use for computing evaluation metrics. When `None` (default), the
+        cutoff will be loaded from the project config. If a list is provided, there
+        should be one value for each bodypart and one value for each unique bodypart
+        (if there are any). If a dict is provided, the keys should be bodyparts
+        mapping to pcutoff values for each bodypart. Bodyparts that are not defined
+        in the dict will have pcutoff set to 0.6.
 
     engine: Engine, optional, default = None.
         The default behavior loads the engine for the shuffle from the metadata. You can
@@ -543,6 +554,7 @@ def evaluate_network(
             comparison_bodyparts=comparisonbodyparts,
             per_keypoint_evaluation=per_keypoint_evaluation,
             modelprefix=modelprefix,
+            pcutoff=pcutoff,
             **torch_kwargs,
         )
 

--- a/deeplabcut/compat.py
+++ b/deeplabcut/compat.py
@@ -501,6 +501,16 @@ def evaluate_network(
             plotting="individual",
         )
 
+    If you have a PyTorch model for which you want to set a different p-cutoff for
+    "left_ear" and "right_ear" bodyparts, and keep the one set in the project config
+    for other bodyparts:
+
+    >>> deeplabcut.evaluate_network(
+    >>>     "/analysis/project/reaching-task/config.yaml",
+    >>>     Shuffles=[0, 1],
+    >>>     pcutoff={"left_ear": 0.8, "right_ear": 0.8},
+    >>> )
+
     Note: This defaults to standard plotting for single-animal projects.
     """
     if engine is None:

--- a/deeplabcut/core/metrics/distance_metrics.py
+++ b/deeplabcut/core/metrics/distance_metrics.py
@@ -222,7 +222,7 @@ def match_predictions_for_rmse(
 def compute_rmse(
     data: list[tuple[np.ndarray, np.ndarray]],
     single_animal: bool,
-    pcutoff: float,
+    pcutoff: float | list[float],
     data_unique: list[tuple[np.ndarray, np.ndarray]] | None = None,
     per_keypoint_results: bool = False,
     oks_bbox_margin: float = 0.0,
@@ -245,7 +245,9 @@ def compute_rmse(
             num_bpts, 3). For the GT, the 3 coordinates are (x, y, visibility) while for
             the pose they are (x, y, confidence score).
         single_animal: Whether this is a single animal dataset.
-        pcutoff: The p-cutoff to use to compute RMSE.
+        pcutoff: The p-cutoff to use to compute RMSE. If a list, the cutoff for each
+            bodypart is set individually. The list must have length num_bodyparts +
+            num_unique_bodyparts.
         data_unique: Unique bodypart ground truth and predictions to include in RMSE
             computations, if there are any such bodyparts.
         per_keypoint_results: Whether to compute the RMSE for each individual keypoint.
@@ -272,8 +274,12 @@ def compute_rmse(
 
     error, support, cutoff_error, cutoff_support = 0, 0, 0, 0
     if pixel_errors is not None:
+        bpt_cutoffs = pcutoff
+        if not isinstance(pcutoff, float):
+            bpt_cutoffs = pcutoff[:pixel_errors.shape[1]]
+
         error, support, cutoff_error, cutoff_support = collect_pixel_errors(
-            pixel_errors, keypoint_scores, pcutoff,
+            pixel_errors, keypoint_scores, bpt_cutoffs,
         )
 
     unique_pixel_errors, unique_keypoint_scores = None, None
@@ -283,8 +289,11 @@ def compute_rmse(
             unique_pixel_errors = np.stack([m.pixel_errors() for m in u_matches])
             unique_keypoint_scores = np.stack([m.keypoint_scores() for m in u_matches])
 
+            bpt_cutoffs = pcutoff
+            if not isinstance(pcutoff, float):
+                bpt_cutoffs = pcutoff[-unique_pixel_errors.shape[1]:]
             u_error, u_support, u_cutoff_error, u_cutoff_support = collect_pixel_errors(
-                unique_pixel_errors, unique_keypoint_scores, pcutoff,
+                unique_pixel_errors, unique_keypoint_scores, bpt_cutoffs,
             )
             error += u_error
             support += u_support
@@ -314,7 +323,7 @@ def compute_rmse(
 
 def compute_detection_rmse(
     data: list[tuple[np.ndarray, np.ndarray]],
-    pcutoff: float,
+    pcutoff: float | list[float],
     data_unique: list[tuple[np.ndarray, np.ndarray]] | None = None,
 ) -> tuple[float, float]:
     """Computes the detection RMSE for pose predictions.
@@ -331,7 +340,9 @@ def compute_detection_rmse(
             num_bpts, 3) and predicted_poses is an array of shape (num_predictions,
             num_bpts, 3). For the GT, the 3 coordinates are (x, y, visibility) while for
             the pose they are (x, y, confidence score).
-        pcutoff: The p-cutoff to use to compute RMSE.
+        pcutoff: The p-cutoff to use to compute RMSE. If a list, the cutoff for each
+            bodypart is set individually. The list must have length num_bodyparts +
+            num_unique_bodyparts.
         data_unique: Unique bodypart ground truth and predictions to include in RMSE
             computations, if there are any such bodyparts.
 
@@ -340,7 +351,7 @@ def compute_detection_rmse(
         score below the pcutoff.
     """
     distances = []
-    scores = []
+    distances_cutoff = []
     for image_gt, image_pred in data:
         image_gt = image_gt.transpose((1, 0, 2))  # to (num_bpts, num_gt_individuals, 3)
         image_pred = image_pred.transpose((1, 0, 2))  # to (num_bpts, num_pred, 3)
@@ -352,14 +363,23 @@ def compute_detection_rmse(
             if len(bpt_gt) == 0 or len(bpt_pred) == 0:
                 continue
 
+            if isinstance(pcutoff, float):
+                bpt_pcutoff = pcutoff
+            else:
+                bpt_pcutoff = pcutoff[bpt_index]
+
             # assignment of predicted bodyparts to ground truth
             neighbors = find_closest_neighbors(bpt_gt, bpt_pred, k=3)
             for gt_index, pred_index in enumerate(neighbors):
                 if pred_index != -1:
                     gt = bpt_gt[gt_index]
                     pred = bpt_pred[pred_index]
-                    distances.append(np.linalg.norm(gt[:2] - pred[:2]))
-                    scores.append(bpt_pred[pred_index, 2])
+                    dist = np.linalg.norm(gt[:2] - pred[:2])
+                    distances.append(dist)
+
+                    score = bpt_pred[pred_index, 2]
+                    if score >= bpt_pcutoff:
+                        distances_cutoff.append(dist)
 
     if data_unique is not None:
         for image_gt, image_pred in data_unique:
@@ -368,9 +388,23 @@ def compute_detection_rmse(
                 f"{image_pred.shape}."
             )
             unique_gt, unique_pred = image_gt[0], image_pred[0]
-            for gt, pred in zip(unique_gt, unique_pred):
-                distances.append(np.linalg.norm(gt[:2] - pred[:2]))
-                scores.append(pred[2])
+            num_unique = unique_gt.shape[0]
+            unique_cutoffs = pcutoff
+            if not isinstance(pcutoff, float):
+                unique_cutoffs = pcutoff[-num_unique:]
+
+            for bpt_index, (gt, pred) in enumerate(zip(unique_gt, unique_pred)):
+                dist = np.linalg.norm(gt[:2] - pred[:2])
+                distances.append(dist)
+
+                score = pred[2]
+                if isinstance(pcutoff, float):
+                    bpt_pcutoff = unique_cutoffs
+                else:
+                    bpt_pcutoff = unique_cutoffs[bpt_index]
+
+                if score >= bpt_pcutoff:
+                    distances_cutoff.append(dist)
 
     rmse, rmse_cutoff = float("nan"), float("nan")
     if len(distances) == 0:
@@ -380,10 +414,10 @@ def compute_detection_rmse(
     if np.any(~np.isnan(distances)):
         rmse = float(np.nanmean(distances).item())
 
-        keypoint_scores = np.stack(scores)
-        pixel_errors_cutoff = distances[keypoint_scores >= pcutoff]
-        if np.any(~np.isnan(pixel_errors_cutoff)):
-            rmse_cutoff = float(np.nanmean(pixel_errors_cutoff).item())
+        if len(distances_cutoff) > 0:
+            distances_cutoff = np.stack(distances_cutoff)
+            if np.any(~np.isnan(distances_cutoff)):
+                rmse_cutoff = float(np.nanmean(distances_cutoff).item())
 
     return rmse, rmse_cutoff
 

--- a/deeplabcut/pose_estimation_pytorch/apis/evaluate.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/evaluate.py
@@ -668,25 +668,6 @@ def evaluate_snapshot(
     return df_predictions
 
 
-def _validate_pcutoff(
-    bodyparts: list[str],
-    unique_bpts: list[str],
-    pcutoff: float | list[float],
-) -> None:
-    """Checks that the given `pcutoff` value has the correct number of elements"""
-    if isinstance(pcutoff, float):
-        return
-
-    total_bodyparts = len(bodyparts) + len(unique_bpts)
-    if len(pcutoff) != total_bodyparts:
-        raise ValueError(
-            "When passing the pcutoff as a list, the length of the list should be "
-            "equal to the number of bodyparts and the number of unique bpts. "
-            f"Found a list containing {len(pcutoff)} elements, but there are "
-            f"{total_bodyparts} total bodyparts, which are {bodyparts + unique_bpts}."
-        )
-
-
 def evaluate_network(
     config: str | Path,
     shuffles: Iterable[int] = (1,),
@@ -930,6 +911,25 @@ def save_rmse_per_bodypart(
     # Save scores file
     df_rmse_per_bodypart = pd.DataFrame(data, index=index)
     df_rmse_per_bodypart.to_csv(output_path)
+
+
+def _validate_pcutoff(
+    bodyparts: list[str],
+    unique_bpts: list[str],
+    pcutoff: float | list[float],
+) -> None:
+    """Checks that the given `pcutoff` value has the correct number of elements"""
+    if isinstance(pcutoff, float):
+        return
+
+    total_bodyparts = len(bodyparts) + len(unique_bpts)
+    if len(pcutoff) != total_bodyparts:
+        raise ValueError(
+            "When passing the pcutoff as a list, the length of the list should be "
+            "equal to the number of bodyparts and the number of unique bpts. "
+            f"Found a list containing {len(pcutoff)} elements, but there are "
+            f"{total_bodyparts} total bodyparts, which are {bodyparts + unique_bpts}."
+        )
 
 
 def _get_keypoints_to_use(

--- a/deeplabcut/pose_estimation_pytorch/apis/evaluate.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/evaluate.py
@@ -560,7 +560,10 @@ def evaluate_snapshot(
         "Detector epochs (TD only)": (
             -1 if detector_snapshot is None else detector_snapshot.epochs
         ),
-        "pcutoff": pcutoff,
+        "pcutoff": (
+            ", ".join([str(v) for v in pcutoff])
+            if isinstance(pcutoff, list) else pcutoff
+        ),
     }
     for split in ["train", "test"]:
         results, predictions_for_split = evaluate(

--- a/deeplabcut/pose_estimation_pytorch/apis/evaluate.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/evaluate.py
@@ -107,7 +107,7 @@ def evaluate(
     parameters: PoseDatasetParameters | None = None,
     comparison_bodyparts: str | list[str] | None = None,
     per_keypoint_evaluation: bool = False,
-    pcutoff: float = 1,
+    pcutoff: float | list[float] = 0.6,
 ) -> tuple[dict[str, float], dict[str, dict[str, np.ndarray]]]:
     """
     Args:
@@ -125,22 +125,16 @@ def evaluate(
         per_keypoint_evaluation: Compute the train and test RMSE for each keypoint, and
             save the results to a {model_name}-keypoint-results.csv in the
             evaluation-results-pytorch folder.
-        pcutoff: The p-cutoff to use for evaluation
+        pcutoff: Confidence threshold for RMSE computation. If a list is provided,
+            there should be one value for each bodypart and one value for each unique
+            bodypart (if there are any).
 
     Returns:
         A dict containing the evaluation results
         A dict mapping the paths of images for which predictions were computed to the
             different predictions made by each model head
     """
-    if comparison_bodyparts == "all":
-        comparison_bodyparts = None
-
-    predictions = predict(
-        pose_runner=pose_runner,
-        loader=loader,
-        mode=mode,
-        detector_runner=detector_runner,
-    )
+    predictions = predict(pose_runner, loader, mode, detector_runner=detector_runner)
 
     # For models trained with memory-replay from SuperAnimal, keep project bodyparts
     if weight_init_cfg := loader.model_cfg["train_settings"].get("weight_init"):
@@ -149,45 +143,62 @@ def evaluate(
             for _, pred in predictions.items():
                 pred["bodyparts"] = pred["bodyparts"][:, weight_init.conversion_array]
 
-    gt_keypoints = loader.ground_truth_keypoints(mode)
-    poses = {filename: pred["bodyparts"] for filename, pred in predictions.items()}
-
     if parameters is None:
         parameters = loader.get_dataset_parameters()
 
-    gt_unique_keypoints, unique_poses = None, None
-    if parameters.num_unique_bpts > 1:
-        unique_poses = {
+    gt_pose = loader.ground_truth_keypoints(mode)
+    pred_pose = {filename: pred["bodyparts"] for filename, pred in predictions.items()}
+    kpt_idx = _get_keypoints_to_use(parameters.bodyparts, comparison_bodyparts)
+
+    gt_unique, pred_unique, unique_idx = None, None, None
+    if parameters.num_unique_bpts >= 1:
+        gt_unique = loader.ground_truth_keypoints(mode, unique_bodypart=True)
+        pred_unique = {
             filename: pred["unique_bodyparts"] for filename, pred in predictions.items()
         }
-        gt_unique_keypoints = loader.ground_truth_keypoints(mode, unique_bodypart=True)
+        unique_idx = _get_keypoints_to_use(parameters.unique_bpts, comparison_bodyparts)
 
-    if comparison_bodyparts is not None:
-        poses = _get_keypoint_subset(poses, parameters.bodyparts, comparison_bodyparts)
-        gt_keypoints = _get_keypoint_subset(
-            gt_keypoints, parameters.bodyparts, comparison_bodyparts
-        )
-        if poses is None or gt_keypoints is None:
+    # When `comparison_bodyparts` is used, check that the bodyparts used for evaluation
+    # make sense; If only unique bodyparts are being evaluated, set them as bodyparts
+    if kpt_idx is not None and unique_idx is not None:
+        if len(kpt_idx) == 0 and len(unique_idx) == 0:
+            unique_err = ""
+            if len(parameters.unique_bpts) > 0:
+                unique_err = f" and the unique_bodyparts are {parameters.unique_bpts}"
             raise ValueError(
-                "comparison_bodyparts must include at least one bodypart defined in "
-                f"the project. Found {comparison_bodyparts} but project bodyparts are "
-                f"{parameters.bodyparts}"
+                f"No bodyparts left when comparison_bodyparts={comparison_bodyparts}! "
+                f"The project bodyparts are {parameters.bodyparts}{unique_err}! Set "
+                f"comparison_bodyparts to `None` or `'all'` to evaluate on all of them,"
+                f" or select a subset of them to evaluate."
             )
+        elif len(kpt_idx) == 0 and len(unique_idx) > 0:
+            gt_pose, pred_pose, kpt_idx = gt_unique, pred_unique, unique_idx
+            parameters = PoseDatasetParameters(
+                bodyparts=parameters.unique_bpts,
+                unique_bpts=[],
+                individuals=["animal"],
+            )
+            gt_unique, pred_unique, unique_idx = None, None, None
 
-        unique_poses = _get_keypoint_subset(
-            unique_poses, parameters.unique_bpts, comparison_bodyparts
-        )
-        gt_unique_keypoints = _get_keypoint_subset(
-            gt_unique_keypoints, parameters.unique_bpts, comparison_bodyparts
-        )
+    if kpt_idx is not None:
+        gt_pose = {img: kpts[:, kpt_idx] for img, kpts in gt_pose.items()}
+        pred_pose = {img: kpts[:, kpt_idx] for img, kpts in pred_pose.items()}
+
+    if unique_idx is not None:
+        gt_unique = {img: kpts[:, unique_idx] for img, kpts in gt_unique.items()}
+        pred_unique = {img: kpts[:, unique_idx] for img, kpts in pred_unique.items()}
+
+    bodyparts = _get_subset_bodyparts(parameters.bodyparts, comparison_bodyparts)
+    unique_bpts = _get_subset_bodyparts(parameters.unique_bpts, comparison_bodyparts)
+    _validate_pcutoff(bodyparts, unique_bpts, pcutoff)
 
     results = metrics.compute_metrics(
-        gt_keypoints,
-        poses,
+        gt_pose,
+        pred_pose,
         single_animal=parameters.max_num_animals == 1,
         pcutoff=pcutoff,
-        unique_bodypart_poses=unique_poses,
-        unique_bodypart_gt=gt_unique_keypoints,
+        unique_bodypart_poses=pred_unique,
+        unique_bodypart_gt=gt_unique,
         per_keypoint_rmse=per_keypoint_evaluation,
     )
 
@@ -198,15 +209,15 @@ def evaluate(
         id_scores = metrics.compute_identity_scores(
             individuals=parameters.individuals,
             bodyparts=parameters.bodyparts,
-            predictions=poses,
+            predictions=pred_pose,
             identity_scores=pred_id_scores,
-            ground_truth=gt_keypoints,
+            ground_truth=gt_pose,
         )
         for name, score in id_scores.items():
             results[f"id_head_{name}"] = score
 
     # Updating poses to be aligned and padded
-    for image, pose in poses.items():
+    for image, pose in pred_pose.items():
         predictions[image]["bodyparts"] = pose
 
     return results, predictions
@@ -223,29 +234,28 @@ def visualize_predictions(
 ) -> None:
     """Visualize model predictions alongside ground truth keypoints.
 
-    This function processes keypoint predictions and ground truth data, applies visibility
-    masks, and generates visualization plots. It supports random or sequential sampling
-    of images for visualization.
+    This function processes keypoint predictions and ground truth data, applies
+    visibility masks, and generates visualization plots. It supports random or
+    sequential sampling of images for visualization.
 
     Args:
         predictions: Dictionary mapping image paths to prediction data.
             Each prediction contains:
-            - bodyparts: array of shape [N, num_keypoints, 3] where 3 represents (x, y, confidence)
+            - bodyparts: array of shape [N, num_keypoints, 3] where 3 represents
+                (x, y, confidence)
             - bboxes: array of shape [N, 4] for bounding boxes (optional)
             - bbox_scores: array of shape [N,] for bbox confidences (optional)
-
         ground_truth: Dictionary mapping image paths to ground truth keypoints.
-            Each value has shape [N, num_keypoints, 3] where 3 represents (x, y, visibility)
-
+            Each value has shape [N, num_keypoints, 3] where 3 represents
+                (x, y, visibility)
         output_dir: Path to save visualization outputs.
             Defaults to "predictions_visualizations"
-
         num_samples: Number of images to visualize. If None, processes all images
-
         random_select: If True, randomly samples images; if False, uses first N images
-
         show_ground_truth: If True, displays ground truth poses alongside predictions.
-                          If False, only shows predictions but uses GT visibility mask
+            If False, only shows predictions but uses GT visibility mask
+        plot_bboxes: If True and the model is a top-down model, predicted bboxes will
+            be shown in the images as well
     """
     # Setup output directory
     output_dir = Path(output_dir or "predictions_visualizations")
@@ -324,7 +334,7 @@ def plot_gt_and_predictions(
     colormap: str = "rainbow",
     dot_size: int = 12,
     alpha_value: float = 0.7,
-    p_cutoff: float = 0.6,
+    p_cutoff: float | list[float] = 0.6,
     bounding_boxes: tuple[np.ndarray, np.ndarray] | None = None,
     bboxes_pcutoff: float = 0.6,
     bounding_boxes_color: str = "auto",
@@ -342,13 +352,17 @@ def plot_gt_and_predictions(
         colormap: Matplotlib colormap name
         dot_size: Size of the plotted points
         alpha_value: Transparency of the points
-        p_cutoff: Confidence threshold for showing predictions
-        bounding_boxes:  bounding boxes (top-left corner, size) and their respective confidence levels,
-        bboxes_cutoff: bounding boxes confidence cutoff threshold.
-        bounding_boxes_color: If plotting bounding boxes, this is the color that will be used for bounding boxes.
-            If set to "auto" (default value):
+        p_cutoff: Confidence threshold for showing predictions. If a list is provided,
+            there should be one value for each bodypart and one value for each unique
+            bodypart (if there are any).
+        bounding_boxes:  bounding boxes (top-left corner, size) and their respective
+            confidence levels,
+        bboxes_pcutoff: bounding boxes confidence cutoff threshold.
+        bounding_boxes_color: If plotting bounding boxes, this is the color that will be
+            used for bounding boxes. If set to "auto" (default value):
                 - if mode is "bodypart", the bbox color will be a default color
-                - if mode is "individual", each individual's color will be used for its bounding box
+                - if mode is "individual", each individual's color will be used for its
+                    bounding box
     """
     # Ensure output directory exists
     output_dir = Path(output_dir)
@@ -452,6 +466,7 @@ def evaluate_snapshot(
     comparison_bodyparts: str | list[str] | None = None,
     per_keypoint_evaluation: bool = False,
     detector_snapshot: Snapshot | None = None,
+    pcutoff: float | list[float] | dict[str, float] | None = None,
 ) -> pd.DataFrame:
     """Evaluates a snapshot.
     The evaluation results are stored in the .h5 and .csv file under the subdirectory
@@ -475,6 +490,12 @@ def evaluate_snapshot(
             evaluation-results-pytorch folder.
         detector_snapshot: Only for TD models. If defined, evaluation metrics are
             computed using the detections made by this snapshot
+        pcutoff: The cutoff to use for computing evaluation metrics. When `None`, the
+            cutoff will be loaded from the project config. If a list is provided, there
+            should be one value for each bodypart and one value for each unique bodypart
+            (if there are any). If a dict is provided, the keys should be bodyparts
+            mapping to pcutoff values for each bodypart. Bodyparts that are not defined
+            in the dict will have pcutoff set to 0.6.
     """
     head_type = loader.model_cfg["model"]["heads"]["bodypart"]["type"]
     if head_type == "DLCRNetHead":
@@ -483,7 +504,6 @@ def evaluate_snapshot(
         )
 
     parameters = loader.get_dataset_parameters()
-    pcutoff = cfg.get("pcutoff", 0.6)
 
     detector_path = None
     if detector_snapshot is not None:
@@ -520,6 +540,15 @@ def evaluate_snapshot(
         unique_bpts=_get_subset_bodyparts(parameters.unique_bpts, comparison_bodyparts),
         individuals=parameters.individuals,
     )
+
+    if pcutoff is None:
+        pcutoff = cfg.get("pcutoff", 0.6)
+    elif isinstance(pcutoff, dict):
+        pcutoff = [
+            pcutoff.get(bpt, 0.6)
+            for bpt in eval_parameters.bodyparts + eval_parameters.unique_bpts
+        ]
+    _validate_pcutoff(parameters.bodyparts, parameters.unique_bpts, pcutoff)
 
     predictions = {}
     rmse_per_bodypart = {}
@@ -635,6 +664,25 @@ def evaluate_snapshot(
     return df_predictions
 
 
+def _validate_pcutoff(
+    bodyparts: list[str],
+    unique_bpts: list[str],
+    pcutoff: float | list[float],
+) -> None:
+    """Checks that the given `pcutoff` value has the correct number of elements"""
+    if isinstance(pcutoff, float):
+        return
+
+    total_bodyparts = len(bodyparts) + len(unique_bpts)
+    if len(pcutoff) != total_bodyparts:
+        raise ValueError(
+            "When passing the pcutoff as a list, the length of the list should be "
+            "equal to the number of bodyparts and the number of unique bpts. "
+            f"Found a list containing {len(pcutoff)} elements, but there are "
+            f"{total_bodyparts} total bodyparts, which are {bodyparts + unique_bpts}."
+        )
+
+
 def evaluate_network(
     config: str | Path,
     shuffles: Iterable[int] = (1,),
@@ -648,6 +696,7 @@ def evaluate_network(
     per_keypoint_evaluation: bool = False,
     modelprefix: str = "",
     detector_snapshot_index: int | None = None,
+    pcutoff: float | list[float] | dict[str, float] | None = None,
 ) -> None:
     """Evaluates a snapshot.
 
@@ -683,6 +732,12 @@ def evaluate_network(
             the network. By default, they are assumed to exist in the project folder.
         detector_snapshot_index: Only for TD models. If defined, uses the detector with
             the given index for pose estimation.
+        pcutoff: The cutoff to use for computing evaluation metrics. When `None`, the
+            cutoff will be loaded from the project config. If a list is provided, there
+            should be one value for each bodypart and one value for each unique bodypart
+            (if there are any). If a dict is provided, the keys should be bodyparts
+            mapping to pcutoff values for each bodypart. Bodyparts that are not defined
+            in the dict will have pcutoff set to 0.6.
 
     Examples:
         If you want to evaluate on shuffle 1 without plotting predictions.
@@ -787,6 +842,7 @@ def evaluate_network(
                         comparison_bodyparts=comparison_bodyparts,
                         per_keypoint_evaluation=per_keypoint_evaluation,
                         detector_snapshot=detector_snapshot,
+                        pcutoff=pcutoff,
                     )
 
 
@@ -872,39 +928,30 @@ def save_rmse_per_bodypart(
     df_rmse_per_bodypart.to_csv(output_path)
 
 
-def _get_keypoint_subset(
-    data: dict[str, np.ndarray] | None,
+def _get_keypoints_to_use(
     bodyparts: list[str],
-    bodypart_subset: str | list[str],
-) -> dict[str, np.ndarray] | None:
-    """Obtains the pose for a subset of bodyparts
+    bodypart_subset: str | list[str] | None,
+) -> list[int] | None:
+    """Computes the indices of the keypoints indices to keep based on the given subset.
 
     Args:
-        data: The data for which to obtain the pose belonging to the subset. A dict
-            mapping image name to an array of shape (num_idv, len(bodyparts), ...).
-        bodyparts: The bodyparts corresponding to the columns of the arrays in the data
-            dict (in the same order).
-        bodypart_subset: The subset of bodyparts to keep.
+        bodyparts: The bodyparts predicted by the model.
+        bodypart_subset: The subset of bodyparts to keep. If None or "all", all
+            bodyparts are kept.
 
     Returns:
-        A dict containing the image keys, mapping to arrays of shape
-        (num_idv, len(subset), ...) containing the data subset.
+        None if all bodyparts should be kept, or bodyparts is an empty list. Otherwise,
+        returns a list containing the indices of the bodyparts to keep. If no bodyparts
+        should be kept, returns an empty list.
     """
-    if data is None:
+    if len(bodyparts) == 0 or bodypart_subset is None or bodypart_subset == "all":
         return None
 
     if isinstance(bodypart_subset, str):
-        if bodypart_subset == "all":
-            return data
-
         bodypart_subset = [bodypart_subset]
 
     to_keep = set(bodypart_subset)
-    bpt_indices = [i for i, b in enumerate(bodyparts) if b in to_keep]
-    if len(bpt_indices) == 0:
-        return None
-
-    return {image: kpts[:, bpt_indices] for image, kpts in data.items()}
+    return [i for i, b in enumerate(bodyparts) if b in to_keep]
 
 
 def _get_subset_bodyparts(
@@ -920,9 +967,10 @@ def _get_subset_bodyparts(
     Returns:
         The bodyparts that were used to evaluate the model.
     """
+    if subset is None or subset == "all":
+        return bodyparts
+
     if isinstance(subset, str):
-        if subset == "all":
-            return bodyparts
         subset = [subset]
 
     to_keep = set(subset)

--- a/tests/pose_estimation_pytorch/apis/test_apis_evaluate.py
+++ b/tests/pose_estimation_pytorch/apis/test_apis_evaluate.py
@@ -1,0 +1,447 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+from dataclasses import dataclass
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pytest
+
+import deeplabcut.pose_estimation_pytorch.apis as apis
+import deeplabcut.pose_estimation_pytorch.data as data
+
+
+PREDICT = Mock()
+
+
+@patch("deeplabcut.pose_estimation_pytorch.apis.evaluate.predict", PREDICT)
+@pytest.mark.parametrize("num_individuals", [1, 2, 5])
+@pytest.mark.parametrize(
+    "bodyparts, error",
+    [
+        (["nose", "left_ear"], [5, 10]),
+        (["nose", "left_ear", "right_ear"], [2, 3, 4]),
+    ]
+)
+def test_evaluate_basic(
+    num_individuals: int,
+    bodyparts: list[str],
+    error: list[float],
+) -> None:
+    print()
+    gt, pred = generate_data(1, num_individuals, len(bodyparts), error)
+
+    pose_runner = Mock()
+
+    PREDICT.return_value = {img: {"bodyparts": pose} for img, pose in pred.items()}
+    loader = build_mock_loader(gt, num_individuals, bodyparts)
+    results, preds = apis.evaluate(pose_runner, loader, mode="test")
+    print("results", results)
+    np.testing.assert_almost_equal(results["rmse"], np.mean(error))
+
+
+@patch("deeplabcut.pose_estimation_pytorch.apis.evaluate.predict", PREDICT)
+@pytest.mark.parametrize("num_individuals", [1, 2, 5])
+@pytest.mark.parametrize(
+    "bodyparts, error",
+    [
+        (["nose", "left_ear"], [5, 10]),
+        (["nose", "left_ear", "right_ear"], [2, 3, 4]),
+    ]
+)
+@pytest.mark.parametrize(
+    "unique_bodyparts, unique_error",
+    [
+        (["top_left"], [2]),
+        (["top_left", "bottom_right"], [2, 3]),
+    ]
+)
+def test_evaluate_with_unique_bodyparts(
+    num_individuals: int,
+    bodyparts: list[str],
+    error: list[float],
+    unique_bodyparts: list[str],
+    unique_error: list[float],
+) -> None:
+    print()
+    num_images = 5
+    gt, pred = generate_data(num_images, num_individuals, len(bodyparts), error)
+    gt_unique, pred_unique = generate_data(
+        num_images, 1, len(unique_bodyparts), unique_error
+    )
+
+    pose_runner = Mock()
+    PREDICT.return_value = {
+        img: {"bodyparts": pose, "unique_bodyparts": pred_unique[img]}
+        for img, pose in pred.items()
+    }
+    loader = build_mock_loader(
+        gt, num_individuals, bodyparts, gt_unique=gt_unique, unique=unique_bodyparts
+    )
+    results, preds = apis.evaluate(pose_runner, loader, mode="test")
+    idv_errors = np.tile(error, (num_individuals, 1)).reshape(-1)
+    expected_rmse = np.mean(np.concatenate([idv_errors, unique_error]))
+    print(num_individuals)
+    print(error)
+    print(idv_errors)
+    print(unique_error)
+    print(np.concatenate([idv_errors, unique_error]))
+    print(expected_rmse)
+    print("results", results)
+    np.testing.assert_almost_equal(results["rmse"], expected_rmse)
+
+
+@dataclass
+class CompTestConfig:
+    num_individuals: int = 1
+    bodyparts: tuple[str, ...] = ("nose", "left_ear")
+    error: tuple[float, ...] = (5, 10)
+    unique_bodyparts: tuple[str, ...] = ("top_left", )
+    unique_error: tuple[float, ...] = (2, )
+    comparison_bodyparts: str | list[str] | None = None
+    expected_error: float = (2 + 5 + 10) / 3
+
+    def num_bpt(self) -> int:
+        return len(self.bodyparts)
+
+    def num_unique(self) -> int:
+        return len(self.unique_bodyparts)
+
+
+@patch("deeplabcut.pose_estimation_pytorch.apis.evaluate.predict", PREDICT)
+@pytest.mark.parametrize(
+    "cfg",
+    [
+        CompTestConfig(comparison_bodyparts=None),
+        CompTestConfig(comparison_bodyparts="all"),
+        CompTestConfig(comparison_bodyparts=["nose", "left_ear", "top_left"]),
+        CompTestConfig(num_individuals=2, expected_error=(2 + 5 + 5 + 10 + 10) / 5),
+        CompTestConfig(comparison_bodyparts="nose", expected_error=5),
+        CompTestConfig(comparison_bodyparts=["nose"], expected_error=5),
+        CompTestConfig(comparison_bodyparts=["left_ear"], expected_error=10),
+        CompTestConfig(comparison_bodyparts=["nose", "left_ear"], expected_error=7.5),
+        CompTestConfig(comparison_bodyparts="top_left", expected_error=2),
+        CompTestConfig(comparison_bodyparts=["top_left"], expected_error=2),
+        CompTestConfig(
+            unique_bodyparts=("a", "b", "c"),
+            unique_error=(3.0, 4.0, 5.0),
+            comparison_bodyparts=["a", "b", "c"],
+            expected_error=4,
+        ),
+        CompTestConfig(
+            num_individuals=1,
+            unique_bodyparts=("a", "b", "c"),
+            unique_error=(3.0, 4.0, 5.0),
+            comparison_bodyparts=["nose", "a", "b", "c"],
+            expected_error=(5.0 + 3.0 + 4.0 + 5.0) / 4,
+        ),
+        CompTestConfig(
+            num_individuals=7,
+            unique_bodyparts=("a", "b", "c"),
+            unique_error=(3.0, 4.0, 5.0),
+            comparison_bodyparts=["nose", "left_ear", "a", "b"],
+            expected_error=((7 * 5) + (7 * 10) + 3.0 + 4.0) / (7 + 7 + 2),
+        ),
+    ]
+)
+def test_evaluate_with_comparison_bodyparts(cfg: CompTestConfig) -> None:
+    print()
+    num_images = 5
+    gt, pred = generate_data(num_images, cfg.num_individuals, cfg.num_bpt(), cfg.error)
+    gt_unique, pred_unique = generate_data(num_images, 1, cfg.num_unique(), cfg.unique_error)
+
+    pose_runner = Mock()
+    PREDICT.return_value = {
+        img: {"bodyparts": pose, "unique_bodyparts": pred_unique[img]}
+        for img, pose in pred.items()
+    }
+    loader = build_mock_loader(
+        gt,
+        cfg.num_individuals,
+        cfg.bodyparts,
+        gt_unique=gt_unique,
+        unique=cfg.unique_bodyparts,
+    )
+    results, preds = apis.evaluate(
+        pose_runner, loader, mode="test", comparison_bodyparts=cfg.comparison_bodyparts,
+    )
+    print(cfg)
+    print("results", results)
+    np.testing.assert_almost_equal(results["rmse"], cfg.expected_error)
+
+
+@dataclass
+class KeypointData:
+    img: int
+    idv: int
+    bodypart: str
+    gt: tuple[float, float]
+    pred: tuple[float, float]
+    score: float
+
+    def image(self) -> str:
+        return f"image_{self.img:04d}.png"
+
+    def error(self) -> float:
+        return np.linalg.norm(
+            np.asarray(self.gt, dtype=float) - np.asarray(self.pred, dtype=float)
+        ).item()
+
+
+@patch("deeplabcut.pose_estimation_pytorch.apis.evaluate.predict", PREDICT)
+@pytest.mark.parametrize(
+    "pcutoff", [0.4, 0.6, 0.8, [0.3, 0.5, 0.7]],
+)
+@pytest.mark.parametrize(
+    "keypoints", [
+        [
+            KeypointData(img=0, idv=0, bodypart="a", gt=(10, 10), pred=(11, 10), score=0.7),
+            KeypointData(img=0, idv=0, bodypart="b", gt=(20, 20), pred=(21, 20), score=0.7),
+            KeypointData(img=0, idv=0, bodypart="c", gt=(20, 20), pred=(20, 22), score=0.5),
+        ],
+        [
+            KeypointData(img=0, idv=0, bodypart="a", gt=(10, 10), pred=(11, 10), score=0.7),
+            KeypointData(img=0, idv=0, bodypart="b", gt=(20, 20), pred=(21, 20), score=0.5),
+            KeypointData(img=0, idv=0, bodypart="c", gt=(30, 30), pred=(30, 32), score=0.2),
+            KeypointData(img=0, idv=1, bodypart="a", gt=(40, 10), pred=(41, 10), score=0.7),
+            KeypointData(img=0, idv=1, bodypart="b", gt=(50, 20), pred=(49, 20), score=0.5),
+            KeypointData(img=0, idv=1, bodypart="c", gt=(60, 20), pred=(58, 20), score=0.2),
+        ],
+    ]
+)
+def test_evaluate_with_pcutoff(
+    pcutoff: float | list[float],
+    keypoints: list[KeypointData],
+) -> None:
+    print()
+
+    images = {d.image() for d in keypoints}
+    individuals = list({d.idv for d in keypoints if d.idv != -1})
+    bodyparts = list({d.bodypart for d in keypoints if d.idv != -1})
+    unique_bodyparts = list({d.bodypart for d in keypoints if d.idv == -1})
+
+    num_idv = len(individuals)
+    num_bodyparts = len(bodyparts)
+    num_unique = len(unique_bodyparts)
+
+    gt, pred = {}, {}
+    for img in images:
+        gt[img] = np.zeros((num_idv, num_bodyparts, 3))
+        pred[img] = np.zeros((num_idv, num_bodyparts, 3))
+
+    errors = []
+    errors_cutoff = []
+    for kpt in keypoints:
+        img = kpt.image()
+        bpt = bodyparts.index(kpt.bodypart)
+
+        gt[img][kpt.idv, bpt, :2] = kpt.gt
+        gt[img][kpt.idv, bpt, 2] = 2
+        pred[img][kpt.idv, bpt, :2] = kpt.pred
+        pred[img][kpt.idv, bpt, 2] = kpt.score
+
+        if isinstance(pcutoff, list):
+            bpt_cutoff = pcutoff[bpt]
+        else:
+            bpt_cutoff = pcutoff
+
+        errors.append(kpt.error())
+        if kpt.score >= bpt_cutoff:
+            errors_cutoff.append(kpt.error())
+
+    print(errors)
+    print(errors_cutoff)
+
+    pose_runner = Mock()
+    PREDICT.return_value = {img: {"bodyparts": pose} for img, pose in pred.items()}
+    loader = build_mock_loader(gt, num_idv, bodyparts)
+    results, preds = apis.evaluate(pose_runner, loader, mode="test", pcutoff=pcutoff)
+    print("results", results)
+    np.testing.assert_almost_equal(results["rmse"], np.mean(errors))
+    np.testing.assert_almost_equal(results["rmse_pcutoff"], np.mean(errors_cutoff))
+    if "rmse_detections" in results:
+        np.testing.assert_almost_equal(
+            results["rmse_detections"], np.mean(errors)
+        )
+        np.testing.assert_almost_equal(
+            results["rmse_detections_pcutoff"], np.mean(errors_cutoff)
+        )
+
+
+@patch("deeplabcut.pose_estimation_pytorch.apis.evaluate.predict", PREDICT)
+@pytest.mark.parametrize(
+    "pcutoff", [0.4, 0.6, 0.8, [0.3, 0.5, 0.7, 0.4, 0.6]],
+)
+@pytest.mark.parametrize(
+    "keypoints", [
+        [
+            KeypointData(img=0, idv=0, bodypart="a", gt=(10, 10), pred=(11, 10), score=0.7),
+            KeypointData(img=0, idv=0, bodypart="b", gt=(20, 20), pred=(21, 20), score=0.7),
+            KeypointData(img=0, idv=0, bodypart="c", gt=(20, 20), pred=(20, 22), score=0.5),
+            KeypointData(img=0, idv=-1, bodypart="u1", gt=(20, 20), pred=(20, 22), score=0.5),
+            KeypointData(img=0, idv=-1, bodypart="u2", gt=(20, 20), pred=(20, 22), score=0.3),
+        ],
+        [
+            KeypointData(img=0, idv=0, bodypart="a", gt=(10, 10), pred=(11, 10), score=0.7),
+            KeypointData(img=0, idv=0, bodypart="b", gt=(20, 20), pred=(21, 20), score=0.5),
+            KeypointData(img=0, idv=0, bodypart="c", gt=(30, 30), pred=(30, 32), score=0.2),
+            KeypointData(img=0, idv=1, bodypart="a", gt=(40, 10), pred=(41, 10), score=0.7),
+            KeypointData(img=0, idv=1, bodypart="b", gt=(50, 20), pred=(49, 20), score=0.5),
+            KeypointData(img=0, idv=1, bodypart="c", gt=(60, 20), pred=(58, 20), score=0.2),
+            KeypointData(img=0, idv=-1, bodypart="u1", gt=(2, 3), pred=(3, 3), score=0.7),
+            KeypointData(img=0, idv=-1, bodypart="u2", gt=(20, 20), pred=(20, 22), score=0.9),
+        ]
+    ]
+)
+def test_evaluate_with_pcutoff_and_unique_bodyparts(
+    pcutoff: float | list[float],
+    keypoints: list[KeypointData],
+) -> None:
+    print()
+
+    images = {d.image() for d in keypoints}
+    individuals = list({d.idv for d in keypoints if d.idv != -1})
+    bodyparts = list({d.bodypart for d in keypoints if d.idv != -1})
+    unique_bodyparts = list({d.bodypart for d in keypoints if d.idv == -1})
+
+    num_idv = len(individuals)
+    num_bodyparts = len(bodyparts)
+    num_unique = len(unique_bodyparts)
+
+    gt, pred, gt_unique, pred_unique = {}, {}, {}, {}
+    for img in images:
+        gt[img] = np.zeros((num_idv, num_bodyparts, 3))
+        pred[img] = np.zeros((num_idv, num_bodyparts, 3))
+        gt_unique[img] = np.zeros((1, num_unique, 3))
+        pred_unique[img] = np.zeros((1, num_unique, 3))
+
+    errors, errors_cutoff = [], []
+    for kpt in keypoints:
+        img = kpt.image()
+        if kpt.idv == -1:
+            idv, bpt = 0, unique_bodyparts.index(kpt.bodypart)
+            gt_data, pred_data = gt_unique[img], pred_unique[img]
+        else:
+            idv, bpt = kpt.idv, bodyparts.index(kpt.bodypart)
+            gt_data, pred_data = gt[img], pred[img]
+
+        gt_data[idv, bpt, :2] = kpt.gt
+        gt_data[idv, bpt, 2] = 2
+        pred_data[idv, bpt, :2] = kpt.pred
+        pred_data[idv, bpt, 2] = kpt.score
+
+        if isinstance(pcutoff, list):
+            bpt_cutoff = pcutoff[bpt]
+        else:
+            bpt_cutoff = pcutoff
+
+        errors.append(kpt.error())
+        if kpt.score >= bpt_cutoff:
+            errors_cutoff.append(kpt.error())
+
+    print(errors)
+    print(errors_cutoff)
+
+    pose_runner = Mock()
+    PREDICT.return_value = {
+        img: {"bodyparts": pose, "unique_bodyparts": pred_unique[img]}
+        for img, pose in pred.items()
+    }
+    loader = build_mock_loader(gt, num_idv, bodyparts, gt_unique, unique_bodyparts)
+    results, preds = apis.evaluate(pose_runner, loader, mode="test", pcutoff=pcutoff)
+
+    print("results", results)
+    np.testing.assert_almost_equal(results["rmse"], np.mean(errors))
+    np.testing.assert_almost_equal(results["rmse_pcutoff"], np.mean(errors_cutoff))
+    if "rmse_detections" in results:
+        np.testing.assert_almost_equal(
+            results["rmse_detections"], np.mean(errors)
+        )
+        np.testing.assert_almost_equal(
+            results["rmse_detections_pcutoff"], np.mean(errors_cutoff)
+        )
+
+
+def generate_data(
+    num_images: int,
+    num_individuals: int,
+    num_bodyparts: int,
+    error: list[float] | tuple[float, ...] | np.ndarray,
+    cutoffs: list[float] | tuple[float, ...] | np.ndarray | None = None,
+    error_cutoff: list[float] | tuple[float, ...] | np.ndarray | None = None,
+) -> tuple[dict[str, np.ndarray], dict[str, np.ndarray]]:
+    num_elems = num_individuals * num_bodyparts
+    shape = num_individuals, num_bodyparts, 3
+    error = np.asarray(error)
+    coord_error = (np.sqrt(2) / 2) * error
+
+    gt, pred = {}, {}
+    for img in range(num_images):
+        gt_pose = 100 * np.arange(3 * num_elems, dtype=float).reshape(shape)
+        gt_pose[..., 2] = 2
+        gt[f"img_{img:04d}.png"] = gt_pose
+
+        pred_pose = np.ones(shape, dtype=float)
+        pred_pose[..., :2] = gt_pose[..., :2]
+        pred_pose[:, :, 0] += coord_error
+        pred_pose[:, :, 1] += coord_error
+        pred[f"img_{img:04d}.png"] = pred_pose
+
+    if error_cutoff is not None and cutoffs is not None:
+        for img in range(num_images):
+            gt_pose = 100 * np.arange(3 * num_elems, dtype=float).reshape(shape)
+            gt_pose[..., 2] = 2
+            gt[f"img_{num_images + img:04d}.png"] = gt_pose
+
+            pred_pose = np.ones(shape, dtype=float)
+            pred_pose[..., :2] = gt_pose[..., :2]
+            pred_pose[..., 2] = cutoffs
+            pred_pose[:, :, 0] += coord_error
+            pred_pose[:, :, 1] += coord_error
+            pred[f"img_{num_images + img:04d}.png"] = pred_pose
+
+    return gt, pred
+
+
+def build_mock_loader(
+    gt: dict[str, np.ndarray],
+    num_individuals: int,
+    bodyparts: list[str] | tuple[str, ...],
+    gt_unique: dict[str, np.ndarray] | None = None,
+    unique: list[str] | tuple[str, ...] | None = None,
+) -> Mock:
+    if unique is None:
+        unique = []
+
+    def _gt(mode: str, unique_bodypart: bool = False) -> dict[str, np.ndarray]:
+        if unique_bodypart:
+            print("LOADING UNIQUE GT")
+            return gt_unique
+        print("LOADING GT")
+        return gt
+
+    individuals = [f"animal_{i:03d}" for i in range(num_individuals)]
+    loader = Mock()
+    loader.get_dataset_parameters.return_value = data.PoseDatasetParameters(
+        bodyparts=bodyparts,
+        unique_bpts=unique,
+        individuals=individuals,
+    )
+    loader.ground_truth_keypoints = _gt
+    loader.model_cfg = {
+        "metadata": {
+            "bodyparts": bodyparts,
+            "unique_bodyparts": unique,
+            "individuals": individuals,
+            "with_identity": False,
+        },
+        "train_settings": {},
+    }
+    return loader


### PR DESCRIPTION
Adds an option to select the `pcutoff` for each bodypart individually for models trained with the PyTorch engine.

The `pcutoff` can be set as a `float`, a `list` or a `dict`. Examples for a project where there are 5 bodyparts: `["snout", "left_ear", "right_ear", "mid", "tail_base"]`.

Example 1: Using the same pcutoff for all bodyparts

```python
deeplabcut.evaluate_network(config, ..., pcutoff=0.6),
```

Example 2: Using a list to set the `pcutoff`

```python
deeplabcut.evaluate_network(config, ..., pcutoff=[0.6, 0.8, 0.8, 0.6, 0.6]),
```

Example 3: Changing the `pcutoff` for the ears to `0.8`, and otherwise keeping the same values as set in the project `config.yaml`: 

```python
deeplabcut.evaluate_network(config, ..., pcutoff={"left_ear": 0.8, "right_ear": 0.8})
```

Tests were added for evaluation.