### PR TITLE
PyTorch: Speed up single animal models

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/models/predictors/single_predictor.py
+++ b/deeplabcut/pose_estimation_pytorch/models/predictors/single_predictor.py
@@ -134,8 +134,8 @@ class HeatmapPredictor(BasePredictor):
 
         Example:
             >>> predictor = HeatmapPredictor(location_refinement=True, locref_std=7.2801)
-            >>> heatmap = torch.rand(32, 17, 64, 64)
-            >>> locref = torch.rand(32, 17, 64, 64, 2)
+            >>> heatmap = torch.rand(32, 64, 64, 17)
+            >>> locref = torch.rand(32, 64, 64, 17, 2)
             >>> scale_factors = (0.5, 0.5)
             >>> poses = predictor.get_pose_prediction(heatmap, locref, scale_factors)
         """

--- a/deeplabcut/pose_estimation_pytorch/models/predictors/single_predictor.py
+++ b/deeplabcut/pose_estimation_pytorch/models/predictors/single_predictor.py
@@ -139,24 +139,31 @@ class HeatmapPredictor(BasePredictor):
             >>> scale_factors = (0.5, 0.5)
             >>> poses = predictor.get_pose_prediction(heatmap, locref, scale_factors)
         """
-        y, x = self.get_top_values(heatmap)
+        y, x = self.get_top_values(heatmap) # y, x: (batch_size, num_joints)
 
         batch_size, num_joints = x.shape
 
-        dz = torch.zeros((batch_size, 1, num_joints, 3), device=heatmap.device)
-        for b in range(batch_size):
-            for j in range(num_joints):
-                dz[b, 0, j, 2] = heatmap[b, y[b, j], x[b, j], j]
-                if locref is not None:
-                    dz[b, 0, j, :2] = locref[b, y[b, j], x[b, j], j, :]
+        # Create batch and joint indices for indexing
+        # batch_idx: [[0,0,0,...], [1,1,1,...], [2,2,2,...], ...]
+        batch_idx = torch.arange(batch_size, device=heatmap.device).unsqueeze(1).expand(-1, num_joints) # (batch_size, num_joints)
+        # joint_idx: [[0,1,2,...], [0,1,2,...], [0,1,2,...], ...]
+        joint_idx = torch.arange(num_joints, device=heatmap.device).unsqueeze(0).expand(batch_size, -1) # (batch_size, num_joints)
 
-        x, y = torch.unsqueeze(x, 1), torch.unsqueeze(y, 1)
+        # Vectorized extraction of heatmap scores and locref offsets
+        scores = heatmap[batch_idx, y, x, joint_idx]  # (batch_size, num_joints)
+        
+        dz = torch.zeros((batch_size, 1, num_joints, 3), device=heatmap.device)
+        dz[:, 0, :, 2] = scores
+        
+        if locref is not None:
+            offsets = locref[batch_idx, y, x, joint_idx, :]  # (batch_size, num_joints, 2)
+            dz[:, 0, :, :2] = offsets
+
+        x, y = x.unsqueeze(1), y.unsqueeze(1) # x, y: (batch_size, 1, num_joints)
 
         x = x * scale_factors[1] + 0.5 * scale_factors[1] + dz[:, :, :, 0]
         y = y * scale_factors[0] + 0.5 * scale_factors[0] + dz[:, :, :, 1]
 
-        pose = torch.zeros((batch_size, 1, num_joints, 3), device=heatmap.device)
-        pose[:, :, :, 0] = x
-        pose[:, :, :, 1] = y
-        pose[:, :, :, 2] = dz[:, :, :, 2]
+        pose = torch.stack([x, y, dz[:, :, :, 2]], dim=-1)  # (batch_size, 1, num_joints, 3)
+        
         return pose


### PR DESCRIPTION
This PR improves the prediction performance of various single animal PyTorch models.
The `for` loops for extracting values out of the `heatmap` tensor were replaced with advanced indexing.

 ## Details

Profiling results showed [`HeatmapPredictor.get_pose_prediction`](https://github.com/DeepLabCut/DeepLabCut/blob/33164a461c30c4144b27c5000e775472fb3a95a6/deeplabcut/pose_estimation_pytorch/models/predictors/single_predictor.py#L122) as a major hot spot in single animal inference procedure.

After this change, we see a massive speed-up in the major single animal models as shown below (thanks to @maximpavliv for running the benchmark)

<div style="display: flex; gap: 10px;">
  <img src="https://github.com/user-attachments/assets/d2b5c0d5-fefb-4a6f-b897-e9259fd9c6a5" alt="fps_vs_batchsize_128x128" width="250"/>
  <img src="https://github.com/user-attachments/assets/25946b21-4a34-4442-8299-ade0a07b1919" alt="fps_vs_batchsize_256x256" width="250"/>
  <img src="https://github.com/user-attachments/assets/041c8b10-c6c0-4324-9d28-969aac3dd900" alt="fps_vs_batchsize_512x512" width="250"/>
</div>
