### PR TITLE
Add `autocast` sub-config to inference settings and disable `torch.autocast` by default

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/apis/videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/videos.py
@@ -40,6 +40,7 @@ from deeplabcut.pose_estimation_pytorch.runners import (
     InferenceRunner,
     TopDownDynamicCropper,
 )
+from deeplabcut.pose_estimation_pytorch.runners.inference import InferenceConfig
 from deeplabcut.pose_estimation_pytorch.task import Task
 from deeplabcut.refine_training_dataset.stitch import stitch_tracklets
 from deeplabcut.utils import auxiliaryfunctions, VideoReader
@@ -272,6 +273,7 @@ def analyze_videos(
     cropping: list[int] | None = None,
     save_as_df: bool = False,
     show_gpu_memory: bool = False,
+    inference_cfg: InferenceConfig | dict | None = None,
 ) -> str:
     """Makes prediction based on a trained network.
 
@@ -402,6 +404,8 @@ def analyze_videos(
             saved in a CSV file.
         show_gpu_memory: When true, the tqdm progress bar shows the gpu memory usage
             of the current process.
+        inference_cfg: InferenceConfig to use
+            If None, the configuration from the `pytorch_cfg.yaml` will be used
 
     Returns:
         The scorer used to analyze the videos
@@ -512,6 +516,7 @@ def analyze_videos(
         dynamic=dynamic,
         cond_provider=cond_provider,
         ctd_tracking=ctd_tracking,
+        inference_cfg=inference_cfg,
     )
 
     detector_runner = None
@@ -536,6 +541,7 @@ def analyze_videos(
             snapshot_path=detector_snapshot.path,
             max_individuals=max_num_animals,
             batch_size=detector_batch_size,
+            inference_cfg=inference_cfg,
         )
 
     dlc_scorer = loader.scorer(snapshot, detector_snapshot)

--- a/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
+++ b/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
@@ -23,6 +23,7 @@ from deeplabcut.pose_estimation_pytorch.config.utils import (
     replace_default_values,
     update_config,
 )
+from deeplabcut.pose_estimation_pytorch.runners.inference import InferenceConfig
 from deeplabcut.pose_estimation_pytorch.task import Task
 from deeplabcut.utils import auxiliaryfunctions, auxfun_multianimal
 
@@ -186,6 +187,8 @@ def make_pytorch_pose_config(
             num_individuals=len(individuals),
             backbone_output_channels=pose_config["model"]["backbone_output_channels"],
         )
+
+    pose_config["inference"] = InferenceConfig().to_dict()
 
     # sort first-level keys to make it prettier
     pose_config = dict(sorted(pose_config.items()))

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/config.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/config.py
@@ -28,6 +28,7 @@ from deeplabcut.pose_estimation_pytorch.modelzoo.utils import (
     get_super_animal_model_config_path,
     get_super_animal_project_config_path,
 )
+from deeplabcut.pose_estimation_pytorch.runners.inference import InferenceConfig
 from deeplabcut.pose_estimation_pytorch.task import Task
 
 
@@ -169,6 +170,8 @@ def create_config_from_modelzoo(
         model_cfg["model"], num_bodyparts=len(converted_bodyparts)
     )
     model_cfg["train_settings"]["weight_init"] = weight_init.to_dict()
+
+    model_cfg["inference"] = InferenceConfig().to_dict()
 
     # sort first-level keys to make it prettier
     return dict(sorted(model_cfg.items()))

--- a/deeplabcut/pose_estimation_pytorch/runners/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/inference.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass, field, asdict
 from pathlib import Path
 from typing import Any, Generic, Iterable
 import threading
@@ -36,6 +37,56 @@ from deeplabcut.pose_estimation_pytorch.runners.dynamic_cropping import (
 from deeplabcut.pose_estimation_pytorch.task import Task
 
 
+def _merge_defaults(cls, data: dict[str, Any]):
+    """
+    Utility: merge a partial dict with the defaults of a dataclass.
+    Unknown keys are ignored.
+    """
+    defaults = asdict(cls())  # defaults from calling the dataclass constructor
+    for k, v in data.items():
+        if k in defaults and isinstance(defaults[k], dict) and isinstance(v, dict):
+            # merge nested dicts recursively
+            defaults[k].update(v)
+        elif k in defaults:
+            defaults[k] = v
+    return defaults
+
+@dataclass
+class MultithreadingConfig:
+    """
+    Parameters for the multithreaded inference pipeline:
+        enabled: Whether to use async inference with pipeline parallelism
+        queue_length: Number of batches to prefetch in async mode
+        timeout: Timeout for queue operations in async mode
+    """
+    enabled: bool = True
+    queue_length: int = 4
+    timeout: float = 30.0
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "MultithreadingConfig":
+        return cls(**_merge_defaults(cls, data or {}))
+
+@dataclass
+class InferenceConfig:
+    """
+    Top-level inference configuration that mirrors the `inference` block
+    in pytorch_config.yaml.
+    """
+    multithreading: MultithreadingConfig = field(default_factory=MultithreadingConfig)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> "InferenceConfig":
+        """
+        Build an InferenceConfig from a (possibly partial) dict
+        like the one loaded from pytorch_config.yaml["inference"].
+        """
+        data = data or {}
+        return cls(
+            multithreading=MultithreadingConfig.from_dict(data.get("multithreading", {})),
+        )
+
+
 class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
     """Base class for inference runners
 
