### PR TITLE
Unsupervised ID tracking through the GUI - `set` of videos instead of `list`

### DIFF
--- a/deeplabcut/gui/tabs/unsupervised_id_tracking.py
+++ b/deeplabcut/gui/tabs/unsupervised_id_tracking.py
@@ -112,7 +112,7 @@ class UnsupervizedIdTracking(DefaultTab):
 
     def run_transformer(self):
         config = self.root.config
-        videos = self.files
+        videos = [v for v in self.files]
         videotype = self.video_selection_widget.videotype_widget.currentText()
         n_tracks = self.num_animals_in_videos.value()
         shuffle = self.shuffle.value()

--- a/deeplabcut/pose_tracking_pytorch/create_dataset.py
+++ b/deeplabcut/pose_tracking_pytorch/create_dataset.py
@@ -96,6 +96,13 @@ def create_triplets_dataset(
 
         method = trackingutils.TRACK_METHODS[track_method]
         track_file = os.path.join(destfolder, vname + dlcscorer + f"{method}.pickle")
+        if not Path(track_file).exists():
+            raise ValueError(
+                f"Tracklet file {track_file} does not exist. Please run "
+                f"`analyze_videos` with the {method} tracker before using the ReID "
+                "transformer."
+            )
+
         out_fname = os.path.join(destfolder, vname + dlcscorer + "_triplet_vector.npy")
         create_train_using_pickle(
             feature_fname, track_file, out_fname, n_triplets=n_triplets


### PR DESCRIPTION
Closes #2949

When running unsupervised ID tracking in the GUI, the videos are passed as a set to `deeplabcut.transformer_reID` when it expects a list. This PR fixes the issue, and adds a clearer error when users run `transformer_reID` before analyzing videos.