### PR TITLE
hotfix extract_outlier_frames for cropped videos 

### DIFF
--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -180,7 +180,7 @@ def _read_video_specific_cropping_margins(
     config: str | Path | dict,
     video_path: str | Path
 ) -> tuple[int, int]:
-    if isinstance(video_path, (str, Path)):
+    if isinstance(config, (str, Path)):
         config = auxiliaryfunctions.read_config(config)
     output_crop = config["video_sets"].get(str(video_path), {}).get("crop")
     x1, _, y1, _ = (

--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -422,7 +422,7 @@ def extract_outlier_frames(
 
             # offset if the data was cropped
             # note: When output video is also cropped, the keypoints should be shifted back.
-            out_x1, out_y1 = _read_video_specific_cropping_margins(config, video)    
+            out_x1, out_y1 = _read_video_specific_cropping_margins(config, video)
             if metadata.get("data", {}).get("cropping"):
                 x1, _, y1, _ = metadata["data"]["cropping_parameters"]
                 df.iloc[:, df.columns.get_level_values(level="coords") == "x"] += x1 - out_x1

--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -183,11 +183,24 @@ def _read_video_specific_cropping_margins(
     if isinstance(config, (str, Path)):
         config = auxiliaryfunctions.read_config(config)
     output_crop = config["video_sets"].get(str(video_path), {}).get("crop")
-    x1, _, y1, _ = (
-        list(map(int, output_crop.split(", ")))
-        if output_crop is not None
-        else (0, 0, 0, 0)
-    )
+    if output_crop is None:
+        x1, _, y1, _ = (0, 0, 0, 0)
+    else:
+        # Accept comma-separated values with optional spaces, and validate format.
+        parts = [p.strip() for p in str(output_crop).split(",")]
+        if len(parts) != 4:
+            raise ValueError(
+                f"Invalid crop specification {output_crop!r} for video {video_path!r} "
+                "in config: expected exactly 4 comma-separated integers "
+                "in the form 'x1,x2,y1,y2'."
+            )
+        try:
+            x1, _, y1, _ = map(int, parts)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Invalid crop specification {output_crop!r} for video {video_path!r} "
+                "in config: values must be integers in the form 'x1,x2,y1,y2'."
+            ) from exc
     return x1, y1
 
 


### PR DESCRIPTION
This PR fixes a bug that introduces a mismatch between label-coordinates and video, when extracting cropped outlier frames.

**bug description**
When using cropping, the predicted keypoints produced with `analyze_videos` are stored in crop-window coordinates. This is also reflected in the *metadata.pickle*. In the current implementation of `extract_outlier_frames`, key-point coordinates are ALWAYS converted back to full-frame coordinates by adding the crop margin read from the metadata pickle file. (introduced in PR #2538)

This should not always the intended behavior: e.g. when the user tries to extract _cropped_ output frames for a next refinement iteration, the keypoints should also reflect _cropped_ coordinates.

See [this imageforum issue](https://forum.image.sc/t/dlc-image-labeling-gui-displaying-predicted-keypoints-with-consistent-rightward-offset/118304/7) and potentially related github issues: #3060, #3130, #1979

 
**Steps to reproduce:**
1. Create a new project with labeled data and train a network.
2. Run `analyze_video` with cropping enabled, e.g. : 
```python
deeplabcut.analyze_videos(
    config_path,
    [video_path],
    shuffle=shuffle,
    trainingsetindex=trainingsetindex,
    cropping=[908, 1920, 0, 1080],
)
```
3. Add the analyzed video to the video sets in `config.yaml ` and specify cropping coordinates there.
``` yaml
video_sets: 
   path/to/video.mp4:
      crop: 908, 1920, 0, 1080
 ```
4. Run `extract_outlier_frames`:
``` python
deeplabcut.extract_outlier_frames(
    config_path,
    [video_path],
    shuffle=shuffle,
    trainingsetindex=trainingsetindex,
    automatic=True,
)
```
5. In Napari, open the created image folder inside `labeled-frames` to check the labels.


Omitting step 3:
<img width="517" height="334" alt="image" src="https://github.com/user-attachments/assets/fe986d8b-d7ec-45ed-80ea-fc4bbb2a088a" />

Including step3: 
<img width="690" height="401" alt="image" src="https://github.com/user-attachments/assets/34357625-c304-4f10-ba72-c3f6e0677a48" />

After accepting proposed code change in this PR:
 <img width="1626" height="955" alt="image" src="https://github.com/user-attachments/assets/53579097-9616-4451-80ad-f410ba22f251" />


**changed behavior:**
`extract_outlier_frames` reads the fields `video_sets` in config and checks if cropping is configured. The keypoints are converted by the difference between margins in metadata.pickle and the output crop margin specified in `video_sets`, instead of always adding the margins specified in the metadata.pickle. 