### PR TITLE
Add argument max workers for multiprocessing in create_labeled_video

### DIFF
--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -451,6 +451,7 @@ def create_labeled_video(
     confidence_to_alpha: Union[bool, Callable[[float], float]] = False,
     plot_bboxes: bool = True,
     bboxes_pcutoff: float | None = None,
+    max_workers: Optional[int] = None,
     **kwargs,
 ):
     """Labels the bodyparts in a video.
@@ -596,6 +597,11 @@ def create_labeled_video(
 
     bboxes_pcutoff, float, optional, default=None:
         If plotting bounding boxes, this overrides the bboxes_pcutoff set in the model configuration.
+
+    max_workers (int | None):
+        Maximum number of processes to use for multiprocessing. Set this parameter to limit the total RAM-usage of
+        simultaneous processes. Default: no maximum (i.e. number of spawned processes is based on the number of 
+        cores and the number of input videos).  
 
     kwargs: additional arguments.
         For torch-based shuffles, can be used to specify:
@@ -806,7 +812,8 @@ def create_labeled_video(
     )
 
     if get_start_method() == "fork":
-        with Pool(min(os.cpu_count(), len(Videos))) as pool:
+        n_workers = (max_workers or min(os.cpu_count(), len(Videos)))
+        with Pool(n_workers) as pool:
             results = pool.map(func, Videos)
     else:
         results = []


### PR DESCRIPTION
Add argument `max_workers` to limit the number of processes spawned in `create_labeled_video`. 

The default behavior remains the same: when using multiprocessing, the number of spawned processes is `min(cpu_cores, n_videos)`. 

For some users that are processing many videos on a machine with many cores, the large number of simultaneous processes can drastically increase RAM-usage, especially for high resolution videos. Adding the `max_workers` parameter helps to the user to mitigate this.


**Some profiling results:**
The effects of limiting the max number of workers to 4 on a machine with 20 cores.
<img width="590" height="590" alt="total-memory-and-time" src="https://github.com/user-attachments/assets/14dd3c8e-ddc8-43a6-8f83-70373e9bbf39" />

<img width="590" height="590" alt="per-worker-memory" src="https://github.com/user-attachments/assets/f11b9ce8-6209-4115-b3f3-31f92cf39a37" />