@@ -51,9 +102,7 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
         preprocessor: Preprocessor | None = None,
         postprocessor: Postprocessor | None = None,
         load_weights_only: bool | None = None,
-        async_mode: bool = True,
-        num_prefetch_batches: int = 2,
-        timeout: float = 30.0,
+        inference_cfg: InferenceConfig | dict | None = None,
     ):
         """
         Args:
@@ -70,9 +119,7 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
                         https://pytorch.org/docs/stable/generated/torch.load.html
                 If None, the default value is used:
                     `deeplabcut.pose_estimation_pytorch.get_load_weights_only()`
-            async_mode: Whether to use async inference with pipeline parallelism
-            num_prefetch_batches: Number of batches to prefetch in async mode
-            timeout: Timeout for queue operations in async mode
+            inference_cfg: Configuration for the inference runner
         """
         super().__init__(model=model, device=device, snapshot_path=snapshot_path)
         if not isinstance(batch_size, int) or batch_size <= 0:
@@ -81,9 +128,13 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
         self.batch_size = batch_size
         self.preprocessor = preprocessor
         self.postprocessor = postprocessor
-        self.async_mode = async_mode
-        self.num_prefetch_batches = num_prefetch_batches
-        self.timeout = timeout
+
+        if isinstance(inference_cfg, InferenceConfig):
+            self.inference_cfg = inference_cfg
+        elif isinstance(inference_cfg, dict):
+            self.inference_cfg = InferenceConfig.from_dict(inference_cfg)
+        elif inference_cfg is None:
+            self.inference_cfg = InferenceConfig()
 
         if self.snapshot_path is not None and self.snapshot_path != "":
             self.load_snapshot(
@@ -104,8 +155,8 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
         self._predictions: list = []
 
         # Async-specific attributes
-        if self.async_mode:
-            self._input_queue = Queue(maxsize=num_prefetch_batches)
+        if self.inference_cfg.multithreading.enabled:
+            self._input_queue = Queue(maxsize=self.inference_cfg.multithreading.queue_length)
             self._preprocessing_thread = None
             self._stop_event = threading.Event()
             self._exception = None
@@ -154,7 +205,7 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
                 }
             ]
         """
-        if self.async_mode:
+        if self.inference_cfg.multithreading.enabled:
             return self._async_inference(images, shelf_writer)
         else:
             return self._sequential_inference(images, shelf_writer)
@@ -237,7 +288,7 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
         finally:
             # Wait for preprocessing thread to finish
             if self._preprocessing_thread is not None:
-                self._preprocessing_thread.join(timeout=self.timeout)
+                self._preprocessing_thread.join(timeout=self.inference_cfg.multithreading.timeout)
 
             # Check for exceptions in preprocessing thread
             if self._exception is not None:
@@ -897,9 +948,7 @@ def build_inference_runner(
     postprocessor: Postprocessor | None = None,
     dynamic: DynamicCropper | None = None,
     load_weights_only: bool | None = None,
-    async_mode: bool = True,
-    num_prefetch_batches: int = 4,
-    timeout: float = 30.0,
+    inference_cfg: InferenceConfig | dict | None = None,
     **kwargs,
 ) -> InferenceRunner:
     """
