### PR TITLE
Close figures before plotting

### DIFF
--- a/deeplabcut/utils/plotting.py
+++ b/deeplabcut/utils/plotting.py
@@ -64,6 +64,10 @@ def PlottingResults(
     if individuals2plot:
         Dataframe = Dataframe.loc(axis=1)[:, individuals2plot]
     animal_bpts = Dataframe.columns.get_level_values("bodyparts")
+    
+    # Close previous figures before plotting
+    plt.close("all")
+
     # Pose X vs pose Y
     fig1 = plt.figure(figsize=(8, 6))
     ax1 = fig1.add_subplot(111)
@@ -161,9 +165,7 @@ def PlottingResults(
         os.path.join(tmpfolder, "hist" + suffix), bbox_inches="tight", dpi=resolution
     )
 
-    if not showfigures:
-        plt.close("all")
-    else:
+    if showfigures:
         plt.show()
 
 

--- a/deeplabcut/utils/plotting.py
+++ b/deeplabcut/utils/plotting.py
@@ -64,7 +64,6 @@ def PlottingResults(
     if individuals2plot:
         Dataframe = Dataframe.loc(axis=1)[:, individuals2plot]
     animal_bpts = Dataframe.columns.get_level_values("bodyparts")
-    
     # Close previous figures before plotting
     plt.close("all")
 


### PR DESCRIPTION
Closing all plots before plotting new ones. This avoids overflowing the screen with old plots.

This commit changes behavior from only closing figures when `showfigures=False` to always closing figures before plotting. Addresses feature request #3164.