### PR TITLE
Update TensorFlow backend for Python 3.12 compatibility (Keras 2 via `tf-keras`) - LTS DLC 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build-and-test:
     working_directory: ~/circleci-demo-python-django
     docker:
-      - image: circleci/python:3.8  # primary container for the build job
+      - image: cimg/python:3.12  # primary container for the build job
         auth:
           username: mydockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,9 +3,9 @@ name: Codespell
 
 on:
   push:
-    branches: [main]
+    branches: [LTS-DLC-2]
   pull_request:
-    branches: [main]
+    branches: [LTS-DLC-2]
 
 jobs:
   codespell:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,20 +13,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, windows-latest]
-        python-version: ["3.10"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.10", "3.11", "3.12"]
         include:
           - os: ubuntu-latest
             path: ~/.cache/pip
-          - os: macos-13
+          - os: macos-latest
             path: ~/Library/Caches/pip
           - os: windows-latest
             path: ~\AppData\Local\pip\Cache
-        exclude:
-          - os: macos-13
-            python-version: 3.7
-          - os: windows-latest
-            python-version: 3.7
 
     steps:
       - name: Checkout code

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,9 +2,9 @@ name: Python package
 
 on:
   push:
-    branches: [ main ]
+    branches: [LTS-DLC-2]
   pull_request:
-    branches: [ main ]
+    branches: [LTS-DLC-2]
 
 jobs:
   build:

--- a/deeplabcut/__init__.py
+++ b/deeplabcut/__init__.py
@@ -12,10 +12,6 @@
 
 import os
 
-# Suppress tensorflow warning messages
-import tensorflow as tf
-
-tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
 DEBUG = True and "DEBUG" in os.environ and os.environ["DEBUG"]
 from deeplabcut.version import __version__, VERSION
 

--- a/deeplabcut/pose_estimation_tensorflow/__init__.py
+++ b/deeplabcut/pose_estimation_tensorflow/__init__.py
@@ -14,6 +14,10 @@
 
 from . import _tf_legacy
 
+# Suppress tensorflow warning messages
+import tensorflow as tf
+tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
+
 from deeplabcut.pose_estimation_tensorflow.config import *
 from deeplabcut.pose_estimation_tensorflow.datasets import *
 from deeplabcut.pose_estimation_tensorflow.default_config import *

--- a/deeplabcut/pose_estimation_tensorflow/__init__.py
+++ b/deeplabcut/pose_estimation_tensorflow/__init__.py
@@ -12,6 +12,7 @@
 # Licensed under GNU Lesser General Public License v3.0
 #
 
+from . import _tf_legacy
 
 from deeplabcut.pose_estimation_tensorflow.config import *
 from deeplabcut.pose_estimation_tensorflow.datasets import *

--- a/deeplabcut/pose_estimation_tensorflow/_tf_legacy.py
+++ b/deeplabcut/pose_estimation_tensorflow/_tf_legacy.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+os.environ.setdefault("TF_USE_LEGACY_KERAS", "1")
+os.environ.setdefault("WRAPT_DISABLE_EXTENSIONS", "1")
+
+try:
+    import tf_keras.src.legacy_tf_layers as legacy_tf_layers
+    sys.modules["tf_keras.legacy_tf_layers"] = legacy_tf_layers
+except ImportError:
+    # Older tf-keras didn’t use src/, so nothing to do
+    pass

--- a/deeplabcut/utils/auxfun_multianimal.py
+++ b/deeplabcut/utils/auxfun_multianimal.py
@@ -147,7 +147,7 @@ def prune_paf_graph(list_of_edges, desired_n_edges=None, average_degree=None):
         )
 
     while True:
-        g = nx.Graph(random.sample(G.edges, desired_n_edges))
+        g = nx.Graph(random.sample(list(G.edges), desired_n_edges))
         if len(g.nodes) == n_nodes and nx.is_connected(g):
             print("Valid subgraph found...")
             break

