### PR TITLE
Fix: check assembly length before getting first element.

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/apis/tracklets.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/tracklets.py
@@ -225,7 +225,7 @@ def build_tracklets(
         tracklets[0] = {}
         for index in tqdm(range(num_frames)):
             assemblies = assemblies_data.get(index)
-            if assemblies is None:
+            if assemblies is None or len(assemblies) == 0:
                 continue
 
             assembly = np.asarray(assemblies[0].data)


### PR DESCRIPTION
Closes #2932.

Checks that there is at least one assembly in the list before getting the first element when building tracklets.