### PR TITLE
Improve CTD preprocessors pipeline

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/data/preprocessor.py
+++ b/deeplabcut/pose_estimation_pytorch/data/preprocessor.py
@@ -19,10 +19,7 @@ import albumentations as A
 import numpy as np
 import torch
 
-from deeplabcut.pose_estimation_pytorch.data.image import (
-    load_image,
-    top_down_crop
-)
+from deeplabcut.pose_estimation_pytorch.data.image import load_image, top_down_crop
 from deeplabcut.pose_estimation_pytorch.data.utils import bbox_from_keypoints
 
 

--- a/deeplabcut/pose_estimation_pytorch/data/preprocessor.py
+++ b/deeplabcut/pose_estimation_pytorch/data/preprocessor.py
@@ -353,7 +353,12 @@ class ToTensor(Preprocessor):
 
 
 class ToBatch(Preprocessor):
-    """TODO"""
+    """Adds a batch dimension to the image tensor.
+
+    This preprocessor is used to convert a single image tensor into a batched format
+    by unsqueezing along the 0th dimension. This is typically required before passing
+    the image to models that expect batched input (i.e., shape `[B, C, H, W]`).
+    """
 
     def __call__(self, image: Image, context: Context) -> tuple[np.ndarray, Context]:
         return image.unsqueeze(0), context

--- a/deeplabcut/pose_estimation_pytorch/data/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/data/utils.py
@@ -10,6 +10,7 @@
 #
 from __future__ import annotations
 
+import warnings
 from collections import defaultdict
 from functools import reduce, lru_cache
 from pathlib import Path
