### PR TITLE
`create_training_model_comparison`: check that `existing_shuffles` is not empty

### DIFF
--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -1542,7 +1542,11 @@ def create_training_model_comparison(
     else:
         pass
 
-    largestshuffleindex = get_existing_shuffle_indices(cfg)[-1] + 1
+    existing_shuffles = get_existing_shuffle_indices(cfg)
+    if len(existing_shuffles) == 0:
+        largestshuffleindex = 0
+    else:
+        largestshuffleindex = existing_shuffles[-1] + 1
 
     shuffle_list = []
     for shuffle in range(num_shuffles):


### PR DESCRIPTION
Closes #2954

Checks that the `existing_shuffles` is not empty, and sets the first shuffle index to 0 when it is.