### PR TITLE
[Docs] pcutoff per bodypart documentation

### DIFF
--- a/docs/maDLC_UserGuide.md
+++ b/docs/maDLC_UserGuide.md
@@ -608,6 +608,32 @@ and test errors are comparable (good generalization). What (numerically) compris
 many factors (including the size of the tracked body parts, the labeling variability, etc.). Note that the test error can
 also be larger than the training error due to human variability (in labeling, see Figure 2 in Mathis et al, Nature Neuroscience 2018).
 
+**Optional parameters:**
+
+- `Shuffles: list, optional` - List of integers specifying the shuffle indices of the training dataset.
+The default is [1]
+
+- `plotting: bool | str, optional` - Plots the predictions on the train and test images. The default is `False`;
+if provided it must be either `True`, `False`, `"bodypart"`, or `"individual"`.
+
+- `show_errors: bool, optional` - Display train and test errors. The default is `True`
+
+- `comparisonbodyparts: list of bodyparts, Default is all` - The average error will be computed for those body parts
+only (Has to be a subset of the body parts).
+
+- `gputouse: int, optional` - Natural number indicating the number of your GPU (see number in nvidia-smi). If you do not
+have a GPU, put None. See: https://nvidia.custhelp.com/app/answers/detail/a_id/3751/~/useful-nvidia-smi-queries
+
+- `pcutoff: float | list[float] | dict[str, float], optional`
+(Only applicable when using the PyTorch engine. For TensorFlow, set `pcutoff` in the `config.yaml` file.)
+Specifies the cutoff value(s) used to compute evaluation metrics.
+  - If `None` (default), the cutoff will be loaded from the project configuration.
+  - To apply a single cutoff value to all bodyparts, provide a `float`.
+  - To specify different cutoffs per bodypart, provide either:
+    - A `list[float]`: one value per bodypart, with an additional value for each unique bodypart if applicable.
+    - A `dict[str, float]`: where keys are bodypart names and values are the corresponding cutoff values.
+If a bodypart is not included in the provided dictionary, a default `pcutoff` of `0.6` will be used for that bodypart.
+
 The plots can be customized by editing the **config.yaml** file (i.e., the colormap, scale, marker size (dotsize), and
 transparency of labels (alpha-value) can be modified). By default each body part is plotted in a different color
 (governed by the colormap) and the plot labels indicate their source. Note that by default the human labels are

--- a/docs/standardDeepLabCut_UserGuide.md
+++ b/docs/standardDeepLabCut_UserGuide.md
@@ -552,6 +552,16 @@ only (Has to be a subset of the body parts).
 - `gputouse: int, optional` - Natural number indicating the number of your GPU (see number in nvidia-smi). If you do not
 have a GPU, put None. See: https://nvidia.custhelp.com/app/answers/detail/a_id/3751/~/useful-nvidia-smi-queries
 
+- `pcutoff: float | list[float] | dict[str, float], optional`
+(Only applicable when using the PyTorch engine. For TensorFlow, set `pcutoff` in the `config.yaml` file.)
+Specifies the cutoff value(s) used to compute evaluation metrics.
+  - If `None` (default), the cutoff will be loaded from the project configuration.
+  - To apply a single cutoff value to all bodyparts, provide a `float`.
+  - To specify different cutoffs per bodypart, provide either:
+    - A `list[float]`: one value per bodypart, with an additional value for each unique bodypart if applicable.
+    - A `dict[str, float]`: where keys are bodypart names and values are the corresponding cutoff values.
+If a bodypart is not included in the provided dictionary, a default `pcutoff` of `0.6` will be used for that bodypart.
+
 The plots can be customized by editing the **config.yaml** file (i.e., the colormap, scale, marker size (dotsize), and
 transparency of labels (alphavalue) can be modified). By default each body part is plotted in a different color
 (governed by the colormap) and the plot labels indicate their source. Note that by default the human labels are


### PR DESCRIPTION
This Pull Requests addresses https://github.com/DeepLabCut/DeepLabCut/pull/2889#issuecomment-2665014853 by adding documentation for the `pcutoff` argument in `deeplabcut.evaluate_network()`, introduced in https://github.com/DeepLabCut/DeepLabCut/pull/2889 (including the **pcutoff-per-bodypart feature**).

It also adds a description to several other optional arguments (`Shuffles`, `plotting`, `show_errors`, `comparisonbodyparts`, `gputouse`) in the multi-animal documentation page, that were missing there.