### PR TITLE
lower default LR to 5e-4 for ResNets and CSPNeXt

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/config/backbones/cspnext_m.yaml
+++ b/deeplabcut/pose_estimation_pytorch/config/backbones/cspnext_m.yaml
@@ -11,7 +11,7 @@ runner:
   optimizer:
     type: AdamW
     params:
-      lr: 0.001
+      lr: 5e-4
   scheduler:
     type: LRListScheduler
     params:

--- a/deeplabcut/pose_estimation_pytorch/config/backbones/cspnext_s.yaml
+++ b/deeplabcut/pose_estimation_pytorch/config/backbones/cspnext_s.yaml
@@ -11,7 +11,7 @@ runner:
   optimizer:
     type: AdamW
     params:
-      lr: 0.001
+      lr: 5e-4
   scheduler:
     type: LRListScheduler
     params:

--- a/deeplabcut/pose_estimation_pytorch/config/backbones/cspnext_x.yaml
+++ b/deeplabcut/pose_estimation_pytorch/config/backbones/cspnext_x.yaml
@@ -11,7 +11,7 @@ runner:
   optimizer:
     type: AdamW
     params:
-      lr: 0.001
+      lr: 5e-4
   scheduler:
     type: LRListScheduler
     params:

--- a/deeplabcut/pose_estimation_pytorch/config/backbones/resnet_101.yaml
+++ b/deeplabcut/pose_estimation_pytorch/config/backbones/resnet_101.yaml
@@ -10,7 +10,7 @@ runner:
   optimizer:
     type: AdamW
     params:
-      lr: 0.001
+      lr: 5e-4
   scheduler:
     type: LRListScheduler
     params:

--- a/deeplabcut/pose_estimation_pytorch/config/backbones/resnet_50.yaml
+++ b/deeplabcut/pose_estimation_pytorch/config/backbones/resnet_50.yaml
@@ -10,7 +10,7 @@ runner:
   optimizer:
     type: AdamW
     params:
-      lr: 0.001
+      lr: 5e-4
   scheduler:
     type: LRListScheduler
     params:


### PR DESCRIPTION
Addresses the issue found in #2922. For some datasets, setting `1e-3` as an initial learning rate is too aggressive and prevents the model from learning. This PR changes the default to `5e-4` for ResNets and CSPNeXt backbones (other models already have lower learning rates as default), which resolved the issue on datasets where it occurred and led to more stable learning.