### PR TITLE
Fix circular import

### DIFF
--- a/deeplabcut/create_project/modelzoo.py
+++ b/deeplabcut/create_project/modelzoo.py
@@ -22,8 +22,8 @@ from dlclibrary.dlcmodelzoo.modelzoo_download import (
 )
 
 import deeplabcut
-from deeplabcut import Engine
 from deeplabcut.core.config import read_config_as_dict, write_config
+from deeplabcut.core.engine import Engine
 from deeplabcut.generate_training_dataset.metadata import (
     TrainingDatasetMetadata,
     ShuffleMetadata,


### PR DESCRIPTION
Fix circular import introduced in https://github.com/DeepLabCut/DeepLabCut/pull/2897, which was logging
`DLC loaded in light mode; you cannot use any GUI (labeling, relabeling and standalone GUI)`
when launching the DLC GUI.