### PR TITLE
add missing __init__.py to `pose_estimation_tensorflow/modelzoo`.

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/modelzoo/__init__.py
+++ b/deeplabcut/pose_estimation_tensorflow/modelzoo/__init__.py
@@ -1,0 +1,11 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/master/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+from api.spatiotemporal_adapt import SpatiotemporalAdaptation

--- a/deeplabcut/pose_estimation_tensorflow/modelzoo/__init__.py
+++ b/deeplabcut/pose_estimation_tensorflow/modelzoo/__init__.py
@@ -8,4 +8,4 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
-from api.spatiotemporal_adapt import SpatiotemporalAdaptation
+from .api import SpatiotemporalAdaptation


### PR DESCRIPTION
Adding this missing file will cause the tensorflow modelzoo module to be included in PyPi packaging. This resolves #3149