### PR TITLE
Fix testscript_superanimal_create_pretrained_project

### DIFF
--- a/examples/testscript_superanimal_create_pretrained_project.py
+++ b/examples/testscript_superanimal_create_pretrained_project.py
@@ -21,7 +21,7 @@ import deeplabcut
 if __name__ == "__main__":
     superanimal_name = "superanimal_quadruped"
     working_dir = Path(__file__).resolve().parent
-    video_dir = working_dir / "openfield-Pranav-2018-10-30/videos/m3v1mp4short.mp4"
+    video_dir = working_dir / "openfield-Pranav-2018-10-30/videos/m3v1mp4.mp4"
     project_name = "pretrained"
 
     deeplabcut.create_pretrained_project(


### PR DESCRIPTION
_testscript_superanimal_create_pretrained_project.py_ was using a video in _examples/openfield-Pranav-2018-10-30/videos/_ that is originally not present in the directory, and created by another testscript.

This PR fixes this by using the original video that is always present in _examples/openfield-Pranav-2018-10-30/videos/_ .