### PR TITLE
BUCTD GUI integration

### DIFF
--- a/deeplabcut/gui/components.py
+++ b/deeplabcut/gui/components.py
@@ -341,12 +341,13 @@ class ConditionsSelectionWidget(QtWidgets.QWidget):
         def _shorten_path(path: str, max_length: int = 30) -> str:
             if len(path) <= max_length:
                 return path
-            return '...' + path[-(max_length - 3):]
+            return "..." + path[-(max_length - 3) :]
 
         self.selected_conditions_text.setText(
-            "" if self.selected_conditions is None else f"{_shorten_path(self.selected_conditions)}"
+            ""
+            if self.selected_conditions is None
+            else f"{_shorten_path(self.selected_conditions)}"
         )
-
 
     def select_conditions(self):
         def _is_model_bu(selected_conditions) -> bool:
@@ -361,11 +362,13 @@ class ConditionsSelectionWidget(QtWidgets.QWidget):
         snapshot_types = ["*.pt", "*.PT"]
         h5_predictions_types = ["*.h5", "*.H5"]
         json_prediction_types = ["*.json", "*.JSON"]
-        conditions_filter = ";;".join([
-            f"{snapshots_label} ({' '.join(snapshot_types)})",
-            f"{h5_predictions_label} ({' '.join(h5_predictions_types)})",
-            f"{json_prediction_label} ({' '.join(json_prediction_types)})",
-        ])
+        conditions_filter = ";;".join(
+            [
+                f"{snapshots_label} ({' '.join(snapshot_types)})",
+                f"{h5_predictions_label} ({' '.join(h5_predictions_types)})",
+                f"{json_prediction_label} ({' '.join(json_prediction_types)})",
+            ]
+        )
 
         directory_to_open = self.root.project_folder
 
@@ -388,7 +391,9 @@ class ConditionsSelectionWidget(QtWidgets.QWidget):
                 selected_conditions = None
 
         # When Canceling a file selection, Qt returns an empty string as selected file
-        self.selected_conditions = str(os.path.abspath(selected_conditions)) if selected_conditions else None
+        self.selected_conditions = (
+            str(os.path.abspath(selected_conditions)) if selected_conditions else None
+        )
 
         self._update_selected_conditions_display()
 

--- a/deeplabcut/gui/components.py
+++ b/deeplabcut/gui/components.py
@@ -8,10 +8,14 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
+from __future__ import annotations
+
 import os
 
 from PySide6 import QtWidgets
 from PySide6.QtCore import Qt, Slot
+from PySide6.QtGui import QIcon
+
 from deeplabcut.gui.dlc_params import DLCParams
 from deeplabcut.gui.widgets import ConfigEditor
 
@@ -437,3 +441,33 @@ class BrowseFilesButton(QtWidgets.QPushButton):
 
         if filepaths:
             self.files.update(filepaths[0])
+
+
+def _create_message_box(text, info_text):
+    msg = QtWidgets.QMessageBox()
+    msg.setIcon(QtWidgets.QMessageBox.Information)
+    msg.setText(text)
+    msg.setInformativeText(info_text)
+
+    msg.setWindowTitle("Info")
+    msg.setMinimumWidth(900)
+    logo_dir = os.path.dirname(os.path.realpath("logo.png")) + os.path.sep
+    logo = logo_dir + "/assets/logo.png"
+    msg.setWindowIcon(QIcon(logo))
+    msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
+    return msg
+
+
+def _create_confirmation_box(title, description):
+    msg = QtWidgets.QMessageBox()
+    msg.setIcon(QtWidgets.QMessageBox.Information)
+    msg.setText(title)
+    msg.setInformativeText(description)
+
+    msg.setWindowTitle("Confirmation")
+    msg.setMinimumWidth(900)
+    logo_dir = os.path.dirname(os.path.realpath("logo.png")) + os.path.sep
+    logo = logo_dir + "/assets/logo.png"
+    msg.setWindowIcon(QIcon(logo))
+    msg.setStandardButtons(QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No)
+    return msg

--- a/deeplabcut/gui/components.py
+++ b/deeplabcut/gui/components.py
@@ -204,20 +204,20 @@ class VideoSelectionWidget(QtWidgets.QWidget):
             self.select_video_button.setText("Select videos")
 
     def update_videos(self):
-        cwd = self.root.project_folder
+        directory_to_open = self.root.project_folder
 
         # Create a filter string with both lowercase and uppercase extensions
 
         video_types = [f"*.{ext.lower()}" for ext in DLCParams.VIDEOTYPES[1:]] + [
             f"*.{ext.upper()}" for ext in DLCParams.VIDEOTYPES[1:]
         ]
