### PR TITLE
Save all pytorch config updates in dlc_torch.train_network()

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/apis/training.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/training.py
@@ -323,8 +323,8 @@ def train_network(
         if display_iters is not None:
             detector_cfg["train_settings"]["display_iters"] = display_iters
 
-    if pytorch_cfg_updates is not None:
-        loader.update_model_cfg(pytorch_cfg_updates)
+    # Save updated model config
+    loader.update_model_cfg(pytorch_cfg_updates or {})
 
     setup_file_logging(loader.model_folder / "train.txt")
 

--- a/deeplabcut/pose_estimation_pytorch/apis/training.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/training.py
@@ -303,28 +303,36 @@ def train_network(
                 train_json_filename="memory_replay_train.json",
             )
 
+    cfg_updates = {}
+
+    # Pose model training settings
     if batch_size is not None:
-        loader.model_cfg["train_settings"]["batch_size"] = batch_size
+        cfg_updates["train_settings.batch_size"] = batch_size
     if epochs is not None:
-        loader.model_cfg["train_settings"]["epochs"] = epochs
+        cfg_updates["train_settings.epochs"] = epochs
     if save_epochs is not None:
-        loader.model_cfg["runner"]["snapshots"]["save_epochs"] = save_epochs
+        cfg_updates["runner.snapshots.save_epochs"] = save_epochs
     if display_iters is not None:
-        loader.model_cfg["train_settings"]["display_iters"] = display_iters
+        cfg_updates["train_settings.display_iters"] = display_iters
 
-    detector_cfg = loader.model_cfg.get("detector")
-    if detector_cfg is not None:
+    # Detector config settings (if exists)
+    if loader.model_cfg.get("detector") is not None:
         if detector_batch_size is not None:
-            detector_cfg["train_settings"]["batch_size"] = detector_batch_size
+            cfg_updates["detector.train_settings.batch_size"] = detector_batch_size
         if detector_epochs is not None:
-            detector_cfg["train_settings"]["epochs"] = detector_epochs
+            cfg_updates["detector.train_settings.epochs"] = detector_epochs
         if detector_save_epochs is not None:
-            detector_cfg["runner"]["snapshots"]["save_epochs"] = detector_save_epochs
+            cfg_updates["detector.runner.snapshots.save_epochs"] = detector_save_epochs
         if display_iters is not None:
-            detector_cfg["train_settings"]["display_iters"] = display_iters
+            cfg_updates["detector.train_settings.display_iters"] = display_iters
 
-    # Save updated model config
-    loader.update_model_cfg(pytorch_cfg_updates or {})
+    # Optional generic overrides
+    if pytorch_cfg_updates is not None:
+        cfg_updates.update(pytorch_cfg_updates)
+
+    # Only call update if anything changed
+    if cfg_updates:
+        loader.update_model_cfg(cfg_updates)
 
     setup_file_logging(loader.model_folder / "train.txt")
 


### PR DESCRIPTION
This Pull Request saves all updates done to the model configuration to the disk (_pytorch_config.yaml_) before starting training in `dlc_torch.train_network()`.

Previously, the pytorch config was [only saved when `pytorch_cfg_updates` were passed](https://github.com/DeepLabCut/DeepLabCut/blob/5374737dddbf201aba1ac9905626cc6e4d069be6/deeplabcut/pose_estimation_pytorch/apis/training.py#L326-L327). This prevented saving [other updated fields](https://github.com/DeepLabCut/DeepLabCut/blob/5374737dddbf201aba1ac9905626cc6e4d069be6/deeplabcut/pose_estimation_pytorch/apis/training.py#L306-L324).