### PR TITLE
Implement `snapshots_to_evaluate` for PyTorch models 

### DIFF
--- a/deeplabcut/compat.py
+++ b/deeplabcut/compat.py
@@ -562,6 +562,7 @@ def evaluate_network(
             plotting=plotting,
             show_errors=show_errors,
             comparison_bodyparts=comparisonbodyparts,
+            snapshots_to_evaluate=snapshots_to_evaluate,
             per_keypoint_evaluation=per_keypoint_evaluation,
             modelprefix=modelprefix,
             pcutoff=pcutoff,

--- a/deeplabcut/pose_estimation_pytorch/apis/evaluation.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/evaluation.py
@@ -677,6 +677,7 @@ def evaluate_network(
     plotting: bool | str = False,
     show_errors: bool = True,
     transform: A.Compose = None,
+    snapshots_to_evaluate: list[str] | None = None,
     comparison_bodyparts: str | list[str] | None = None,
     per_keypoint_evaluation: bool = False,
     modelprefix: str = "",
@@ -708,6 +709,8 @@ def evaluate_network(
         show_errors: display train and test errors.
         transform: transformation pipeline for evaluation
             ** Should normalise the data the same way it was normalised during training **
+        snapshots_to_evaluate: List of snapshot names to evaluate (e.g. ["snapshot-50",
+            "snapshot-75"]). If defined, `snapshotindex` will be ignored.
         comparison_bodyparts: A subset of the bodyparts for which to compute the
             evaluation metrics.
         per_keypoint_evaluation: Compute the train and test RMSE for each keypoint, and
@@ -781,6 +784,7 @@ def evaluate_network(
                 snapshotindex,
                 model_folder=loader.model_folder,
                 task=loader.pose_task,
+                snapshot_filter=snapshots_to_evaluate,
             )
 
             detector_snapshots = [None]


### PR DESCRIPTION
Closes #2934.

This pull request implements `snapshots_to_evaluate` for PyTorch models.

- adds `snapshots_to_evaluate` as a parameter to `pose_estimation_pytorch.evaluate_network`
- adds a `snapshot_filter` to `get_model_snapshots`
