### PR TITLE
Remove trailing underscore in superanimal scorer names

### DIFF
--- a/deeplabcut/modelzoo/utils.py
+++ b/deeplabcut/modelzoo/utils.py
@@ -97,9 +97,9 @@ def get_super_animal_scorer(
         detector_name = detector_snapshot_path.stem
         if detector_name.startswith(super_animal_prefix):
             detector_name = detector_name[len(super_animal_prefix) :]
-        dlc_scorer += f"_{detector_name}_"
+        dlc_scorer += f"_{detector_name}"
     elif torchvision_detector_name is not None:
-        dlc_scorer += f"_{torchvision_detector_name}_"
+        dlc_scorer += f"_{torchvision_detector_name}"
 
     return dlc_scorer
 


### PR DESCRIPTION
Cleans up the DLC SuperAnimal scorer naming introduced by mistake in PR https://github.com/DeepLabCut/DeepLabCut/pull/3066, where an
extra trailing underscore was appended when a detector was used.  

- Trailing underscores are now removed when concatenating `detector_snapshot_path` or `torchvision_detector_name`.
- Ensures cleaner and more consistent scorer names.

Example:
- Previously: `superanimal_bird_resnet_50_fasterrcnn_mobilenet_v3_large_fpn_`
- Now: `superanimal_bird_resnet_50_fasterrcnn_mobilenet_v3_large_fpn`