### PR TITLE
PyTorch: Improve inference batching speed

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/runners/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/inference.py
@@ -96,7 +96,7 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
         self.model.to(self.device)
         self.model.eval()
 
-        self._batch: torch.Tensor | None = None
+        self._batch_list: list[torch.Tensor] = []
         self._model_kwargs: dict[str, np.ndarray | torch.Tensor] = {}
 
         self._contexts: list[dict] = []
@@ -193,7 +193,7 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
         # Reset state
         self._stop_event.clear()
         self._exception = None
-        self._batch = None
+        self._batch_list = []
         self._model_kwargs = {}
         self._contexts = []
         self._image_batch_sizes = []
@@ -288,14 +288,12 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
         if len(inputs) == 0:
             return
 
-        if self._batch is None:
-            self._batch = inputs
-        else:
-            self._batch = torch.cat([self._batch, inputs], dim=0)
+        # extend the list with individual image tensors (slice along first dim)
+        self._batch_list.extend(list(inputs))
 
     def _process_full_batches(self) -> None:
         """Processes prepared inputs in batches of the desired batch size."""
-        while self._batch is not None and len(self._batch) >= self.batch_size:
+        while len(self._batch_list) >= self.batch_size:
             self._process_batch()
 
     def _extract_results(self, shelf_writer: shelving.ShelfWriter) -> list:
@@ -334,26 +332,26 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
         Processes a batch. There must be inputs waiting to be processed before this is
         called, otherwise this method will raise an error.
         """
-        batch = self._batch[: self.batch_size]
+        batch = torch.stack(self._batch_list[: self.batch_size], dim=0)
         model_kwargs = {
             mk: v[: self.batch_size] for mk, v in self._model_kwargs.items()
         }
 
         self._predictions += self.predict(batch, **model_kwargs)
 
-        # remove processed inputs from batch
-        if len(self._batch) <= self.batch_size:
-            self._batch = None
+        # remove processed inputs
+        if len(self._batch_list) <= self.batch_size:
+            self._batch_list = []
             self._model_kwargs = {}
         else:
-            self._batch = self._batch[self.batch_size :]
+            self._batch_list = self._batch_list[self.batch_size :]
             self._model_kwargs = {
                 mk: v[self.batch_size :] for mk, v in self._model_kwargs.items()
             }
 
     def _inputs_waiting_for_processing(self) -> bool:
         """Returns: Whether there are inputs which have not yet been processed"""
-        return self._batch is not None and len(self._batch) > 0
+        return len(self._batch_list) > 0
 
     def _safe_put(self, item: Any) -> bool:
         """Put item in the queue, retrying until successful or stop_event is set"""
@@ -393,8 +391,8 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
                 self._prepare_inputs(data)
 
                 # Process full batches and put them in the queue
-                while self._batch is not None and len(self._batch) >= self.batch_size:
-                    batch = self._batch[: self.batch_size]
+                while len(self._batch_list) >= self.batch_size:
+                    batch = torch.stack(self._batch_list[: self.batch_size], dim=0)
                     model_kwargs = {
                         mk: v[: self.batch_size] for mk, v in self._model_kwargs.items()
                     }
@@ -402,18 +400,19 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
                     self._safe_put((batch, model_kwargs))
 
                     # Remove processed inputs from batch
-                    if len(self._batch) <= self.batch_size:
-                        self._batch, self._model_kwargs = None, {}
+                    if len(self._batch_list) <= self.batch_size:
+                        self._batch_list, self._model_kwargs = [], {}
                     else:
-                        self._batch = self._batch[self.batch_size :]
+                        self._batch_list = self._batch_list[self.batch_size :]
                         self._model_kwargs = {
                             mk: v[self.batch_size :]
                             for mk, v in self._model_kwargs.items()
                         }
 
             # Process any remaining inputs
-            if self._batch is not None and len(self._batch) > 0:
-                self._safe_put((self._batch, self._model_kwargs))
+            if len(self._batch_list) > 0:
+                batch = torch.stack(self._batch_list, dim=0)
+                self._safe_put((batch, self._model_kwargs))
 
         except BaseException as e:  # catches KeyboardInterrupt, SystemExit, etc.
             self._exception = e


### PR DESCRIPTION
## Summary
This PR replaces incremental tensor concatenation ( $O(n^2)$ ) during inference with a list-based accumulation. Final stacking now happens only when forming a batch, avoiding repeated reallocation and copy.

(Depends on #3094)

**Main points:**
- Appending images is now $O(1)$ amortized.
- Single torch.stack per processed batch.
- Reduced peak allocator churn and CPU overhead.
- No public API changes.


## Details

The [previous pattern](https://github.com/DeepLabCut/DeepLabCut/blob/5fb2525df9f8b49cf1d270c486fac5c2c66e4357/deeplabcut/pose_estimation_pytorch/runners/inference.py#L297) for batching images during inference:
```python
self._batch = torch.cat([self._batch, inputs], dim=0)
```
caused $O(n^2)$ total memory movement for $n$ appended images. This was a bottleneck for larger batches, causing allocator churn and CPU overhead.

### Profiling 
This was confirmed by benchmarking the inference procedure with [Torch Profile](https://docs.pytorch.org/tutorials/recipes/recipes/profiler_recipe.html) and [Scalene](https://github.com/plasma-umass/scalene).

**Torch Profile**
We can see for large batch sizes, the GPU is stalled and waits for the producer CPU thread to finish preprocessing the images.
<img width="1895" height="880" alt="image" src="https://github.com/user-attachments/assets/8a19a60a-ec2b-4af8-a46b-f86f14487571" />

**Scalene**
Statistical analysis shows that the concatenation operation is one of the main hot spots of the inference procedure due to reallocation and copying of the immutable tensor:
<img width="1682" height="496" alt="image" src="https://github.com/user-attachments/assets/2eb588d5-e682-429c-85e4-cc62c4622cd2" />


### Results


We can see that these changes fix the problem with large batch sizes being inefficient (thanks @maximpavliv for running the benchmark):


<div style="display: flex; gap: 10px;">
  <img src="https://github.com/user-attachments/assets/549bd227-9958-4bd4-9b13-2fad78ac6b6f" alt="fps_vs_batchsize_128x128" width="250"/>
  <img src="https://github.com/user-attachments/assets/288ab111-f714-4042-9831-8bb742beb2bd" alt="fps_vs_batchsize_256x256" width="250"/>
  <img src="https://github.com/user-attachments/assets/c26c190b-5c5a-472c-b64f-d7695a6747fb" alt="fps_vs_batchsize_512x512" width="250"/>
</div>
And the batching pipeline is no longer listed in Scalene results:
<img width="1527" height="1015" alt="image" src="https://github.com/user-attachments/assets/1758b5fd-ed29-493e-b4dc-daf75be20bf8" />
 


