### PR TITLE
Default net type in config set according to engine

### DIFF
--- a/deeplabcut/create_project/new.py
+++ b/deeplabcut/create_project/new.py
@@ -14,7 +14,9 @@ import os
 import shutil
 import warnings
 from pathlib import Path
+
 from deeplabcut import DEBUG
+from deeplabcut.core.engine import Engine
 from deeplabcut.utils.auxfun_videos import VideoReader
 
 
@@ -260,8 +262,15 @@ def create_new_project(
             ["bodypart2", "bodypart3"],
             ["bodypart1", "bodypart3"],
         ]
-        cfg_file["default_augmenter"] = "multi-animal-imgaug"
-        cfg_file["default_net_type"] = "dlcrnet_ms5"
+        engine = cfg_file.get("engine")
+        if engine in Engine.PYTORCH.aliases:
+            cfg_file["default_augmenter"] = "albumentations"
+            cfg_file["default_net_type"] = "rtmpose_m"
+        elif engine in Engine.TF.aliases:
+            cfg_file["default_augmenter"] = "multi-animal-imgaug"
+            cfg_file["default_net_type"] = "dlcrnet_ms5"
+        else:
+            raise ValueError(f"Unknown or undefined engine {engine}")
         cfg_file["default_track_method"] = "ellipse"
     else:
         cfg_file, ruamelFile = auxiliaryfunctions.create_config_template()

--- a/deeplabcut/create_project/new.py
+++ b/deeplabcut/create_project/new.py
@@ -265,7 +265,7 @@ def create_new_project(
         engine = cfg_file.get("engine")
         if engine in Engine.PYTORCH.aliases:
             cfg_file["default_augmenter"] = "albumentations"
-            cfg_file["default_net_type"] = "rtmpose_m"
+            cfg_file["default_net_type"] = "resnet_50"
         elif engine in Engine.TF.aliases:
             cfg_file["default_augmenter"] = "multi-animal-imgaug"
             cfg_file["default_net_type"] = "dlcrnet_ms5"

--- a/deeplabcut/gui/tabs/create_training_dataset.py
+++ b/deeplabcut/gui/tabs/create_training_dataset.py
@@ -419,6 +419,9 @@ class CreateTrainingDataset(DefaultTab):
         if default_net is None:
             default_net = self.root.cfg.get("default_net_type", "resnet_50")
 
+        if engine == Engine.TF and default_net not in DLCParams.NNETS or engine == Engine.PYTORCH and default_net not in available_models():
+            default_net = "resnet_50"
+
         if default_net in nets:
             self.net_choice.setCurrentIndex(nets.index(default_net))
 

--- a/deeplabcut/gui/tabs/create_training_dataset.py
+++ b/deeplabcut/gui/tabs/create_training_dataset.py
@@ -24,16 +24,17 @@ from deeplabcut.core.engine import Engine
 from deeplabcut.core.weight_init import WeightInitialization
 from deeplabcut.generate_training_dataset import get_existing_shuffle_indices
 from deeplabcut.generate_training_dataset.metadata import get_shuffle_engine
-from deeplabcut.gui.displays.shuffle_metadata_viewer import ShuffleMetadataViewer
-from deeplabcut.gui.dlc_params import DLCParams
 from deeplabcut.gui.components import (
     DefaultTab,
     ShuffleSpinBox,
     _create_grid_layout,
     _create_label_widget,
 )
+from deeplabcut.gui.displays.shuffle_metadata_viewer import ShuffleMetadataViewer
+from deeplabcut.gui.dlc_params import DLCParams
 from deeplabcut.gui.widgets import launch_napari
 from deeplabcut.modelzoo import build_weight_init
+from deeplabcut.pose_estimation_pytorch import available_models
 from deeplabcut.utils.auxiliaryfunctions import (
     get_data_and_metadata_filenames,
     get_training_set_folder,
@@ -394,9 +395,6 @@ class CreateTrainingDataset(DefaultTab):
             if not self.root.is_multianimal:
                 nets.remove("dlcrnet_ms5")
         else:
-            # FIXME: Circular imports make it impossible to import this at the top
-            from deeplabcut.pose_estimation_pytorch import available_models
-
             nets = available_models()
             net_filter = self.get_net_filter()
             default_net = self.get_default_net()

--- a/deeplabcut/gui/tabs/create_training_dataset.py
+++ b/deeplabcut/gui/tabs/create_training_dataset.py
@@ -419,7 +419,12 @@ class CreateTrainingDataset(DefaultTab):
         if default_net is None:
             default_net = self.root.cfg.get("default_net_type", "resnet_50")
 
-        if engine == Engine.TF and default_net not in DLCParams.NNETS or engine == Engine.PYTORCH and default_net not in available_models():
+        if (
+            engine == Engine.TF
+            and default_net not in DLCParams.NNETS
+            or engine == Engine.PYTORCH
+            and default_net not in available_models()
+        ):
             default_net = "resnet_50"
 
         if default_net in nets:

--- a/examples/testscript_multianimal.py
+++ b/examples/testscript_multianimal.py
@@ -332,6 +332,7 @@ if __name__ == "__main__":
     deeplabcut.create_multianimaltraining_dataset(
         config_path,
         Shuffles=[4, 5],
+        net_type=NET,
         trainIndices=[trainIndices, trainIndices],
         testIndices=[testIndices, testIndices],
         engine=ENGINE,

--- a/examples/testscript_multianimal.py
+++ b/examples/testscript_multianimal.py
@@ -118,7 +118,10 @@ if __name__ == "__main__":
 
     print("Creating train dataset...")
     deeplabcut.create_multianimaltraining_dataset(
-        config_path, net_type=NET, crop_size=(200, 200), engine=ENGINE,
+        config_path,
+        net_type=NET,
+        crop_size=(200, 200),
+        engine=ENGINE,
     )
     print("Train dataset created.")
 


### PR DESCRIPTION
Previously, when a new project was created, `default_net_type` and `default_augmenter` were both set respectively to `multi-animal-imgaug` and `dlcrnet_ms5`, regardless of `engine` being set to `pytorch` by default. `dlcrnet_ms5` and `multi-animal-imgaug` being not implemented with `engine = pytorch`, the default _Network architecture_ in the GUI was set to _animaltokenpose_base_.

This PR sets `default_net_type` and `default_augmenter` in the _config.yaml_ according to the specified `engine`.