### PR TITLE
Add custom augmentation feature to pose_estimation_pytorch

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/data/transforms.py
+++ b/deeplabcut/pose_estimation_pytorch/data/transforms.py
@@ -21,10 +21,12 @@ from numpy.typing import NDArray
 from scipy.spatial.distance import pdist, squareform
 from scipy.stats import truncnorm
 
+# add in second parameter to see if train or inference is passed for the training
 
 def build_transforms(augmentations: dict) -> A.BaseCompose:
     transforms = []
-
+    print("ADDING AUGMENTATIONS")
+    print(f"This is augmentations passed {augmentations}")
     if resize_aug := augmentations.get("resize", False):
         transforms += build_resize_transforms(resize_aug)
 
@@ -121,6 +123,9 @@ def build_transforms(augmentations: dict) -> A.BaseCompose:
         transforms.append(ElasticTransform(sigma=5, p=0.5))
     if augmentations.get("grayscale", False):
         transforms.append(Grayscale(alpha=(0.5, 1.0)))
+        
+   
+
     if noise := augmentations.get("gaussian_noise", False):
         # TODO inherit custom gaussian transform to support per_channel = 0.5
         if not isinstance(noise, (int, float)):
@@ -134,7 +139,66 @@ def build_transforms(augmentations: dict) -> A.BaseCompose:
                 p=0.5,
             )
         )
-
+    # If the custom_augmentation is set to true , it will add augmentations in training
+    if augmentations.get("custom_augmentation", False):    
+        # Add in compression tranformation
+        transforms.append(A.ImageCompression(quality_lower=50, quality_upper=90, p=1.0))
+        print("Image Compression augmentation added...")
+        # Add in sun flare that mimics the lights reflection in rat chamber
+        transforms.append(    # Custom physics-based sun flare
+        A.RandomSunFlare(
+            flare_roi=(0.4, 0.4, 0.6, 0.6),  # center of the image
+            # angle_range=(0.45, 0.55),        # roughly centered
+            angle_lower = 0.45,
+            angle_upper = 0.55,
+            # num_flare_circles_range=(5, 15), # same, you can increase for more effect
+            num_flare_circles_lower = 5,
+            num_flare_circles_upper = 15,
+            src_radius=200,                   # adjust size if needed
+            src_color=(255, 255, 100),        # bright yellow
+            # method="physics_based",
+            p=1.0                             # always apply
+            )
+        )
+        print("SunFlare augmentation added...")
+        # Add in rain augmentation
+        transforms.append(
+            A.RandomRain(
+            # slant_range=(-1, 1),       # angle of rain
+            slant_lower = -1,
+            slant_upper = 1,
+            drop_length=15,              # length of drops
+            # drop_width=20,                # width of drops
+            drop_width=5,
+            drop_color=(180, 180, 180),  # color of drops (grayish)
+            blur_value=5,                # motion blur
+            brightness_coefficient=0.8,  # darken slightly
+            rain_type="drizzle",           # heavy rain
+            p=1.0
+            )
+        )
+        print("Rain effect augmentation added...")
+        # Add in sharpen augmentation
+        transforms.append(
+            A.Sharpen(
+            alpha=(1.0, 1.0),        # strength of sharpening (0.0, 1.0) 0 is original
+            lightness=(1.0, 1.0),    # overall brightness adjustment (0.0, 1.0) 1 is original
+            # method='kernel',         # traditional sharpening
+            p=1.0                 
+            )
+        )
+        print("Sharpen augmentation added...")
+        # Add in hue saturation
+        transforms.append(   
+            A.HueSaturationValue(
+            hue_shift_limit=(-5, -5),           #(-180, 180)
+            sat_shift_limit=(-60, -60),         #(-255, 255)
+            val_shift_limit=(20, 20),           #(-255, 255)
+            p=1
+            )
+        )
+        print("Hue saturation augmentation added...")
+    
     if augmentations.get("auto_padding"):
         transforms.append(build_auto_padding(**augmentations["auto_padding"]))
 
@@ -145,6 +209,8 @@ def build_transforms(augmentations: dict) -> A.BaseCompose:
 
     if augmentations.get("scale_to_unit_range"):
         transforms.append(ScaleToUnitRange())
