### PR TITLE
Improve tracklet creation for ID-only tracking

### DIFF
--- a/deeplabcut/core/metrics/identity.py
+++ b/deeplabcut/core/metrics/identity.py
@@ -67,6 +67,12 @@ def compute_identity_scores(
             # assign ground truth keypoints to the closest prediction, so the ID score
             # is the closest possible to the ID score computed with "ground truth"
             indices_gt = np.flatnonzero(np.all(~np.isnan(bpt_gt), axis=1))
+
+            # Remove NaN predictions from the bodypart predictions
+            indices_pred = np.all(np.isfinite(bpt_pred), axis=1)
+            bpt_pred = bpt_pred[indices_pred]
+            bpt_id_scores = bpt_id_scores[indices_pred]
+
             neighbors = find_closest_neighbors(bpt_gt[indices_gt], bpt_pred, k=3)
             found = neighbors != -1
             indices = np.flatnonzero(all_bpts == bpt)

--- a/deeplabcut/pose_estimation_pytorch/apis/tracklets.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/tracklets.py
@@ -10,7 +10,6 @@
 #
 import os
 import pickle
-import re
 import warnings
 from pathlib import Path
 from typing import Dict, List, Optional, Union

--- a/deeplabcut/pose_estimation_pytorch/apis/tracklets.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/tracklets.py
@@ -216,7 +216,7 @@ def convert_detections2tracklets(
                         continue
 
                     animals = np.stack([a for a in assemblies])
-                    animals[animals[..., 2] < 0, :2] = np.nan
+                    animals[np.any(animals[..., :3] < 0, axis=-1), :2] = np.nan
                     animals[animals[..., 2] < pcutoff, :2] = np.nan
                     animal_mask = ~np.all(np.isnan(animals[:, :, :2]), axis=(1, 2))
                     if ~np.any(animal_mask):

--- a/tests/pose_estimation_pytorch/apis/test_apis_evaluate.py
+++ b/tests/pose_estimation_pytorch/apis/test_apis_evaluate.py
@@ -277,7 +277,15 @@ def test_evaluate_with_pcutoff(
 
 @patch("deeplabcut.pose_estimation_pytorch.apis.evaluation.predict", PREDICT)
 @pytest.mark.parametrize(
-    "pcutoff", [0.4, 0.6, 0.8, [0.3, 0.5, 0.7, 0.4, 0.6], [0.25, 0.43, 0.61, 0.46, 0.92]],
+    "pcutoff", [
+        0.4,
+        0.6,
+        0.8,
+        [0.3, 0.5, 0.7, 0.4, 0.6],
+        [0.25, 0.43, 0.61, 0.46, 0.92],
+        [0.12, 0.15, 0.92, 0.97, 0.85],
+        [0.92, 0.97, 0.85, 0.12, 0.15],
+    ],
 )
 @pytest.mark.parametrize(
     "keypoints", [


### PR DESCRIPTION
This pull request fixes tracklet creation with `identity_only=True`. It

- only keeps valid predictions to assign identity to
- removes poses with confidence below the inference `pcutoff`
- updates the way the softmax is computed to assign each assembly (total score across keypoints with a given identity instead of average score)

It also fixes identity metric computation when NaNs are in the predictions.