### PR TITLE
docs: pin jupyter-book version

### DIFF
--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install .[docs]
-        pip install jupyter-book sphinxcontrib-mermaid
+        pip install jupyter-book==1.0.4.post1 sphinxcontrib-mermaid
 
     - name: Build the book
       run: |


### PR DESCRIPTION
### Summary
Fix [the issue](https://github.com/DeepLabCut/DeepLabCut/actions/runs/19066278258/job/54457618175) with an empty documentation being deployed to gh-pages caused by the new `juptyer-book` version.

Pin the `juptyer-book` version to "1.0.4.post1" to avoid build failures.