-        video_files = f"Videos ({' '.join(video_types)})"
+        video_filter = f"Videos ({' '.join(video_types)})"
 
         filenames = QtWidgets.QFileDialog.getOpenFileNames(
-            self,
-            "Select video(s) to analyze",
-            cwd,
-            video_files,
+            parent=self,
+            caption="Select video(s) to analyze",
+            dir=directory_to_open,
+            filter=video_filter,
         )
 
         if filenames[0]:
@@ -238,18 +238,15 @@ class SnapshotSelectionWidget(QtWidgets.QWidget):
         select_button_text: str,
     ):
         super().__init__(parent)
-
         self.root = root
         self.parent = parent
-
         self.selected_snapshot = None
-
         self._init_layout(margins, select_button_text)
 
     def _init_layout(self, margins, select_button_text):
         layout = _create_horizontal_layout(margins=margins)
 
-        # Select videos
+        # Select snapshot
         self.select_snapshot_button = QtWidgets.QPushButton(select_button_text)
         self.select_snapshot_button.setMaximumWidth(200)
         self.select_snapshot_button.clicked.connect(self.select_snapshot)
@@ -283,15 +280,15 @@ class SnapshotSelectionWidget(QtWidgets.QWidget):
     def select_snapshot(self):
         # Create a filter string with both lowercase and uppercase extensions
         snapshot_types = ["*.pt", "*.PT"]
-        snapshot_files = f"Snapshots ({' '.join(snapshot_types)})"
+        snapshot_filter = f"Snapshots ({' '.join(snapshot_types)})"
 
         directory_to_open = self.root.models_folder
 
         selected_snapshot, _ = QtWidgets.QFileDialog.getOpenFileName(
-            self,
-            "Select snapshot to start training from",
-            directory_to_open,
-            snapshot_files,
+            parent=self,
+            caption="Select snapshot to start training from",
+            dir=directory_to_open,
+            filter=snapshot_filter,
         )
         # When Canceling a file selection, Qt returns an empty string as selected file
         if selected_snapshot:

--- a/deeplabcut/gui/components.py
+++ b/deeplabcut/gui/components.py
@@ -118,7 +118,7 @@ class BodypartListWidget(QtWidgets.QListWidget):
         # NOTE: Is there a case where a specific list should
         # have bodyparts other than the root? I don't think so.
     ):
-        super(BodypartListWidget, self).__init__()
+        super().__init__()
 
         self.root = root
         self.parent = parent
@@ -146,7 +146,7 @@ class BodypartListWidget(QtWidgets.QListWidget):
 
 class VideoSelectionWidget(QtWidgets.QWidget):
     def __init__(self, root: QtWidgets.QMainWindow, parent: QtWidgets.QWidget):
-        super(VideoSelectionWidget, self).__init__(parent)
+        super().__init__(parent)
 
         self.root = root
         self.parent = parent
@@ -237,7 +237,7 @@ class SnapshotSelectionWidget(QtWidgets.QWidget):
         margins: tuple,
         select_button_text: str,
     ):
-        super(SnapshotSelectionWidget, self).__init__(parent)
+        super().__init__(parent)
 
         self.root = root
         self.parent = parent
@@ -306,7 +306,7 @@ class SnapshotSelectionWidget(QtWidgets.QWidget):
 
 class TrainingSetSpinBox(QtWidgets.QSpinBox):
     def __init__(self, root, parent):
-        super(TrainingSetSpinBox, self).__init__(parent)
+        super().__init__(parent)
 
         self.root = root
         self.parent = parent
@@ -318,7 +318,7 @@ class TrainingSetSpinBox(QtWidgets.QSpinBox):
 
 class ShuffleSpinBox(QtWidgets.QSpinBox):
     def __init__(self, root, parent):
-        super(ShuffleSpinBox, self).__init__(parent)
+        super().__init__(parent)
 
         self.root = root
         self.parent = parent
@@ -341,7 +341,7 @@ class DefaultTab(QtWidgets.QWidget):
         parent: QtWidgets.QWidget = None,
         h1_description: str = "",
     ):
-        super(DefaultTab, self).__init__(parent)
+        super().__init__(parent)
 
         self.parent = parent
         self.root = root
@@ -377,7 +377,7 @@ class EditYamlButton(QtWidgets.QPushButton):
     def __init__(
         self, button_label: str, filepath: str, parent: QtWidgets.QWidget = None
     ):
-        super(EditYamlButton, self).__init__(button_label)
+        super().__init__(parent)
         self.filepath = filepath
         self.parent = parent
 
