### PR TITLE
Improved error handling when extracting frames fails

### DIFF
--- a/deeplabcut/generate_training_dataset/frame_extraction.py
+++ b/deeplabcut/generate_training_dataset/frame_extraction.py
@@ -401,13 +401,14 @@ def extract_frames(
                         )
                 else:
                     print(
-                        "Please implement this method yourself and send us a pull request! Otherwise, choose 'uniform' or 'kmeans'."
+                        "Please implement this method yourself and send us a pull "
+                        "request! Otherwise, choose 'uniform' or 'kmeans'."
                     )
                     frames2pick = []
 
                 if not len(frames2pick):
                     print("Frame selection failed...")
-                    return
+                    return []
 
                 output_path = (
                     Path(config).parents[0] / "labeled-data" / Path(video).stem
@@ -464,7 +465,7 @@ def extract_frames(
 
         if all(has_failed):
             print("Frame extraction failed. Video files must be corrupted.")
-            return
+            return has_failed
         elif any(has_failed):
             print("Although most frames were extracted, some were invalid.")
         else:
@@ -475,6 +476,7 @@ def extract_frames(
             "\nYou can now label the frames using the function 'label_frames' "
             "(Note, you should label frames extracted from diverse videos (and many videos; we do not recommend training on single videos!))."
         )
+        return has_failed
 
     elif mode == "match":
         import cv2

--- a/deeplabcut/gui/tabs/extract_frames.py
+++ b/deeplabcut/gui/tabs/extract_frames.py
@@ -85,6 +85,8 @@ class ExtractFrames(DefaultTab):
     def __init__(self, root, parent, h1_description):
         super(ExtractFrames, self).__init__(root, parent, h1_description)
 
+        self.worker = None
+        self.thread = None
         self._set_page()
 
     def _set_page(self):
@@ -238,7 +240,8 @@ class ExtractFrames(DefaultTab):
             userfeedback=False,
             videos_list=self.video_selection_widget.files or None,
         )
-        self.worker, self.thread = move_to_separate_thread(func)
+
+        self.worker, self.thread = move_to_separate_thread(func, capture_outputs=True)
         self.worker.finished.connect(lambda: self.ok_button.setEnabled(True))
         self.worker.finished.connect(lambda: self.root._progress_bar.hide())
         self.thread.finished.connect(self._show_success_message)
@@ -247,13 +250,37 @@ class ExtractFrames(DefaultTab):
         self.root._progress_bar.show()
 
     def _show_success_message(self):
+        message = "Failed to create worker: it is None"
+        root_message = "failed to extract frames: worker is None"
+        if self.worker is not None:
+            failed: list[bool] = self.worker.outputs
+            if failed is None:
+                # outputs are None during manual frame extraction
+                return
+
+            if len(failed) == 0:
+                message = (
+                    "Frame extraction failed. Please check your terminal output "
+                    "for more information."
+                )
+            elif all(failed):
+                message = "Frame extraction failed. Video files must be corrupted."
+            elif any(failed):
+                message = "Although most frames were extracted, some were invalid."
+                root_message = "failed to extract (some) frames"
+            else:
+                message = (
+                    "Frames were successfully extracted, for the videos of interest."
+                )
+                root_message = "successfully extracted frames"
+
         msg = QtWidgets.QMessageBox()
         msg.setIcon(QtWidgets.QMessageBox.Information)
-        msg.setText("Frames were successfully extracted, for the videos of interest.")
+        msg.setText(message)
         msg.setWindowTitle("Info")
         msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
         msg.exec_()
-        self.root.writer.write("Frames successfully extracted.")
+        self.root.writer.write(root_message)
 
     def _check_symlink(self, video_path: Union[str, Path]) -> Path:
         """Checks that a video is in the DeepLabCut 'videos' folder

--- a/deeplabcut/gui/tabs/extract_frames.py
+++ b/deeplabcut/gui/tabs/extract_frames.py
@@ -253,7 +253,7 @@ class ExtractFrames(DefaultTab):
         message = "Failed to create worker: it is None"
         root_message = "failed to extract frames: worker is None"
         if self.worker is not None:
-            failed: list[bool] = self.worker.outputs
+            failed = self.worker.outputs
             if failed is None:
                 # outputs are None during manual frame extraction
                 return

--- a/deeplabcut/gui/utils.py
+++ b/deeplabcut/gui/utils.py
@@ -8,7 +8,7 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
-from typing import Tuple
+from typing import Tuple, Callable
 
 from PySide6 import QtCore
 import re
@@ -26,9 +26,25 @@ class Worker(QtCore.QObject):
         self.finished.emit()
 
 
-def move_to_separate_thread(func):
+class CaptureWorker(Worker):
+    """A worker that captures outputs from methods that are run."""
+
+    def __init__(self, func: Callable):
+        super().__init__(func)
+        self.outputs = None
+
+    def run(self):
+        self.outputs = self.func()
+        self.finished.emit()
+
+
+def move_to_separate_thread(func: Callable, capture_outputs: bool = False):
     thread = QtCore.QThread()
-    worker = Worker(func)
+    if capture_outputs:
+        worker = CaptureWorker(func)
+    else:
+        worker = Worker(func)
+
     worker.finished.connect(worker.deleteLater)
     worker.moveToThread(thread)
     thread.started.connect(worker.run)

--- a/deeplabcut/gui/utils.py
+++ b/deeplabcut/gui/utils.py
@@ -8,7 +8,7 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
-from typing import Tuple, Callable
+from typing import Callable, Tuple
 
 from PySide6 import QtCore
 import re


### PR DESCRIPTION
This pull request improves the handling of errors when `extract_frames` fails. Changes:

- `deeplabcut.extract_frames` now returns 
  - a list containing a boolean indicating whether frame extraction failed for each image
  - an empty list if no frames could be selected for extraction
  - the GUI parses the result from `extract_frames` to display a failure message if frames were not extracted correctly