@@ -56,8 +57,10 @@ def bbox_from_keypoints(
         keypoints = np.expand_dims(keypoints, axis=0)
 
     bboxes = np.full((keypoints.shape[0], 4), np.nan)
-    bboxes[:, :2] = np.nanmin(keypoints[..., :2], axis=1) - margin  # X1, Y1
-    bboxes[:, 2:4] = np.nanmax(keypoints[..., :2], axis=1) + margin  # X2, Y2
+    with warnings.catch_warnings():  # silence warnings when all pose confidence levels are <= 0
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        bboxes[:, :2] = np.nanmin(keypoints[..., :2], axis=1) - margin  # X1, Y1
+        bboxes[:, 2:4] = np.nanmax(keypoints[..., :2], axis=1) + margin  # X2, Y2
 
     # can have NaNs if some individuals have no visible keypoints
     bboxes = np.nan_to_num(bboxes, nan=0)

--- a/deeplabcut/pose_estimation_pytorch/data/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/data/utils.py
@@ -412,7 +412,7 @@ def _annotation_to_keypoints(annotation: dict, h: int, w: int) -> np.array:
 
     Returns:
         keypoints: np.array where the first two columns are x and y coordinates of the
-    
+
     """
     # we don't mess up visibility flags here
     return annotation["keypoints"].reshape(-1, 3)

--- a/tests/pose_estimation_pytorch/data/test_preprocessor.py
+++ b/tests/pose_estimation_pytorch/data/test_preprocessor.py
@@ -29,21 +29,21 @@ from deeplabcut.pose_estimation_pytorch.data.preprocessor import (
             "resize_transform": {"height": 5, "width": 4, "keep_ratio": True},
             "output_shape": (2, 4, 4),
             "padded_shape": (5, 4, 4),  # single offset as not a batch
-            "output_context": {"offsets": (0, 0), "scales": (1, 1)}
+            "output_context": {"offsets": (0, 0), "scales": (1, 1)},
         },
         {
             "image_shape": (1, 2, 4, 4),  # as batch
             "resize_transform": {"height": 10, "width": 4, "keep_ratio": True},
             "output_shape": (1, 2, 4, 4),
             "padded_shape": (1, 10, 4, 4),
-            "output_context": {"offsets": [(0, 0)], "scales": [(1, 1)]}
+            "output_context": {"offsets": [(0, 0)], "scales": [(1, 1)]},
         },
         {
             "image_shape": (2, 4, 3),
             "resize_transform": {"height": 10, "width": 8, "keep_ratio": True},
             "output_shape": (4, 8, 3),
             "padded_shape": (10, 8, 3),
-            "output_context": {"offsets": (0, 0), "scales": (0.5, 0.5)}
+            "output_context": {"offsets": (0, 0), "scales": (0.5, 0.5)},
         },
     ],
 )

--- a/tests/pose_estimation_pytorch/data/test_preprocessor.py
+++ b/tests/pose_estimation_pytorch/data/test_preprocessor.py
@@ -12,9 +12,13 @@
 import albumentations as A
 import numpy as np
 import pytest
+from albumentations import BaseCompose
 
 from deeplabcut.pose_estimation_pytorch.data.transforms import build_resize_transforms
-from deeplabcut.pose_estimation_pytorch.data.preprocessor import AugmentImage
+from deeplabcut.pose_estimation_pytorch.data.preprocessor import (
+    AugmentImage,
+    build_conditional_top_down_preprocessor,
+)
 
 
 @pytest.mark.parametrize(
@@ -59,3 +63,116 @@ def test_augment_image_rescaling(data):
     assert np.sum(transformed_image) == np.sum(np.ones(data["output_shape"]))
     assert context == data["output_context"]
     assert transformed_image.shape == data["padded_shape"]
+
+
+ctd_preprocessor = build_conditional_top_down_preprocessor(
+    color_mode="RGB",
+    transform=A.Compose(
+        build_resize_transforms({"height": 100, "width": 100, "keep_ratio": True}),
+        keypoint_params=A.KeypointParams("xy", remove_invisible=False),
+        bbox_params=A.BboxParams(format="coco", label_fields=["bbox_labels"]),
+    ),
+    bbox_margin=0,
+    top_down_crop_size=(256, 256),
+)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        # two well-defined individuals
+        {
+            "image_shape": (100, 100, 3),
+            "context": {
+                "cond_kpts": np.array(
+                    [[[10, 10, 0.8], [20, 20, 0.8]], [[60, 60, 0.8], [70, 70, 0.8]]]
+                )
+            },
+            "output_context": {
+                "cond_kpts": np.array(
+                    [[[10, 10, 0.8], [20, 20, 0.8]], [[60, 60, 0.8], [70, 70, 0.8]]]
+                ),
+                "bboxes": [np.array([10, 10, 10, 10]), np.array([60, 60, 10, 10])],
+                "offsets": [(10, 10), (60, 60)],
+                "scales": [(0.1, 0.1), (0.1, 0.1)],
+            },
+        },
+        # one individual has 0 keypoints
+        {
+            "image_shape": (100, 100, 3),
+            "context": {
+                "cond_kpts": np.array(
+                    [[[10, 10, 0.8], [20, 20, 0.8]], [[60, 60, 0.0], [70, 70, 0.0]]]
+                )
+            },
+            "output_context": {
+                "cond_kpts": np.array(
+                    [
+                        [[10, 10, 0.8], [20, 20, 0.8]],
+                    ]
+                ),
+                "bboxes": [np.array([10, 10, 10, 10])],
+                "offsets": [(10, 10)],
+                "scales": [(0.1, 0.1)],
+            },
+        },
+        # one individual has only 1 keypoints
+        {
+            "image_shape": (100, 100, 3),
+            "context": {
+                "cond_kpts": np.array(
+                    [[[10, 10, 0.8], [20, 20, 0.8]], [[60, 60, 0.0], [70, 70, 0.9]]]
+                )
+            },
+            "output_context": {
+                "cond_kpts": np.array(
+                    [
+                        [[10, 10, 0.8], [20, 20, 0.8]],
+                    ]
+                ),
+                "bboxes": [np.array([10, 10, 10, 10])],
+                "offsets": [(10, 10)],
+                "scales": [(0.1, 0.1)],
+            },
+        },
+        # two individuals but one is low confidence
+        {
+            "image_shape": (100, 100, 3),
+            "context": {
+                "cond_kpts": np.array(
+                    [[[10, 10, 0.8], [20, 20, 0.8]], [[60, 60, 0.01], [70, 70, 0.01]]]
+                )
+            },
+            "output_context": {
+                "cond_kpts": np.array(
+                    [
+                        [[10, 10, 0.8], [20, 20, 0.8]],
+                    ]
+                ),
+                "bboxes": [np.array([10, 10, 10, 10])],
+                "offsets": [(10, 10)],
+                "scales": [(0.1, 0.1)],
+            },
+        },
+    ],
+)
+def test_conditional_top_down_preprocessor(data):
+    input_img = np.ones(data["image_shape"])
+
+    output_img, output_context = ctd_preprocessor(input_img, context=data["context"])
+
+    for context_key in ["cond_kpts", "bboxes", "offsets", "scales"]:
+        assert deep_equal(
+            output_context[context_key], data["output_context"][context_key]
+        )
+
+
+def deep_equal(a, b):
+    if isinstance(a, np.ndarray) and isinstance(b, np.ndarray):
+        return np.array_equal(a, b)
+    elif isinstance(a, list) and isinstance(b, list):
+        if len(a) != len(b):
+            return False
+        return all(deep_equal(x, y) for x, y in zip(a, b))
+    else:
+        return a == b


### PR DESCRIPTION
This Pull request

1. Adds a processing stage to the CTD preprocessors that filters out empty bounding boxes and corresponding poses. This prevents the CTD inference to crash when the BU provides a pose with 0 or 1 found bodypart, which was leading to trying to top-down crop using an empty bbox.
2. Adds a processing stage to filter out bounding boxes that are below a certain confidence level.
3. Adds unit test to test these stages.
4. Silences Runtime warning occuring during the computation of a bbox from an empty pose.