### PR TITLE
Clarify the CTD evaluation conditions and fix the variable reference used for URL access

### DIFF
--- a/examples/COLAB/COLAB_BUCTD_and_CTD_tracking.ipynb
+++ b/examples/COLAB/COLAB_BUCTD_and_CTD_tracking.ipynb
@@ -1968,7 +1968,7 @@
    "source": [
     "If your CTD model is well trained, it should now outperform the performance of the BU model who's predictions it uses as conditions!\n",
     "\n",
-    "Note that the model is evaluated using pose conditions that were created with generative sampling. When you evaluate the network with the `evaluate_network` method, the performance will be different as you're using the actual conditions from the bottom-up model we trained first."
+    "Note that during training, the model is evaluated using pose conditions that were created with generative sampling. When you evaluate the network with the `evaluate_network` method, the performance will be different as you're using the actual conditions from the bottom-up model we trained first."
    ]
   },
   {
@@ -2117,7 +2117,7 @@
     "        with ZipFile(BytesIO(r.content)) as zf:\n",
     "            zf.extractall(path=download_path)\n",
     "else:\n",
-    "    raise ValueError(f\"The URL {url_record} could not be reached.\")\n",
+    "    raise ValueError(f\"The URL {url_video_record} could not be reached.\")\n",
     "\n",
     "# Check that the video was downloaded\n",
     "src_video_path = download_path / \"demo-me-2021-07-14\" / \"videos\" / video_name\n",


### PR DESCRIPTION
This pull request includes two updates to the `examples/COLAB/COLAB_BUCTD_and_CTD_tracking.ipynb` file, focusing on clarifying documentation and fixing a variable reference.

### Documentation Improvement:
* Clarified that during training, the CTD model is evaluated using pose conditions created with generative sampling.

### Bug Fix:
* Corrected a variable reference in an error message from `url_record` to `url_video_record` to match the intended variable name.