### PR TITLE
CI: Increase timeout in multiprocessing test

### DIFF
--- a/tests/utils/test_multiprocessing.py
+++ b/tests/utils/test_multiprocessing.py
@@ -28,7 +28,7 @@ def _hanging_method():
 
 def test_call_with_timeout():
     parameter = (10, "Hello test")
-    assert call_with_timeout(_succeeding_method, 30, parameter) == parameter
+    assert call_with_timeout(_succeeding_method, 60, parameter) == parameter
 
     with pytest.raises(ValueError):
         call_with_timeout(_failing_method, timeout=30)


### PR DESCRIPTION
We sometimes get spurious failures on Windows CI because of too short a timeout in one of the tests (rerunning the check usually fixes it).

This PR increases the timeout to avoid these sporadic failures.