--- a/examples/COLAB/COLAB_3miceDemo.ipynb
+++ b/examples/COLAB/COLAB_3miceDemo.ipynb
@@ -32,21 +32,7 @@
     "- a quick guide to maDLC: https://deeplabcut.github.io/DeepLabCut/docs/tutorial.html\n",
     "- a demo COLAB for how to use maDLC on your own data: https://github.com/DeepLabCut/DeepLabCut/blob/main/examples/COLAB/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb\n",
     "\n",
-    "### To get started, please go to \"Runtime\" ->\"change runtime type\"->select \"Python3\", and then select \"GPU\"\n",
-    "\n",
-    "As the COLAB environments were updated to CUDA 12.X and Python 3.11, we need to install DeepLabCut and TensorFlow in a distinct way to get TensorFlow to connect to the GPU."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "HoNN2_0Z9rr_"
-   },
-   "outputs": [],
-   "source": [
-    "# Install TensorFlow, tensorpack and tf_slim versions compatible with DeepLabCut\n",
-    "!pip install \"tensorflow==2.12.1\" \"tensorpack>=0.11\" \"tf_slim>=1.1.0\""
+    "### To get started, please go to \"Runtime\" ->\"change runtime type\"->select \"Python3\", and then select \"GPU\""
    ]
   },
   {
@@ -55,30 +41,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Downgrade PyTorch to a version using CUDA 11.8 and cudnn 8\n",
-    "# This will also install the required CUDA libraries, for both PyTorch and TensorFlow\n",
-    "!pip install torch==2.3.1 torchvision --index-url https://download.pytorch.org/whl/cu118"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Install the latest version of DeepLabCut\n",
-    "!pip install \"git+https://github.com/DeepLabCut/DeepLabCut.git\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# As described in https://www.tensorflow.org/install/pip#step-by-step_instructions, \n",
-    "# create symbolic links to NVIDIA shared libraries:\n",
-    "!ln -svf /usr/local/lib/python3.11/dist-packages/nvidia/*/lib/*.so* /usr/local/lib/python3.11/dist-packages/tensorflow"
+    "# Install DeepLabCut 2.X (LTS)\n",
+    "!pip install \"deeplabcut[tf]\""
    ]
   },
   {

--- a/examples/COLAB/COLAB_DLC_ModelZoo.ipynb
+++ b/examples/COLAB/COLAB_DLC_ModelZoo.ipynb
@@ -45,9 +45,7 @@
         "\n",
         "## **Let's get going: install DeepLabCut into COLAB:**\n",
         "\n",
-        "*Also, be sure you are connected to a GPU: go to menu, click Runtime > Change Runtime Type > select \"GPU\"*\n",
-        "\n",
-        "As the COLAB environments were updated to CUDA 12.X and Python 3.11, we need to install DeepLabCut and TensorFlow in a distinct way to get TensorFlow to connect to the GPU."
+        "*Also, be sure you are connected to a GPU: go to menu, click Runtime > Change Runtime Type > select \"GPU\"*"
       ]
     },
     {
@@ -56,40 +54,8 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# Install TensorFlow, tensorpack and tf_slim versions compatible with DeepLabCut\n",
-        "!pip install \"tensorflow==2.12.1\" \"tensorpack>=0.11\" \"tf_slim>=1.1.0\""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Downgrade PyTorch to a version using CUDA 11.8 and cudnn 8\n",
-        "# This will also install the required CUDA libraries, for both PyTorch and TensorFlow\n",
-        "!pip install torch==2.3.1 torchvision --index-url https://download.pytorch.org/whl/cu118"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Install the latest version of DeepLabCut\n",
-        "!pip install \"git+https://github.com/DeepLabCut/DeepLabCut.git#egg=deeplabcut[modelzoo]\""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# As described in https://www.tensorflow.org/install/pip#step-by-step_instructions, \n",
-        "# create symbolic links to NVIDIA shared libraries:\n",
-        "!ln -svf /usr/local/lib/python3.11/dist-packages/nvidia/*/lib/*.so* /usr/local/lib/python3.11/dist-packages/tensorflow"
+        "# Install the latest version of DeepLabCut, with tf and modelzoo extras\n",
+        "!pip install --pre \"deeplabcut[tf,modelzoo]\""
       ]
     },
     {

--- a/examples/COLAB/COLAB_transformer_reID.ipynb
+++ b/examples/COLAB/COLAB_transformer_reID.ipynb
@@ -32,9 +32,7 @@
     "- a quick guide to maDLC: https://deeplabcut.github.io/DeepLabCut/docs/tutorial.html\n",
     "- a demo COLAB for how to use maDLC on your own data: https://github.com/DeepLabCut/DeepLabCut/blob/main/examples/COLAB/COLAB_maDLC_TrainNetwork_VideoAnalysis.ipynb\n",
     "\n",
-    "### To get started, please go to \"Runtime\" ->\"change runtime type\"->select \"Python3\", and then select \"GPU\"\n",
-    "\n",
-    "As the COLAB environments were updated to CUDA 12.X and Python 3.11, we need to install DeepLabCut and TensorFlow in a distinct way to get TensorFlow to connect to the GPU."
+    "### To get started, please go to \"Runtime\" ->\"change runtime type\"->select \"Python3\", and then select \"GPU\""
    ]
   },
   {
@@ -43,40 +41,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Install TensorFlow, tensorpack and tf_slim versions compatible with DeepLabCut\n",
-    "!pip install \"tensorflow==2.12.1\" \"tensorpack>=0.11\" \"tf_slim>=1.1.0\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Downgrade PyTorch to a version using CUDA 11.8 and cudnn 8\n",
-    "# This will also install the required CUDA libraries, for both PyTorch and TensorFlow\n",
-    "!pip install torch==2.3.1 torchvision --index-url https://download.pytorch.org/whl/cu118"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Install the latest version of DeepLabCut\n",
-    "!pip install \"git+https://github.com/DeepLabCut/DeepLabCut.git\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# As described in https://www.tensorflow.org/install/pip#step-by-step_instructions, \n",
-    "# create symbolic links to NVIDIA shared libraries:\n",
-    "!ln -svf /usr/local/lib/python3.11/dist-packages/nvidia/*/lib/*.so* /usr/local/lib/python3.11/dist-packages/tensorflow"
+    "# Install DeepLabCut 2.X (LTS)\n",
+    "!pip install \"deeplabcut[tf]\""
    ]
   },
   {

--- a/examples/testscript.py
+++ b/examples/testscript.py
@@ -37,7 +37,7 @@ from deeplabcut.utils import auxiliaryfunctions
 import random
 
 USE_SHELVE = random.choice([True, False])
-MODELS = ["resnet_50", "efficientnet-b0", "mobilenet_v2_0.35"]
+MODELS = ["resnet_50", "efficientnet-b0"]
 
 
 if __name__ == "__main__":

--- a/examples/testscript_multianimal.py
+++ b/examples/testscript_multianimal.py
@@ -18,7 +18,7 @@ from deeplabcut.utils.auxfun_videos import VideoReader
 import random
 from pathlib import Path
 
-MODELS = ["dlcrnet_ms5", "dlcr101_ms5", "efficientnet-b0", "mobilenet_v2_0.35"]
+MODELS = ["dlcrnet_ms5", "dlcr101_ms5", "efficientnet-b0"]
 
 
 N_ITER = 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ scikit-learn>=1.0
 scipy>=1.9
 statsmodels>=0.11
 tensorflow>=2.0,<2.13.0
-tables==3.8.0
+tables
 tensorpack==0.11
 tf_slim==1.1.0
 torch==1.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,6 @@ tf-keras
 tables
 tensorpack==0.11
 tf_slim==1.1.0
-torch==1.12
+torch==2.7.1
 tqdm
 Pillow>=7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ intel-openmp; sys_platform == "win32" or sys_platform == "linux"
 imageio-ffmpeg
 imgaug==0.4.0
 numba>=0.54.0
-matplotlib<=3.5.2
+matplotlib>=3.3, <3.8.4
 networkx>=2.6
 numpy>=1.18.5,<2.0.0
 pandas>=1.0.1,!=1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ dlclibrary
 ipython
 filterpy
 ruamel.yaml>=0.15.0
-intel-openmp
+intel-openmp; sys_platform == "win32" or sys_platform == "linux"
 imageio-ffmpeg
 imgaug==0.4.0
 numba>=0.54.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,8 @@ scikit-image>=0.17
 scikit-learn>=1.0
 scipy>=1.9
 statsmodels>=0.11
-tensorflow>=2.0,<2.13.0
+tensorflow>=2.0
+tf-keras
 tables
 tensorpack==0.11
 tf_slim==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
     ],
     extras_require={
         "gui": [
-            "pyside6==6.4.2",
+            "pyside6",
             "qdarkstyle==3.1",
             "napari-deeplabcut>=0.2.1.6",
         ],

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ setuptools.setup(
         "docs": ["numpydoc"],
         "tf": [
             "tensorflow>=2.0,<=2.10;platform_system=='Windows'",
-            "tensorflow>=2.0,<=2.12;platform_system!='Windows'",
+            "tensorflow>=2.0;platform_system!='Windows'",
+            "tf-keras;platform_system!='Windows'",
             "tensorpack>=0.11",
             "tf_slim>=1.1.0",
         ],  # Last supported TF version on Windows Native is 2.10

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,8 @@ setuptools.setup(
             "tf_slim>=1.1.0",
         ],  # Last supported TF version on Windows Native is 2.10
         "apple_mchips": [
-            "tensorflow-macos<2.13.0",
+            "tensorflow-macos",
+            "tf-keras",
             "tensorflow-metal",
             "tensorpack>=0.11",
             "tf_slim>=1.1.0",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
         "tqdm",
         "pyyaml",
         "Pillow>=7.1",
-        "tables==3.8.0",
+        "tables",
     ],
     extras_require={
         "gui": [


### PR DESCRIPTION
### Description

This PR backports the TensorFlow backend fixes from [main branch PR](https://github.com/DeepLabCut/DeepLabCut/pull/3087) to the **DLC 2 LTS branch**, in order to ensure compatibility with **Python 3.12** (needed due to Google Colab’s migration from Python 3.11 → 3.12).

The motivation and general solution are the same as described in the main branch PR:
- Unpin TensorFlow (installing ≥2.16).
- Force switch to Keras 2 by installing `tf-keras` and setting the `TF_USE_LEGACY_KERAS=1` environment variable.
- Add a `_tf_legacy.py` shim to declare the environment variables and restore compatibility with `tf_keras.legacy_tf_layers`.
- Work around TensorFlow/wrapt bug (`WRAPT_DISABLE_EXTENSIONS=1`).
- Relax other pinned dependencies (`tables`, `PySide6`, etc.) for Python 3.12.
- Extend CI/CD to test against Python 3.11 and 3.12.

See the main branch PR for full details.

---

### LTS-specific changes

In addition to the above, the following changes were required specifically for the LTS branch:
- **CI/CD triggers:** Fixed workflow triggers (were missing in LTS branch).
- **TensorFlow import order:** Moved `import tensorflow` out of `deeplabcut/__init__.py` and into `deeplabcut/pose_estimation_tensorflow/__init__.py` (as already done in main branch), to ensure `_tf_legacy.py` runs before TensorFlow is imported.
- **Python 3.12 and `random.samle()`:** Converted Graph edges to list before calling `random.sample` (dict views are no longer supported in 3.12). This fix matches main.
- **Functional tests:** Removed MobileNets from functional tests (not available anymore, also already removed in main).
- **Dependency updates:** Synced with main branch updates (`intel-openmp`, `matplotlib`, `torch`).
- **CircleCI:** Updated Docker image to `python:3.12` (since latest TensorFlow does not provide wheels for 3.8 anymore).

---

### Testing

- Verified unit and functional tests run successfully in CI/CD for Python 3.11 and 3.12 on Linux, Windows, and macOS.
- Verified Colab notebooks with TensorFlow backend run with the simplified installation.
- Same caveat as in main: MacOS with `tensorflow-metal` should be manually tested.