+
+    print(f"This is the augmentations passed {transforms}")
 
     return A.Compose(
         transforms,

--- a/deeplabcut/pose_estimation_pytorch/data/transforms.py
+++ b/deeplabcut/pose_estimation_pytorch/data/transforms.py
@@ -24,6 +24,22 @@ from scipy.stats import truncnorm
 
 
 def transforms_legacy(augmentations):
+
+    """
+    Apply DeepLabCut original augmentation methods.
+
+    This function preserves DLC's default augmentation implementations
+    for backward compatibility.
+
+    Args:
+        augmentations: dictionary of augmentations from config file
+    
+    Returns:
+        
+        The list of augmentation transforms
+    
+    """
+
     transforms = []
     if resize_aug := augmentations.get("resize", False):
         transforms += build_resize_transforms(resize_aug)
@@ -152,6 +168,23 @@ def transforms_legacy(augmentations):
 
 
 def transform_new(augmentations: list[dict[str, Any]]) -> list[A.BasicTransform]:
+
+    """
+    Creates augmentation using Albumentation library with hybrid support.
+
+    Args:
+        augmentations: the augmentations from "transform" in list format
+    
+    Raises:
+        Warnings:
+            Augmentation method must exist in augmentations.
+            Augmentation must exist in the Albumentation library.
+
+    Returns:
+        The list of augmentation transforms
+    
+    """
+
     custom_augmentations =['auto_padding', 'gaussian_noise', 'motion_blur', 'normalize_images']
 
     transforms =[]

--- a/deeplabcut/pose_estimation_pytorch/data/transforms.py
+++ b/deeplabcut/pose_estimation_pytorch/data/transforms.py
@@ -22,7 +22,7 @@ from scipy.spatial.distance import pdist, squareform
 from scipy.stats import truncnorm
 
 
-## KEEPS THE ORIGINAL AUGMENTATION CODE AND ORDER OF DEEPLABCUT 
+
 def transforms_legacy (augmentations):
 
     transforms = []
@@ -153,7 +153,7 @@ def transforms_legacy (augmentations):
     return transforms
 
 
-# Supports the list method 
+
 def transform_new(augmentations: list[dict[str, Any]], transforms =[]) -> list[A.BasicTransform]:
 
     custom_augmentations =['affine','auto_padding','gaussian_noise', 'crop_sampling','motion_blur', 'normalize_images']
@@ -161,12 +161,9 @@ def transform_new(augmentations: list[dict[str, Any]], transforms =[]) -> list[A
     for aug in augmentations:
 
         method = aug.pop('augmentation')
-
-        # Retrieve the default values set by DeepLabCut
         if method.lower() in custom_augmentations:
                 add_aug = transforms_legacy({method.lower(): aug})
                 transforms.extend(add_aug)
-        # Retrieves augmentations that are supported by Albumentations
         elif hasattr(A, method):
             func = getattr(A,method)
             transforms.append(func(**aug))
@@ -175,21 +172,16 @@ def transform_new(augmentations: list[dict[str, Any]], transforms =[]) -> list[A
 
     return transforms
 
+
 def build_transforms(augmentations: dict) -> A.BaseCompose:
 
-    # Get the transform 
     transforms = transforms_legacy(augmentations)
 
-    # if there is only transform in the config file 
     if "transform" in augmentations and len(augmentations) == 1:
         transforms = transform_new(augmentations['transform'])
-        print(f"Augmentations added {t_new}")
-
-    # if transform is in augmentations and with old method
     elif "transform" in augmentations:
         t_new = transform_new(augmentations['transform'])
         transforms.extend(t_new)
-
 
     return A.Compose(
     transforms,
@@ -198,14 +190,6 @@ def build_transforms(augmentations: dict) -> A.BaseCompose:
     ),
     bbox_params=A.BboxParams(format="coco", label_fields=["bbox_labels"]),
     )
-
-    
-
-
-    
-   
-
-    
 
 
 


### PR DESCRIPTION
My team wanted to expand DeepLabCut's limited augmentation options by incorporating the albumentations library as our project needed augmentations that mimic glares. We developed a hybrid approach that preserves DLC's existing augmentation method while enabling custom augmentations.

For this to work, we added a new 'transform' section inside 'train' in the pytorch_config file. The new format is a list which has each entry in this list to specify an augmentation name followed by its parameters. Our solution maintains DLC's default augmentation values and calculations in a function called _**transforms_legacy**_ (supporting dictionary). We then created a new function, **_transform_new_**, which handles both legacy DLC augmentations and our custom augmentations.

Example config format: 

<img width="321" height="453" alt="image" src="https://github.com/user-attachments/assets/0eaa0161-3466-482a-84d6-6275051ac93b" />


The **_transform_new_** function works sequentially. First, it checks whether the 'augmentation' section exists, if not, then it loops to the next augmentation. Next, it checks if an augmentation is one of DLC's original methods. If it is, the function calls **transforms_legacy** and we pass it the augmentation name and its parameters in dictionary format, to retrieve the appropriate augmentation settings. If not, it proceeds to check whether the augmentation exists in the albumentations library. When an albumentations augmentation is found, the function extracts its parameters and adds it to a list of transforms. Otherwise, it issues a warning that the given augmentation does not exist. When finished looping through augmentations, it returns the transform list to **_build_transforms_**, which integrates these augmentations into the training pipeline. 

To add a new augmentation:

1. List the augmentation inside the 'transform' section, must be written with '-' and 'augmentation'. Augmentation must exist from the albumentations library and it is case sensitive so it should match spelling. 
`- augmentation: <name_of_augmentation>`
2.  List its parameter following it with the name of the parameter and the value of it
` - augmentation: <name_of_augmentation>`
`p: 0.6`

Below is our augmentation that we applied using our new method:

<img width="1854" height="734" alt="image" src="https://github.com/user-attachments/assets/b4315dcb-5aaa-4b6f-8032-d3bef6ae0172" />


This approach allows us to leverage albumentations' extensive library while maintaining DLC's existing method.