### PR TITLE
Error handling when extracting frames fails in the GUI

### DIFF
--- a/deeplabcut/generate_training_dataset/frame_extraction.py
+++ b/deeplabcut/generate_training_dataset/frame_extraction.py
@@ -401,13 +401,14 @@ def extract_frames(
                         )
                 else:
                     print(
-                        "Please implement this method yourself and send us a pull request! Otherwise, choose 'uniform' or 'kmeans'."
-                    )
+                         "Please implement this method yourself and send us a pull "
+                         "request! Otherwise, choose 'uniform' or 'kmeans'."
+                     )
                     frames2pick = []
 
                 if not len(frames2pick):
                     print("Frame selection failed...")
-                    return
+                    return []
 
                 output_path = (
                     Path(config).parents[0] / "labeled-data" / Path(video).stem
@@ -464,7 +465,7 @@ def extract_frames(
 
         if all(has_failed):
             print("Frame extraction failed. Video files must be corrupted.")
-            return
+            return has_failed
         elif any(has_failed):
             print("Although most frames were extracted, some were invalid.")
         else:

--- a/deeplabcut/generate_training_dataset/frame_extraction.py
+++ b/deeplabcut/generate_training_dataset/frame_extraction.py
@@ -476,6 +476,7 @@ def extract_frames(
             "\nYou can now label the frames using the function 'label_frames' "
             "(Note, you should label frames extracted from diverse videos (and many videos; we do not recommend training on single videos!))."
         )
+        return has_failed
 
     elif mode == "match":
         import cv2

--- a/deeplabcut/gui/utils.py
+++ b/deeplabcut/gui/utils.py
@@ -8,6 +8,8 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
+from typing import Callable
+
 from PySide6 import QtCore
 
 
@@ -23,9 +25,25 @@ class Worker(QtCore.QObject):
         self.finished.emit()
 
 
-def move_to_separate_thread(func):
+class CaptureWorker(Worker):
+    """A worker that captures outputs from methods that are run."""
+
+    def __init__(self, func: Callable):
+        super().__init__(func)
+        self.outputs = None
+
+    def run(self):
+        self.outputs = self.func()
+        self.finished.emit()
+
+
+def move_to_separate_thread(func: Callable, capture_outputs: bool = False):
     thread = QtCore.QThread()
-    worker = Worker(func)
+    if capture_outputs:
+        worker = CaptureWorker(func)
+    else:
+        worker = Worker(func)
+
     worker.finished.connect(worker.deleteLater)
     worker.moveToThread(thread)
     thread.started.connect(worker.run)


### PR DESCRIPTION
This pull request improves the handling of errors when `extract_frames` fails. Changes:

- `deeplabcut.extract_frames` now returns 
  - a list containing a boolean indicating whether frame extraction failed for each image
  - an empty list if no frames could be selected for extraction
  - the GUI parses the result from `extract_frames` to display a failure message if frames were not extracted correctly

Merges into main instead of `pytorch_dlc`. Replaces #2898.