### PR TITLE
Fix BUCTD Colab

### DIFF
--- a/examples/COLAB/COLAB_BUCTD_and_CTD_tracking.ipynb
+++ b/examples/COLAB/COLAB_BUCTD_and_CTD_tracking.ipynb
@@ -1172,7 +1172,7 @@
     "    config,\n",
     "    from_shuffle=BU_SHUFFLE,\n",
     "    shuffles=[CTD_SHUFFLE],\n",
-    "    net_type=\"ctd_prenet_cspnext_m\",\n",
+    "    net_type=\"ctd_prenet_rtmpose_m\",\n",
     "    engine=deeplabcut.Engine.PYTORCH,\n",
     "    ctd_conditions=(BU_SHUFFLE, -1),\n",
     ")"


### PR DESCRIPTION
https://github.com/DeepLabCut/DeepLabCut/pull/3010 removes the _ctd_prenet_cspnext_m_ and _ctd_prenet_cspnext_x_ architectures. Therefore, this PR changes the CTD model to _ctd_prenet_rtmpose_m_ in the BUCTD Colab.