@@ -399,7 +399,7 @@ class BrowseFilesButton(QtWidgets.QPushButton):
         file_text: str = None,
         parent=None,
     ):
-        super(BrowseFilesButton, self).__init__(button_label)
+        super().__init__(parent)
         self.filetype = filetype
         self.single_file_only = single_file
         self.cwd = cwd

--- a/deeplabcut/gui/tabs/create_training_dataset.py
+++ b/deeplabcut/gui/tabs/create_training_dataset.py
@@ -29,6 +29,7 @@ from deeplabcut.gui.components import (
     ShuffleSpinBox,
     _create_grid_layout,
     _create_label_widget,
+    set_combo_items,
 )
 from deeplabcut.gui.displays.shuffle_metadata_viewer import ShuffleMetadataViewer
 from deeplabcut.gui.dlc_params import DLCParams
@@ -412,13 +413,8 @@ class CreateTrainingDataset(DefaultTab):
                     )
                 ]
 
-        while self.net_choice.count() > 0:
-            self.net_choice.removeItem(0)
-
-        self.net_choice.addItems(nets)
         if default_net is None:
             default_net = self.root.cfg.get("default_net_type", "resnet_50")
-
         if (
             engine == Engine.TF
             and default_net not in DLCParams.NNETS
@@ -427,8 +423,12 @@ class CreateTrainingDataset(DefaultTab):
         ):
             default_net = "resnet_50"
 
