### PR TITLE
Improvements to the create project GUI

### DIFF
--- a/deeplabcut/gui/tabs/create_project.py
+++ b/deeplabcut/gui/tabs/create_project.py
@@ -275,9 +275,13 @@ class ProjectCreator(QtWidgets.QDialog):
 
         # Connect 3d toggle to all other option visibility
         self.toggle_3d.toggled.connect(lambda yes: madlc_widget.setVisible(not yes))
-        self.toggle_3d.toggled.connect(lambda yes: self.bodypart_list.setVisible(not yes))
         self.toggle_3d.toggled.connect(
-            lambda yes: self.individuals_list.setVisible(not yes and self.madlc_toggle.isChecked())
+            lambda yes: self.bodypart_list.setVisible(not yes)
+        )
+        self.toggle_3d.toggled.connect(
+            lambda yes: self.individuals_list.setVisible(
+                not yes and self.madlc_toggle.isChecked()
+            )
         )
 
         # Add both lists to the horizontal layout with top alignment
@@ -287,7 +291,7 @@ class ProjectCreator(QtWidgets.QDialog):
         # Add the horizontal layout to the main vertical layout
         vbox.addLayout(lists_layout)
         return user_frame
-    
+
     def build_toggle_widget(
         self,
         switch: Switch,

--- a/deeplabcut/gui/tabs/create_project.py
+++ b/deeplabcut/gui/tabs/create_project.py
@@ -293,18 +293,16 @@ class ProjectCreator(QtWidgets.QDialog):
 
         # Create both DynamicTextList widgets as class attributes
         self.bodypart_list = DynamicTextList(
-            label_text="bodyparts to track",
-            parent=self,
+            label_text="Bodyparts to track", parent=self,
         )
+
         self.individuals_list = DynamicTextList(
-            label_text="individual names",
-            parent=self,
+            label_text="Individual names", parent=self,
         )
         self.individuals_list.setVisible(False)
 
         self.unique_bodyparts_list = DynamicTextList(
-            label_text="unique bodyparts to track",
-            parent=self,
+            label_text="Unique bodyparts to track", parent=self,
         )
         self.unique_bodyparts_list.setVisible(False)
 
@@ -374,7 +372,7 @@ class ProjectCreator(QtWidgets.QDialog):
         self.copy_box = QtWidgets.QCheckBox("Copy videos to project folder")
         self.copy_box.setChecked(False)
 
-        browse_button = QtWidgets.QPushButton("Browse folders")
+        browse_button = QtWidgets.QPushButton("Browse folders for videos")
         browse_button.clicked.connect(self.browse_videos)
         clear_button = QtWidgets.QPushButton("Clear")
         clear_button.clicked.connect(video_frame.fancy_list.clear)
@@ -501,15 +499,6 @@ class ProjectCreator(QtWidgets.QDialog):
             return
         self.loc_default = dirname
         self.update_project_location()
-
-    def check_num_cameras(self, value):
-        val = int(value)
-        for child in self.video_frame.children():
-            if child.isWidgetType() and not isinstance(child, QtWidgets.QComboBox):
-                if val > 1:
-                    child.setDisabled(True)
-                else:
-                    child.setDisabled(False)
 
     def update_project_name(self, text):
         self.proj_default = text

--- a/deeplabcut/gui/tabs/create_project.py
+++ b/deeplabcut/gui/tabs/create_project.py
@@ -149,8 +149,9 @@ class Switch(QtWidgets.QPushButton):
         self.setMinimumHeight(22)
 
     def paintEvent(self, event):
+        # Colors: https://qdarkstylesheet.readthedocs.io/en/latest/color_reference.html
         label = self.on_text if self.isChecked() else self.off_text
-        bg_color = "#00ff00" if self.isChecked() else "#788D9C"
+        bg_color = "#00ff00" if self.isChecked() else "#9DA9B5"
 
         radius = 10
         width = 32
@@ -159,9 +160,9 @@ class Switch(QtWidgets.QPushButton):
         painter = QPainter(self)
         painter.setRenderHint(QPainter.Antialiasing)
         painter.translate(center)
-        painter.setBrush(QColor(0, 0, 0))
+        painter.setBrush(QColor(69, 83, 100))  # Lighter gray background
 
-        pen = QPen("#000000")
+        pen = QPen("#455364")
         pen.setWidth(2)
         painter.setPen(pen)
 
@@ -174,6 +175,10 @@ class Switch(QtWidgets.QPushButton):
             sw_rect.moveLeft(-width)
 
         painter.drawRoundedRect(sw_rect, radius, radius)
+
+        pen = QPen("#000000")
+        pen.setWidth(2)
+        painter.setPen(pen)
         painter.drawText(sw_rect, QtCore.Qt.AlignCenter, label)
 
 

--- a/deeplabcut/gui/tabs/create_project.py
+++ b/deeplabcut/gui/tabs/create_project.py
@@ -18,6 +18,7 @@ import deeplabcut
 from deeplabcut.gui import BASE_DIR
 from deeplabcut.gui.dlc_params import DLCParams
 from deeplabcut.gui.widgets import ClickableLabel, ItemSelectionFrame
+from deeplabcut.gui.tabs.docs import URL_3D, URL_USE_GUIDE_SCENARIO
 from deeplabcut.utils import auxiliaryfunctions
 
 
@@ -244,19 +245,14 @@ class ProjectCreator(QtWidgets.QDialog):
         widget_3d = self.build_toggle_widget(
             switch=self.toggle_3d,
             question="Do you want to create a 3D pose estimation project?",
-            help_text="(What is the difference?)",
-            docs_link=(
-                "https://deeplabcut.github.io/DeepLabCut/docs/Overviewof3D.html"
-            ),
+            help_text="(What is needed for a 3D project?)",
+            docs_link=URL_3D,
         )
         madlc_widget = self.build_toggle_widget(
             switch=self.madlc_toggle,
-            question="Are there multiple individuals (=animals) in your videos?",
+            question="Are there multiple individuals in your videos?",
             help_text="(Why does this matter?)",
-            docs_link=(
-                "https://deeplabcut.github.io/DeepLabCut/docs/"
-                "UseOverviewGuide.html#what-scenario-do-you-have"
-            ),
+            docs_link=URL_USE_GUIDE_SCENARIO,
         )
         vbox.addWidget(widget_3d, alignment=QtCore.Qt.AlignTop)
         vbox.addWidget(madlc_widget, alignment=QtCore.Qt.AlignTop)
@@ -266,8 +262,14 @@ class ProjectCreator(QtWidgets.QDialog):
         lists_layout.setAlignment(QtCore.Qt.AlignTop)
 
         # Create both DynamicTextList widgets as class attributes
-        self.bodypart_list = DynamicTextList(label_text="bodyparts", parent=self)
-        self.individuals_list = DynamicTextList(label_text="individuals", parent=self)
+        self.bodypart_list = DynamicTextList(
+            label_text="bodyparts to track",
+            parent=self,
+        )
+        self.individuals_list = DynamicTextList(
+            label_text="individual names",
+            parent=self,
+        )
         self.individuals_list.setVisible(False)
 
         # Connect toggle state to individuals list visibility

--- a/deeplabcut/gui/tabs/create_project.py
+++ b/deeplabcut/gui/tabs/create_project.py
@@ -321,11 +321,28 @@ class ProjectCreator(QtWidgets.QDialog):
         # Connect 3d toggle to all other option visibility
         self.toggle_3d.toggled.connect(lambda yes: madlc_widget.setVisible(not yes))
         self.toggle_3d.toggled.connect(
-            lambda yes: self.bodypart_list.setVisible(not yes)
+            lambda checked_3d: unique_widget.setVisible(
+                not checked_3d and self.madlc_toggle.isChecked()
+            )
         )
         self.toggle_3d.toggled.connect(
-            lambda yes: self.individuals_list.setVisible(
-                not yes and self.madlc_toggle.isChecked()
+            lambda checked_3d: identity_widget.setVisible(
+                not checked_3d and self.madlc_toggle.isChecked()
+            )
+        )
+        self.toggle_3d.toggled.connect(
+            lambda checked_3d: self.bodypart_list.setVisible(not checked_3d)
+        )
+        self.toggle_3d.toggled.connect(
+            lambda checked_3d: self.individuals_list.setVisible(
+                not checked_3d and self.madlc_toggle.isChecked()
+            )
+        )
+        self.toggle_3d.toggled.connect(
+            lambda checked_3d: self.unique_bodyparts_list.setVisible(
+                not checked_3d
+                and self.madlc_toggle.isChecked()
+                and self.unique_toggle.isChecked()
             )
         )
 

--- a/deeplabcut/gui/tabs/create_project.py
+++ b/deeplabcut/gui/tabs/create_project.py
@@ -298,16 +298,19 @@ class ProjectCreator(QtWidgets.QDialog):
 
         # Create both DynamicTextList widgets as class attributes
         self.bodypart_list = DynamicTextList(
-            label_text="Bodyparts to track", parent=self,
+            label_text="Bodyparts to track",
+            parent=self,
         )
 
         self.individuals_list = DynamicTextList(
-            label_text="Individual names", parent=self,
+            label_text="Individual names",
+            parent=self,
         )
         self.individuals_list.setVisible(False)
 
         self.unique_bodyparts_list = DynamicTextList(
-            label_text="Unique bodyparts to track", parent=self,
+            label_text="Unique bodyparts to track",
+            parent=self,
         )
         self.unique_bodyparts_list.setVisible(False)
 
@@ -482,8 +485,8 @@ class ProjectCreator(QtWidgets.QDialog):
                                 updates["individuals"] = individuals
 
                         if (
-                            self.unique_toggle.isChecked() and
-                            self.unique_bodyparts_list is not None
+                            self.unique_toggle.isChecked()
+                            and self.unique_bodyparts_list is not None
                         ):
                             unique_bodyparts = self.unique_bodyparts_list.get_entries()
                             if len(unique_bodyparts) > 0:

--- a/deeplabcut/gui/tabs/create_project.py
+++ b/deeplabcut/gui/tabs/create_project.py
@@ -4,7 +4,7 @@
 # https://github.com/DeepLabCut/DeepLabCut
 #
 # Please see AUTHORS for contributors.
-# https://github.com/DeepLabCut/DeepLabCut/blob/master/AUTHORS
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/AUTHORS
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
@@ -276,7 +276,9 @@ class ProjectCreator(QtWidgets.QDialog):
         # Connect 3d toggle to all other option visibility
         self.toggle_3d.toggled.connect(lambda yes: madlc_widget.setVisible(not yes))
         self.toggle_3d.toggled.connect(lambda yes: self.bodypart_list.setVisible(not yes))
-        self.toggle_3d.toggled.connect(lambda yes: self.individuals_list.setVisible(not yes))
+        self.toggle_3d.toggled.connect(
+            lambda yes: self.individuals_list.setVisible(not yes and self.madlc_toggle.isChecked())
+        )
 
         # Add both lists to the horizontal layout with top alignment
         lists_layout.addWidget(self.bodypart_list, alignment=QtCore.Qt.AlignTop)
@@ -294,6 +296,8 @@ class ProjectCreator(QtWidgets.QDialog):
         docs_link: str,
     ) -> QtWidgets.QWidget:
         toggle_layout = QtWidgets.QHBoxLayout()
+        toggle_layout.setContentsMargins(0, 0, 0, 0)
+
         toggle_label = QtWidgets.QLabel(question)
         help_label = ClickableLabel(help_text, parent=self)
         help_label.setStyleSheet("text-decoration: underline; font-weight: bold;")

--- a/deeplabcut/gui/tabs/docs.py
+++ b/deeplabcut/gui/tabs/docs.py
@@ -1,0 +1,16 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+from dataclasses import dataclass
+
+BASE_URL = "https://deeplabcut.github.io/DeepLabCut/docs/"
+README = "https://deeplabcut.github.io/DeepLabCut/README.html"
+URL_3D = BASE_URL + "Overviewof3D.html"
+URL_USE_GUIDE_SCENARIO = BASE_URL + "UseOverviewGuide.html#what-scenario-do-you-have"

--- a/deeplabcut/gui/tabs/docs.py
+++ b/deeplabcut/gui/tabs/docs.py
@@ -11,4 +11,5 @@
 BASE_URL = "https://deeplabcut.github.io/DeepLabCut/docs/"
 README = "https://deeplabcut.github.io/DeepLabCut/README.html"
 URL_3D = BASE_URL + "Overviewof3D.html"
+URL_MA_CONFIGURE = BASE_URL + "maDLC_UserGuide.html#configure-the-project"
 URL_USE_GUIDE_SCENARIO = BASE_URL + "UseOverviewGuide.html#what-scenario-do-you-have"

--- a/deeplabcut/gui/tabs/docs.py
+++ b/deeplabcut/gui/tabs/docs.py
@@ -8,8 +8,6 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
-from dataclasses import dataclass
-
 BASE_URL = "https://deeplabcut.github.io/DeepLabCut/docs/"
 README = "https://deeplabcut.github.io/DeepLabCut/README.html"
 URL_3D = BASE_URL + "Overviewof3D.html"


### PR DESCRIPTION
Improvements to the UX for create project GUI:

- Buttons are now available to navigate between the different project configuration options
- Links are added to the docs
- Users can enter bodyparts, individuals and unique_bodyparts directly
- When users try to enter spaces in bodypart names, it is replaced with an underscore

GUI when it is first opened:

<img width="731" alt="Screenshot 2025-02-20 at 08 30 23" src="https://github.com/user-attachments/assets/6778ef33-575b-42db-a4e9-9eb29a91a088" />

Different configuration options:

<img width="731" alt="Screenshot 2025-02-20 at 08 30 30" src="https://github.com/user-attachments/assets/5b8d028a-ae1f-46b3-9b3b-37832b6754e8" />
 
<img width="731" alt="Screenshot 2025-02-20 at 08 30 44" src="https://github.com/user-attachments/assets/11df3e42-4d72-4d9b-8b72-fea227561e20" />

<img width="731" alt="Screenshot 2025-02-20 at 08 30 50" src="https://github.com/user-attachments/assets/2e45adf8-f028-4447-ac5a-64bf0811b79d" />

<img width="731" alt="Screenshot 2025-02-20 at 08 31 03" src="https://github.com/user-attachments/assets/e4ca249c-843c-4b66-adce-ca01a298e29e" />