### PR TITLE
Set matplotlib in non-interactive backend during tests

### DIFF
--- a/examples/testscript.py
+++ b/examples/testscript.py
@@ -35,6 +35,8 @@ import deeplabcut
 from deeplabcut.core.engine import Engine
 from deeplabcut.utils import auxiliaryfunctions
 
+import matplotlib
+matplotlib.use("Agg")  # Non-interactive backend, for CI/CD on Windows
 
 USE_SHELVE = random.choice([True, False])
 MODELS = ["resnet_50", "efficientnet-b0"]

--- a/examples/testscript_multianimal.py
+++ b/examples/testscript_multianimal.py
@@ -16,6 +16,9 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
+import matplotlib
+matplotlib.use("Agg")  # Non-interactive backend, for CI/CD on Windows
+
 import deeplabcut
 from deeplabcut.core.engine import Engine
 from deeplabcut.utils import auxfun_multianimal, auxiliaryfunctions

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -17,6 +17,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import matplotlib
+matplotlib.use("Agg")  # Non-interactive backend, for CI/CD on Windows
+
 import cv2
 import deeplabcut
 import deeplabcut.utils.auxiliaryfunctions as af


### PR DESCRIPTION
Targeting to fix the well-known `tkinter` error that sometimes happens in CI/CD on Windows:

```
Traceback (most recent call last):
  File "C:\Miniconda\envs\test\lib\tkinter\__init__.py", line 4056, in __del__
    self.tk.call('image', 'delete', self.name)
RuntimeError: main thread is not in main loop

```