-        if default_net in nets:
-            self.net_choice.setCurrentIndex(nets.index(default_net))
+        set_combo_items(
+            combo_box=self.net_choice,
+            items=nets,
+            index=nets.index(default_net) if default_net in nets else 0,
+        )
+
 
     @Slot(Engine)
     def update_detectors(
@@ -450,15 +450,19 @@ class CreateTrainingDataset(DefaultTab):
             if det_filter is not None:
                 detectors = [d for d in detectors if d in det_filter]
 
-        while self.detector_choice.count() > 0:
-            self.detector_choice.removeItem(0)
-
-        self.detector_choice.addItems(detectors)
         default_detector = self.get_default_detector()
-        if default_detector in detectors:
-            self.detector_choice.setCurrentIndex(detectors.index(default_detector))
-        elif "ssdlite" in detectors:
-            self.detector_choice.setCurrentIndex(detectors.index("ssdlite"))
+        try:
+            index = detectors.index(default_detector)
+        except ValueError:
+            try:
+                index = detectors.index("ssdlite")
+            except ValueError:
+                index = -1
+        set_combo_items(
+            combo_box=self.detector_choice,
+            items=detectors,
+            index=index,
+        )
 
         if net_choice is None:
             net_choice = self.net_choice.currentText()
@@ -473,11 +477,11 @@ class CreateTrainingDataset(DefaultTab):
     @Slot(Engine)
     def update_aug_methods(self, engine: Engine) -> None:
         methods = compat.get_available_aug_methods(engine)
-        while self.aug_choice.count() > 0:
-            self.aug_choice.removeItem(0)
-
-        self.aug_choice.addItems(methods)
-        self.aug_choice.setCurrentText(methods[0])
+        set_combo_items(
+            combo_box=self.aug_choice,
+            items=methods,
+            index=0,
+        )
 
     @Slot(Engine)
     def update_weight_init_methods(self, engine: Engine) -> None:
@@ -585,9 +589,10 @@ class WeightInitializationSelector(QtWidgets.QWidget):
 
     def update_choices(self, choices: list[str]) -> None:
         """Updates the WeightInitialization methods that can be selected"""
-        while self.weight_init_choice.count() > 0:
-            self.weight_init_choice.removeItem(0)
-        self.weight_init_choice.addItems(choices)
+        set_combo_items(
+            combo_box=self.weight_init_choice,
+            items=choices,
+        )
 
     def get_super_animal_weight_init(
         self,

--- a/deeplabcut/gui/tabs/create_training_dataset.py
+++ b/deeplabcut/gui/tabs/create_training_dataset.py
@@ -467,7 +467,7 @@ class CreateTrainingDataset(DefaultTab):
         if net_choice is None:
             net_choice = self.net_choice.currentText()
 
-        if is_model_top_down(net_choice):
+        if engine == Engine.PYTORCH and is_model_top_down(net_choice):
             self.detector_label.show()
             self.detector_choice.show()
         else:

--- a/deeplabcut/gui/tabs/create_training_dataset.py
+++ b/deeplabcut/gui/tabs/create_training_dataset.py
@@ -430,7 +430,7 @@ class CreateTrainingDataset(DefaultTab):
 
         Returns:
             ctd_conditions: Path | tuple[int, str]
-                ctd conditions in the right formar for deeplabcut.create_training_dataset() API method.
+                ctd conditions in the right format for deeplabcut.create_training_dataset() API method.
 
         Raises:
             Value error if conditions are missing or invalid.

--- a/deeplabcut/gui/tabs/create_training_dataset.py
+++ b/deeplabcut/gui/tabs/create_training_dataset.py
@@ -16,7 +16,6 @@ from pathlib import Path
 import dlclibrary
 from PySide6 import QtWidgets
 from PySide6.QtCore import Qt, Slot
-from PySide6.QtGui import QIcon
 
 import deeplabcut
 import deeplabcut.compat as compat
@@ -29,7 +28,7 @@ from deeplabcut.gui.components import (
     ShuffleSpinBox,
     _create_grid_layout,
     _create_label_widget,
-    set_combo_items,
+    set_combo_items, _create_message_box, _create_confirmation_box,
 )
 from deeplabcut.gui.displays.shuffle_metadata_viewer import ShuffleMetadataViewer
 from deeplabcut.gui.dlc_params import DLCParams
@@ -715,36 +714,6 @@ class DataSplitSelector(QtWidgets.QWidget):
         else:
             self.shuffle_selector.hide()
             self.shuffle_label.hide()
-
-
-def _create_message_box(text, info_text):
-    msg = QtWidgets.QMessageBox()
-    msg.setIcon(QtWidgets.QMessageBox.Information)
-    msg.setText(text)
-    msg.setInformativeText(info_text)
-
-    msg.setWindowTitle("Info")
-    msg.setMinimumWidth(900)
-    logo_dir = os.path.dirname(os.path.realpath("logo.png")) + os.path.sep
-    logo = logo_dir + "/assets/logo.png"
-    msg.setWindowIcon(QIcon(logo))
-    msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
-    return msg
-
-
-def _create_confirmation_box(title, description):
-    msg = QtWidgets.QMessageBox()
-    msg.setIcon(QtWidgets.QMessageBox.Information)
-    msg.setText(title)
-    msg.setInformativeText(description)
-
-    msg.setWindowTitle("Confirmation")
-    msg.setMinimumWidth(900)
-    logo_dir = os.path.dirname(os.path.realpath("logo.png")) + os.path.sep
-    logo = logo_dir + "/assets/logo.png"
-    msg.setWindowIcon(QIcon(logo))
-    msg.setStandardButtons(QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No)
-    return msg
 
 
 _WEIGHT_INIT_OPTIONS = {  # FIXME - Generate dynamically

--- a/deeplabcut/gui/tabs/create_training_dataset.py
+++ b/deeplabcut/gui/tabs/create_training_dataset.py
@@ -30,13 +30,19 @@ from deeplabcut.gui.components import (
     ConditionsSelectionWidget,
     _create_grid_layout,
     _create_label_widget,
-    set_combo_items, _create_message_box, _create_confirmation_box,
+    set_combo_items,
+    _create_message_box,
+    _create_confirmation_box,
 )
 from deeplabcut.gui.displays.shuffle_metadata_viewer import ShuffleMetadataViewer
 from deeplabcut.gui.dlc_params import DLCParams
 from deeplabcut.gui.widgets import launch_napari
 from deeplabcut.modelzoo import build_weight_init
-from deeplabcut.pose_estimation_pytorch import available_models, is_model_top_down, is_model_cond_top_down
+from deeplabcut.pose_estimation_pytorch import (
+    available_models,
+    is_model_top_down,
+    is_model_cond_top_down,
+)
 from deeplabcut.utils.auxiliaryfunctions import (
     get_data_and_metadata_filenames,
     get_training_set_folder,
@@ -151,13 +157,17 @@ class CreateTrainingDataset(DefaultTab):
 
         # Conditions selection for CTD models
         self.conditions_label = QtWidgets.QLabel("Conditions")
-        self.conditions_selection_widget = ConditionsSelectionWidget(root=self.root, parent=self)
+        self.conditions_selection_widget = ConditionsSelectionWidget(
+            root=self.root, parent=self
+        )
         self.update_conditions(engine=self.root.engine)
         self.root.engine_change.connect(
             lambda engine: self.update_conditions(engine=engine)
         )
         self.net_choice.currentTextChanged.connect(
-            lambda new_net_choice: self.update_conditions(engine=self.root.engine, net_choice=new_net_choice)
+            lambda new_net_choice: self.update_conditions(
+                engine=self.root.engine, net_choice=new_net_choice
+            )
         )
 
         # Overwrite selection
@@ -259,7 +269,9 @@ class CreateTrainingDataset(DefaultTab):
                     if is_model_top_down(net_type):
                         detector_type = self.detector_choice.currentText()
                     elif is_model_cond_top_down(net_type):
-                        ctd_conditions = self._build_ctd_conditions(self.conditions_selection_widget.selected_conditions)
+                        ctd_conditions = self._build_ctd_conditions(
+                            self.conditions_selection_widget.selected_conditions
+                        )
 
                 try:
                     weight_init = (
@@ -407,8 +419,9 @@ class CreateTrainingDataset(DefaultTab):
 
         return True
 
-
-    def _build_ctd_conditions(self, conditions_path: str | Path) -> Path | tuple[int, str]:
+    def _build_ctd_conditions(
+        self, conditions_path: str | Path
+    ) -> Path | tuple[int, str]:
         """
         Builds CTD conditions in appropriate format from path to conditions.
         Args:
@@ -483,7 +496,6 @@ class CreateTrainingDataset(DefaultTab):
             index=nets.index(default_net) if default_net in nets else 0,
         )
 
-
     @Slot(Engine)
     def update_detectors(
         self,
@@ -530,9 +542,9 @@ class CreateTrainingDataset(DefaultTab):
 
     @Slot(Engine)
     def update_conditions(
-            self,
-            engine: Engine | None = None,
-            net_choice: str | None = None,
+        self,
+        engine: Engine | None = None,
+        net_choice: str | None = None,
     ) -> None:
         if engine is None:
             engine = self.root.engine

--- a/deeplabcut/pose_estimation_pytorch/__init__.py
+++ b/deeplabcut/pose_estimation_pytorch/__init__.py
@@ -35,6 +35,7 @@ from deeplabcut.pose_estimation_pytorch.config import (
     available_detectors,
     available_models,
     is_model_top_down,
+    is_model_cond_top_down,
 )
 from deeplabcut.pose_estimation_pytorch.data import (
     build_transforms,

--- a/deeplabcut/pose_estimation_pytorch/config/__init__.py
+++ b/deeplabcut/pose_estimation_pytorch/config/__init__.py
@@ -17,6 +17,7 @@ from deeplabcut.pose_estimation_pytorch.config.utils import (
     available_detectors,
     available_models,
     is_model_top_down,
+    is_model_cond_top_down,
     update_config,
     update_config_by_dotpath,
 )

--- a/deeplabcut/pose_estimation_pytorch/config/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/config/utils.py
@@ -283,7 +283,7 @@ def is_model_top_down(net_type: str) -> bool:
 
 
 def is_model_cond_top_down(net_type: str) -> bool:
-    """Checks whenever a given net_type is conditional top-down or not"""
+    """Checks whether a given net_type is conditional top-down or not"""
     if net_type not in available_models():
         raise ValueError(
             f"Model {net_type} is not part of available models, which are {str(available_models())}"

--- a/deeplabcut/pose_estimation_pytorch/config/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/config/utils.py
@@ -282,6 +282,19 @@ def is_model_top_down(net_type: str) -> bool:
     return model_cfg.get("method", "BU").upper() == "TD"
 
 
+def is_model_cond_top_down(net_type: str) -> bool:
+    """Checks whenever a given net_type is conditional top-down or not"""
+    if net_type not in available_models():
+        raise ValueError(
+            f"Model {net_type} is not part of available models, which are {str(available_models())}"
+        )
+
+    if net_type.startswith("ctd_"):
+        return True
+    else:
+        return False
+
+
 def available_detectors() -> list[str]:
     """Returns: all the possible detectors that can be used"""
     return load_detectors(get_config_folder_path())


### PR DESCRIPTION
This Pull Request adds a **widget to select conditions to the _Create training dataset_ tab in the DeepLabCut GUI**.

![Screenshot from 2025-06-25 08-58-12](https://github.com/user-attachments/assets/0a4bf660-cdee-42bd-a6eb-254b37de6bf2)

The widget is visible only when a CTD model is selected.
The conditions can be one of the following:
- A pytorch model snapshot (a check is applied to verify if the selected model is Bottom-Up , an warning message is displayed if that is not the case)
- Predictions stored in a _.h5_ file
- Predictions stored in a _.json_ file

The user can **choose the type of conditions** they want to use in the `QtWidgets.QFileDialog.getOpenFileName` dialog **using the filter** (in the bottom-right corner of the window).

![Screenshot from 2025-06-25 09-03-42](https://github.com/user-attachments/assets/99093bb8-c9e4-432e-b8ef-16c8ceda9812)

If a CTD model is selected but conditions are missing - the shuffle creation fails (a warning message is displayed).