### PR TITLE
feat: Filter out low-confidence bounding box detections

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/data/postprocessor.py
+++ b/deeplabcut/pose_estimation_pytorch/data/postprocessor.py
@@ -456,7 +456,7 @@ class RemoveLowConfidenceBoxes(Postprocessor):
     def __call__(
         self, predictions: dict[str, np.ndarray], context: Context
     ) -> tuple[dict[str, np.ndarray], Context]:
-        above_threshold = predictions["bbox_scores"] > self.bbox_score_thresh
+        above_threshold = predictions["bbox_scores"] >= self.bbox_score_thresh
         keepers = np.where(above_threshold)
         if any(~above_threshold):
             predictions["bboxes"] = predictions["bboxes"][keepers]

--- a/deeplabcut/pose_estimation_pytorch/data/postprocessor.py
+++ b/deeplabcut/pose_estimation_pytorch/data/postprocessor.py
@@ -214,9 +214,7 @@ def build_detector_postprocessor(max_individuals: int) -> Postprocessor:
                 keys_to_rescale=["bboxes"],
                 mode=RescaleAndOffset.Mode.BBOX_XYWH,
             ),
-            RemoveLowConfidenceBoxes(
-                bbox_score_thresh=0.25
-            ),
+            RemoveLowConfidenceBoxes(bbox_score_thresh=0.25),
         ]
     )
 
@@ -445,12 +443,13 @@ class RemoveLowConfidenceBoxes(Postprocessor):
     """
 
     def __init__(self, bbox_score_thresh: float):
-        print('utilizing low confidence bbox filtering')
+        print("utilizing low confidence bbox filtering")
         self.bbox_score_thresh = bbox_score_thresh
 
-
-    def __call__(self, predictions: dict[str, np.ndarray], context: Context) -> tuple[dict[str, np.ndarray], Context]:
-        keepers = np.where(predictions['bbox_scores'] > self.bbox_score_thresh)
+    def __call__(
+        self, predictions: dict[str, np.ndarray], context: Context
+    ) -> tuple[dict[str, np.ndarray], Context]:
+        keepers = np.where(predictions["bbox_scores"] > self.bbox_score_thresh)
         for name in predictions:
             output = predictions[name]
             if len(output) > len(keepers):

--- a/deeplabcut/pose_estimation_pytorch/data/postprocessor.py
+++ b/deeplabcut/pose_estimation_pytorch/data/postprocessor.py
@@ -449,11 +449,11 @@ class RemoveLowConfidenceBoxes(Postprocessor):
     def __call__(
         self, predictions: dict[str, np.ndarray], context: Context
     ) -> tuple[dict[str, np.ndarray], Context]:
-        keepers = np.where(predictions["bbox_scores"] > self.bbox_score_thresh)
-        for name in predictions:
-            output = predictions[name]
-            if len(output) > len(keepers):
-                predictions[name] = output[keepers]
+        above_threshold = predictions["bbox_scores"] > self.bbox_score_thresh
+        keepers = np.where(above_threshold)
+        if any(~above_threshold):
+            predictions['bboxes'] = predictions["bboxes"][keepers]
+            predictions['bbox_scores'] = predictions["bbox_scores"][keepers]
         return predictions, context
 
 

--- a/deeplabcut/pose_estimation_pytorch/data/postprocessor.py
+++ b/deeplabcut/pose_estimation_pytorch/data/postprocessor.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any
+import logging
 
 import numpy as np
 
@@ -187,7 +188,7 @@ def build_top_down_postprocessor(
 
 
 def build_detector_postprocessor(
-    max_individuals: int, 
+    max_individuals: int,
     min_bbox_score: float | None = None,
 ) -> Postprocessor:
     """Creates a postprocessor for top-down pose estimation
@@ -219,7 +220,7 @@ def build_detector_postprocessor(
                 mode=RescaleAndOffset.Mode.BBOX_XYWH,
             )
     ]
-    if min_bbox_score is not None: 
+    if min_bbox_score is not None:
         components.append(RemoveLowConfidenceBoxes(min_bbox_score))
     return ComposePostprocessor(components=components)
 
@@ -448,7 +449,8 @@ class RemoveLowConfidenceBoxes(Postprocessor):
     """
 
     def __init__(self, bbox_score_thresh: float):
-        print("utilizing low confidence bbox filtering")
+        super().__init__()
+        logging.info("utilizing low confidence bbox filtering")
         self.bbox_score_thresh = bbox_score_thresh
 
     def __call__(
@@ -457,8 +459,8 @@ class RemoveLowConfidenceBoxes(Postprocessor):
         above_threshold = predictions["bbox_scores"] > self.bbox_score_thresh
         keepers = np.where(above_threshold)
         if any(~above_threshold):
-            predictions['bboxes'] = predictions["bboxes"][keepers]
-            predictions['bbox_scores'] = predictions["bbox_scores"][keepers]
+            predictions["bboxes"] = predictions["bboxes"][keepers]
+            predictions["bbox_scores"] = predictions["bbox_scores"][keepers]
         return predictions, context
 
 


### PR DESCRIPTION
Revised version of PR #3118 by @tlancaster6

**Feature**
Filter out low-confidence bounding box detections during top-down pose estimation to reduce false-positives.

Function `get_inference_runners` in deeplabcut.pose_estimation_pytorch now accepts an optional argument `min_bbox_score`. Low-confidence bounding boxes are removed when min_bbox_score parameter is provided. Default behavior remains unchanged (i.e. all bounding boxes are kept). 