### PR TITLE
fix a confusing message for `freeze_bn_stats`

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/apis/training.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/training.py
@@ -174,7 +174,7 @@ def train(
     ):
         logging.info(
             "\nNote: According to your model configuration, you're training with batch "
-            "size 1 and/or ``freeze_bn_stats=false``. This is not an optimal setting "
+            "size 1 and/or ``freeze_bn_stats=true``. This is not an optimal setting "
             "if you have powerful GPUs.\n"
             "This is good for small batch sizes (e.g., when training on a CPU), where "
             "you should keep ``freeze_bn_stats=true``.\n"


### PR DESCRIPTION
This pull request fixes a very confusing message: According to your model configuration, you're training with batch size 1 and/or **freeze_bn_stats=false**. This is not an optimal setting if you have powerful GPUs.


The condition that triggers this message is `loader.model_cfg["model"].get("freeze_bn_stats", False)`. Therefore, the user can see this message only when `freeze_bn_stats=true`. This pull request flips the boolean value to give the correct message.

https://github.com/DeepLabCut/DeepLabCut/blob/ee866cc0648c4a03f64fc40b7bc2267b3ed2a402/deeplabcut/pose_estimation_pytorch/apis/training.py#L170-L188