@@ -924,9 +973,7 @@ def build_inference_runner(
                 https://pytorch.org/docs/stable/generated/torch.load.html
             If None, the default value is used:
                 `deeplabcut.pose_estimation_pytorch.get_load_weights_only()`
-        async_mode: Whether to use async inference with pipeline parallelism
-        num_prefetch_batches: Number of batches to prefetch in async mode
-        timeout: Timeout for queue operations in async mode
+        inference_cfg: Configuration for the inference runner
         **kwargs: Other arguments for the InferenceRunner.
 
     Returns:
@@ -940,9 +987,7 @@ def build_inference_runner(
         preprocessor=preprocessor,
         postprocessor=postprocessor,
         load_weights_only=load_weights_only,
-        async_mode=async_mode,
-        num_prefetch_batches=num_prefetch_batches,
-        timeout=timeout,
+        inference_cfg=inference_cfg,
         **kwargs,
     )
 

--- a/deeplabcut/pose_estimation_pytorch/runners/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/inference.py
@@ -67,6 +67,9 @@ class MultithreadingConfig:
     def from_dict(cls, data: dict[str, Any]) -> "MultithreadingConfig":
         return cls(**_merge_defaults(cls, data or {}))
 
+    def to_dict(self) -> dict:
+        return asdict(self)
+
 @dataclass
 class InferenceConfig:
     """
@@ -85,6 +88,11 @@ class InferenceConfig:
         return cls(
             multithreading=MultithreadingConfig.from_dict(data.get("multithreading", {})),
         )
+
+    def to_dict(self) -> dict:
+        return {
+            "multithreading": self.multithreading.to_dict(),
+        }
 
 
 class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):


### PR DESCRIPTION
### Description

This Pull Request builds on top of [#3104](https://github.com/DeepLabCut/DeepLabCut/pull/3104) and [#3098](https://github.com/DeepLabCut/DeepLabCut/pull/3098), adding a new `autocast` **sub-config** to the `inference:` block of the PyTorch configuration.

The use of `torch.autocast` during inference was first introduced in [#3012 (“Shaokai/faster inference”)](https://github.com/DeepLabCut/DeepLabCut/pull/3012)
 with the goal of improving inference speed.
However, we later discovered that enabling `torch.autocast` can **significantly decrease inference accuracy** — this is the root cause of [issue #3083](https://github.com/DeepLabCut/DeepLabCut/issues/3083) and the forum discussion [“Better results with DeepLabCut==2.3.0 than DeepLabCut==3.0 with PyTorch”](https://forum.image.sc/t/better-results-with-deeplabcut-2-3-0-than-deeplabcut-3-0-with-pytorch/116017).

### Key Changes
- Introduced an `autocast` sub-config in the `inference:` block of `pytorch_config.yaml`.
- Added an `AutocastConfig` class to manage parameters consistently with the existing `compile` and `multithreading` options.
- Inference logic now respects this configuration and defaults to **autocast disabled** to avoid unintended accuracy drops.
- Advanced users can enable autocast either:
  - programmatically (by passing an `InferenceConfig` object or a dictionary), or
  - by editing the `pytorch_config.yaml` file under the `inference:` block.

### Notes & Future Work
- Default behavior is **changed back to v3.0.0rc8** — autocast is now _off_ by default to preserve accuracy.
- Advanced users may still enable it to experiment with potential speedups, accepting the risk of reduced prediction quality.
- In future work, we plan to investigate whether training models with `torch.autocast` can mitigate this accuracy gap and allow safer use of autocast at inference.