### PR TITLE
Fix missing detector in Create Training Dataset GUI with animaltokenpose and rtmpose architectures

### DIFF
--- a/deeplabcut/gui/tabs/create_training_dataset.py
+++ b/deeplabcut/gui/tabs/create_training_dataset.py
@@ -34,7 +34,7 @@ from deeplabcut.gui.displays.shuffle_metadata_viewer import ShuffleMetadataViewe
 from deeplabcut.gui.dlc_params import DLCParams
 from deeplabcut.gui.widgets import launch_napari
 from deeplabcut.modelzoo import build_weight_init
-from deeplabcut.pose_estimation_pytorch import available_models
+from deeplabcut.pose_estimation_pytorch import available_models, is_model_top_down
 from deeplabcut.utils.auxiliaryfunctions import (
     get_data_and_metadata_filenames,
     get_training_set_folder,
@@ -238,7 +238,7 @@ class CreateTrainingDataset(DefaultTab):
 
                     # try importing TF so they can't create shuffles for it if they
                     # don't have it installed
-                elif engine == Engine.PYTORCH and "top_down" in net_type:
+                elif engine == Engine.PYTORCH and is_model_top_down(net_type):
                     detector_type = self.detector_choice.currentText()
 
                 try:
@@ -463,7 +463,7 @@ class CreateTrainingDataset(DefaultTab):
         if net_choice is None:
             net_choice = self.net_choice.currentText()
 
-        if "top_down" in net_choice:
+        if is_model_top_down(net_choice):
             self.detector_label.show()
             self.detector_choice.show()
         else:

--- a/deeplabcut/pose_estimation_pytorch/__init__.py
+++ b/deeplabcut/pose_estimation_pytorch/__init__.py
@@ -34,6 +34,7 @@ from deeplabcut.pose_estimation_pytorch.apis import (
 from deeplabcut.pose_estimation_pytorch.config import (
     available_detectors,
     available_models,
+    is_model_top_down,
 )
 from deeplabcut.pose_estimation_pytorch.data import (
     build_transforms,

--- a/deeplabcut/pose_estimation_pytorch/config/__init__.py
+++ b/deeplabcut/pose_estimation_pytorch/config/__init__.py
@@ -20,6 +20,7 @@ from deeplabcut.pose_estimation_pytorch.config.utils import (
     update_config,
     update_config_by_dotpath,
 )
+
 # For backwards compatibility
 from deeplabcut.core.config import (
     read_config_as_dict,

--- a/deeplabcut/pose_estimation_pytorch/config/__init__.py
+++ b/deeplabcut/pose_estimation_pytorch/config/__init__.py
@@ -16,6 +16,7 @@ from deeplabcut.pose_estimation_pytorch.config.make_pose_config import (
 from deeplabcut.pose_estimation_pytorch.config.utils import (
     available_detectors,
     available_models,
+    is_model_top_down,
     update_config,
     update_config_by_dotpath,
 )

--- a/deeplabcut/pose_estimation_pytorch/config/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/config/utils.py
@@ -257,6 +257,29 @@ def available_models() -> list[str]:
     return list(sorted(models))
 
 
+def is_model_top_down(net_type: str) -> bool:
+    """Checks whenever a given net_type is top-down or not"""
+    if net_type not in available_models():
+        raise ValueError(f"Model {net_type} is not part of available models, which are {str(available_models())}")
+
+    configs_dir = get_config_folder_path()
+    backbones = load_backbones(configs_dir)
+
+    if net_type.startswith("top_down_"):
+        return True
+    elif net_type in backbones:
+        return False
+
+    configs_dir = get_config_folder_path()
+
+    architecture = net_type.split("_")[0]
+
+    cfg_path = configs_dir / architecture / f"{net_type}.yaml"
+    model_cfg = read_config_as_dict(cfg_path)
+
+    return model_cfg.get("method", "BU").upper() == "TD"
+
+
 def available_detectors() -> list[str]:
     """Returns: all the possible detectors that can be used"""
     return load_detectors(get_config_folder_path())

--- a/deeplabcut/pose_estimation_pytorch/config/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/config/utils.py
@@ -260,7 +260,9 @@ def available_models() -> list[str]:
 def is_model_top_down(net_type: str) -> bool:
     """Checks whenever a given net_type is top-down or not"""
     if net_type not in available_models():
-        raise ValueError(f"Model {net_type} is not part of available models, which are {str(available_models())}")
+        raise ValueError(
+            f"Model {net_type} is not part of available models, which are {str(available_models())}"
+        )
 
     configs_dir = get_config_folder_path()
     backbones = load_backbones(configs_dir)


### PR DESCRIPTION
In the Create Training Dataset GUI tab, the detector-related widgets were not shown with _animaltokenpose_ and _rtmpose_ architectures, despite they are Top-Down architectures. This Pull Request fixes this.