### PR TITLE
Bbox score filtering

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/data/postprocessor.py
+++ b/deeplabcut/pose_estimation_pytorch/data/postprocessor.py
@@ -214,9 +214,7 @@ def build_detector_postprocessor(max_individuals: int) -> Postprocessor:
                 keys_to_rescale=["bboxes"],
                 mode=RescaleAndOffset.Mode.BBOX_XYWH,
             ),
-            RemoveLowConfidenceBoxes(
-                bbox_score_thresh=0.25
-            ),
+            RemoveLowConfidenceBoxes(bbox_score_thresh=0.25),
         ]
     )
 
@@ -445,12 +443,13 @@ class RemoveLowConfidenceBoxes(Postprocessor):
     """
 
     def __init__(self, bbox_score_thresh: float):
-        print('utilizing low confidence bbox filtering')
+        print("utilizing low confidence bbox filtering")
         self.bbox_score_thresh = bbox_score_thresh
 
-
-    def __call__(self, predictions: dict[str, np.ndarray], context: Context) -> tuple[dict[str, np.ndarray], Context]:
-        keepers = np.where(predictions['bbox_scores'] > self.bbox_score_thresh)
+    def __call__(
+        self, predictions: dict[str, np.ndarray], context: Context
+    ) -> tuple[dict[str, np.ndarray], Context]:
+        keepers = np.where(predictions["bbox_scores"] > self.bbox_score_thresh)
         for name in predictions:
             output = predictions[name]
             if len(output) > len(keepers):


### PR DESCRIPTION
Summary: Filters out low-confidence bounding box detections during top-down pose estimation to reduce false-positives

I'm working on a project where the animals frequently leave the field of view for extended periods. While I found that top-down pose estimation worked well when both of my animals were in frame, it also resulted in false-positives when less than the max number of animals were in frame. For example, when only one of the two animals was in frame, I would see the scenario shown in the attached image, where two bounding boxes would be placed over the same individual and some keypoints would be detected twice. Upon further investigation, I found that the "bad" bounding boxes almost always had very low detection confidences. So I implemented a new RemoveLowConfidenceBoxes (inheriting from the PostProcessor class) in postprocessor.py, and integrated it into the build_detector_postprocessor function. Now detections with low confidence are removed before reaching the pose estimation phase, preventing the issue. Feedback and suggestions welcome!

<img width="648" height="679" alt="image" src="https://github.com/user-attachments/assets/1d71cfca-1dfa-4d5e-a3fa-4716a26a0972" />

