### PR TITLE
Standardize on pathlib.Path internally with proper type hints

### DIFF
--- a/deeplabcut/modelzoo/utils.py
+++ b/deeplabcut/modelzoo/utils.py
@@ -61,8 +61,8 @@ def get_super_animal_project_cfg(super_animal: str) -> dict:
 
 def get_super_animal_scorer(
     super_animal: str,
-    model_snapshot_path: Path,
-    detector_snapshot_path: Path | None,
+    model_snapshot_path: Path | str,
+    detector_snapshot_path: Path | str | None,
     torchvision_detector_name: str | None = None,
 ) -> str:
     """
@@ -83,18 +83,14 @@ def get_super_animal_scorer(
         )
     super_animal_prefix = super_animal + "_"
     # Always use model name first
-    model_name = (
-        model_snapshot_path.stem
-        if hasattr(model_snapshot_path, "stem")
-        else str(model_snapshot_path)
-    )
+    model_name = Path(model_snapshot_path).stem
     if model_name.startswith(super_animal_prefix):
         model_name = model_name[len(super_animal_prefix) :]
     dlc_scorer = f"{super_animal_prefix}{model_name}"
 
     # Then add detector name if provided
     if detector_snapshot_path is not None:
-        detector_name = detector_snapshot_path.stem
+        detector_name = Path(detector_snapshot_path).stem
         if detector_name.startswith(super_animal_prefix):
             detector_name = detector_name[len(super_animal_prefix) :]
         dlc_scorer += f"_{detector_name}"

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/inference.py
@@ -48,7 +48,7 @@ def construct_bodypart_names(max_individuals, bodyparts):
 
 
 def _video_inference_superanimal(
-    video_paths:str | list,
+    video_paths: str | list,
     superanimal_name: str,
     model_cfg: dict,
     model_snapshot_path: str | Path,
@@ -143,7 +143,6 @@ def _video_inference_superanimal(
 
     dest_folder = Path(video_paths[0]).parent if dest_folder is None else Path(dest_folder)
     dest_folder.mkdir(parents=True, exist_ok=True)
-    
     if create_labeled_video:
         superanimal_colormaps = get_superanimal_colormaps()
         colormap = superanimal_colormaps[superanimal_name]
@@ -151,7 +150,6 @@ def _video_inference_superanimal(
     for video_path in video_paths:
         print(f"Processing video {video_path}")
 
-        # TODO: detector_snapshot_path has to be Path cause it calls stem
         dlc_scorer = get_super_animal_scorer(
             superanimal_name,
             model_snapshot_path,
@@ -217,6 +215,6 @@ def _video_inference_superanimal(
                 bboxes_list=bboxes_list,
                 bboxes_pcutoff=bboxes_pcutoff,
             )
-            print(f"Video with predictions was saved as {dest_folder}")
+            print(f"Video with predictions was saved as {output_video}")
 
     return results

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/inference.py
@@ -141,13 +141,13 @@ def _video_inference_superanimal(
     if isinstance(video_paths, str):
         video_paths = [video_paths]
 
-    # TODO: actually we can remove dest_folder for output_path
     dest_folder = Path(video_paths[0]).parent if dest_folder is None else Path(dest_folder)
     dest_folder.mkdir(parents=True, exist_ok=True)
                     
     for video_path in video_paths:
         print(f"Processing video {video_path}")
 
+        # TODO: detector_snapshot_path has to be Path cause it calls stem
         dlc_scorer = get_super_animal_scorer(
             superanimal_name,
             model_snapshot_path,
@@ -209,7 +209,7 @@ def _video_inference_superanimal(
                 fps=video.fps,
                 bbox=bbox,
                 cmap=colormap,
-                output_path=str(output_video),
+                output_path=output_video,
                 plot_bboxes=plot_bboxes,
                 bboxes_list=bboxes_list,
                 bboxes_pcutoff=bboxes_pcutoff,

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/inference.py
@@ -143,7 +143,11 @@ def _video_inference_superanimal(
 
     dest_folder = Path(video_paths[0]).parent if dest_folder is None else Path(dest_folder)
     dest_folder.mkdir(parents=True, exist_ok=True)
-                    
+    
+    if create_labeled_video:
+        superanimal_colormaps = get_superanimal_colormaps()
+        colormap = superanimal_colormaps[superanimal_name]
+
     for video_path in video_paths:
         print(f"Processing video {video_path}")
 
@@ -194,14 +198,12 @@ def _video_inference_superanimal(
         with open(output_json, "w") as f:
             json.dump(predictions, f, cls=NumpyEncoder)
 
-        output_video = dest_folder / f"{output_prefix}_labeled.mp4"
-        if len(output_suffix) > 0:
-            output_video = output_video.with_stem(output_video.stem + output_suffix)
-
-        superanimal_colormaps = get_superanimal_colormaps()
-        colormap = superanimal_colormaps[superanimal_name]
-
         if create_labeled_video:
+
+            output_video = dest_folder / f"{output_prefix}_labeled.mp4"
+            if len(output_suffix) > 0:
+                output_video = output_video.with_stem(output_video.stem + output_suffix)
+
             create_video(
                 video_path,
                 output_h5,

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/inference.py
@@ -141,6 +141,7 @@ def _video_inference_superanimal(
     if isinstance(video_paths, str):
         video_paths = [video_paths]
 
+    # TODO: actually we can remove dest_folder for output_path
     dest_folder = Path(video_paths[0]).parent if dest_folder is None else Path(dest_folder)
     dest_folder.mkdir(parents=True, exist_ok=True)
                     
@@ -155,8 +156,7 @@ def _video_inference_superanimal(
         )
 
         output_prefix = f"{Path(video_path).stem}_{dlc_scorer}"
-        output_path = Path(dest_folder)
-        output_h5 = Path(output_path) / f"{output_prefix}.h5"
+        output_h5 = dest_folder / f"{output_prefix}.h5"
 
         output_json = output_h5.with_suffix(".json")
         if len(output_suffix) > 0:
@@ -186,7 +186,7 @@ def _video_inference_superanimal(
             dlc_scorer=dlc_scorer,
             multi_animal=True,
             model_cfg=model_cfg,
-            output_path=output_path,
+            output_path=dest_folder,
             output_prefix=output_prefix,
         )
 
@@ -194,7 +194,7 @@ def _video_inference_superanimal(
         with open(output_json, "w") as f:
             json.dump(predictions, f, cls=NumpyEncoder)
 
-        output_video = output_path / f"{output_prefix}_labeled.mp4"
+        output_video = dest_folder / f"{output_prefix}_labeled.mp4"
         if len(output_suffix) > 0:
             output_video = output_video.with_stem(output_video.stem + output_suffix)
 
@@ -214,6 +214,6 @@ def _video_inference_superanimal(
                 bboxes_list=bboxes_list,
                 bboxes_pcutoff=bboxes_pcutoff,
             )
-            print(f"Video with predictions was saved as {output_path}")
+            print(f"Video with predictions was saved as {dest_folder}")
 
     return results

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/inference.py
@@ -9,9 +9,7 @@
 # Licensed under GNU Lesser General Public License v3.0
 #
 import json
-import os
 from pathlib import Path
-from typing import Optional, Union
 
 import numpy as np
 
@@ -50,7 +48,7 @@ def construct_bodypart_names(max_individuals, bodyparts):
 
 
 def _video_inference_superanimal(
-    video_paths: Union[str, list],
+    video_paths:str | list,
     superanimal_name: str,
     model_cfg: dict,
     model_snapshot_path: str | Path,
@@ -60,7 +58,7 @@ def _video_inference_superanimal(
     batch_size: int = 1,
     detector_batch_size: int = 1,
     cropping: list[int] | None = None,
-    dest_folder: Optional[str] = None,
+    dest_folder: str | Path | None = None,
     output_suffix: str = "",
     plot_bboxes: bool = True,
     bboxes_pcutoff: float = 0.9,
@@ -143,12 +141,9 @@ def _video_inference_superanimal(
     if isinstance(video_paths, str):
         video_paths = [video_paths]
 
-    if dest_folder is None:
-        dest_folder = Path(video_paths[0]).parent
-
-    if not os.path.exists(dest_folder):
-        os.makedirs(dest_folder)
-
+    dest_folder = Path(video_paths[0]).parent if dest_folder is None else Path(dest_folder)
+    dest_folder.mkdir(parents=True, exist_ok=True)
+                    
     for video_path in video_paths:
         print(f"Processing video {video_path}")
 

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -18,7 +18,6 @@ https://github.com/DeepLabCut/DeepLabCut/blob/master/AUTHORS
 Licensed under GNU Lesser General Public License v3.0
 """
 from __future__ import annotations
-from tracemalloc import start
 
 import os
 import typing

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -992,12 +992,12 @@ def find_analyzed_data(folder, videoname: str, scorer: str, filtered=False, trac
             candidates.append(file)
     
     if not len(candidates):
-
+        filtered_type = "unfiltered" if not filtered else "filtered"
+        tracker_info = f" and {track_method} tracker" if track_method else ""
         msg = (
-            f'No {"un" if not filtered else ""}filtered data file found in {folder} '
-            f'for video {videoname} and scorer {scorer}'
-            f'{f" and {track_method} tracker" if track_method else ""}.'
-        )
+            f"No {filtered_type} data file found in {folder}"
+            f"for video {videoname} and scorer {scorer}{tracker_info}."
+        ) 
         raise FileNotFoundError(msg)
 
     if len(candidates) > 1:

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -965,12 +965,16 @@ def load_video_full_data(folder, videoname, scorer):
 
 def find_analyzed_data(folder, videoname, scorer, filtered=False, track_method=""):
     """Find potential data files from the hints given to the function."""
+    
+    # TODO: if scorer is Path, replace mesh up with filesystem
     scorer_legacy = scorer.replace("DLC", "DeepCut")
     suffix = "_filtered" if filtered else ""
     tracker = TRACK_METHODS.get(track_method, "")
 
     candidates = []
     for file in grab_files_in_folder(folder, "h5"):
+        # TODO: same here, it is actually replacing the name of the files (?)
+        # stem = Path(file).stem.removesuffix("_filtered")
         stem = Path(file).stem.replace("_filtered", "")
         starts_by_scorer = file.startswith(videoname + scorer) or file.startswith(
             videoname + scorer_legacy

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -941,8 +941,7 @@ def find_video_full_data(folder, videoname, scorer):
 def find_video_metadata(folder, videoname: str, scorer: str):
     """For backward compatibility, let us search the substring 'meta'"""
     
-    # TODO: if scorer is Path '.replace' mesh up with filesystem
-    scorer_legacy = str(scorer).replace("DLC", "DeepCut")
+    scorer_legacy = scorer.replace("DLC", "DeepCut")
     meta_files = filter_files_by_patterns(
         folder=folder,
         start_patterns={videoname + scorer, videoname + scorer_legacy},

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -973,26 +973,26 @@ def find_analyzed_data(folder, videoname: str, scorer: str, filtered=False, trac
 
     candidates = [] 
     folder = Path(folder)
-    for p in folder.iterdir():
-        if p.suffix != ".h5":
-            continue
-        
+    for p in folder.glob("*.h5"):
         file = p.name
-        if "skeleton" in file or filtered != ("filtered" in file):
+
+        if "skeleton" in file:
+            continue
+
+        if filtered != ("filtered" in file):
             continue
 
         stem = p.stem.removesuffix("_filtered")
-        starts_by_scorer = stem.startswith(videoname + scorer) or stem.startswith(videoname + scorer_legacy)
-        if not starts_by_scorer:
-            continue 
-        
-        if tracker:
-            matches_tracker = stem.endswith(tracker)
-        else:
-            matches_tracker = not any(stem.endswith(s) for s in TRACK_METHODS.values())
+        if not stem.startswith((videoname+scorer, videoname+scorer_legacy)):
+            continue
 
-        if matches_tracker:
-            candidates.append(file)
+        if tracker:
+            if not stem.endswith(tracker):
+                continue
+        else:
+            if stem.endswith(tuple(TRACK_METHODS.values())):
+                continue
+        candidates.append(file)
     
     if not len(candidates):
         filtered_type = "unfiltered" if not filtered else "filtered"

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -938,9 +938,11 @@ def find_video_full_data(folder, videoname, scorer):
     return full_files[0]
 
 
-def find_video_metadata(folder, videoname, scorer):
+def find_video_metadata(folder, videoname: str, scorer: str):
     """For backward compatibility, let us search the substring 'meta'"""
-    scorer_legacy = scorer.replace("DLC", "DeepCut")
+    
+    # TODO: if scorer is Path '.replace' mesh up with filesystem
+    scorer_legacy = str(scorer).replace("DLC", "DeepCut")
     meta_files = filter_files_by_patterns(
         folder=folder,
         start_patterns={videoname + scorer, videoname + scorer_legacy},

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -878,9 +878,9 @@ def proc_video(
     print("Starting to process video: {}".format(video))
     vname = Path(video).stem
     if init_weights is not None:
-        init_weights = Path(init_weights).stem
-        DLCscorer = "_DLC" + init_weights
-        DLCscorerlegacy = "_DLC" + init_weights
+        init_weights_name = Path(init_weights).stem
+        DLCscorer = "_DLC" + init_weights_name
+        DLCscorerlegacy = "_DLC" + init_weights_name
         if filtered:
             videooutname1 = destfolder / f"{vname}{DLCscorer}_filtered_labeled.mp4"
             videooutname2 = destfolder / f"{vname}{DLCscorerlegacy}_filtered_labeled.mp4"
@@ -895,6 +895,7 @@ def proc_video(
 
     try:
         # TODO: check whether Path disrupts these auxiliary calls
+        # This doesn't seem to break, cause .stem returns strings so works fine
         df, filepath, _, _ = auxiliaryfunctions.load_analyzed_data(
             destfolder, vname, DLCscorer, filtered, track_method
         )
@@ -906,9 +907,9 @@ def proc_video(
         else:
             s = ""
 
-        # Note: care with filepath.replace in case filepath is a Path object
-        filepath = Path(filepath) # temp until refactor auxiliaryfunctions.load_analyzed_data functions
-        videooutname = filepath.stem / f"{s}_p{int(100 * pcutoff)}_labeled.mp4"
+        # temp until refactor auxiliaryfunctions.load_analyzed_data functions
+        filepath = Path(filepath) 
+        videooutname = filepath.with_name(f"{filepath.stem}{s}_p{int(100 * pcutoff)}_labeled.mp4")
 
         if videooutname.is_file() and not overwrite:
             print("Labeled video already created. Skipping...")

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -340,7 +340,7 @@ def CreateVideoSlow(
     writer = FFMpegWriter(fps=outputframerate, codec="h264")
     with writer.saving(fig, videooutname, dpi=dpi), np.errstate(invalid="ignore"):
         for index in trange(min(nframes, len(Dataframe))):
-            imagename = tmpfolder + "/file" + str(index).zfill(nframes_digits) + ".png"
+            imagename = Path(tmpfolder) / f"file{index:0{nframes_digits}d}.png"
             image = img_as_ubyte(clip.load_frame())
             if index in Index:  # then extract the frame!
                 if cropping and displaycropped:

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -912,7 +912,7 @@ def proc_video(
         videooutname = filepath.with_name(f"{filepath.stem}{s}_p{int(100 * pcutoff)}_labeled.mp4")
         if videooutname.is_file() and not overwrite:
             print("Labeled video already created. Skipping...")
-            return None
+            return True
 
         if individuals != "all":
             if isinstance(individuals, str):

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -895,8 +895,7 @@ def proc_video(
     print(f"Loading {video} and data.")
 
     try:
-        # TODO: check whether Path disrupts these auxiliary calls
-        # This doesn't seem to break, cause .stem returns strings so works fine
+        
         df, filepath, _, _ = auxiliaryfunctions.load_analyzed_data(
             destfolder, vname, DLCscorer, filtered, track_method
         )
@@ -1066,7 +1065,7 @@ def create_video(
 
     if output_path is None:
         s = "_id" if color_by == "individual" else "_bp"
-        output_path = h5file.replace(".h5", f"{s}_labeled.mp4")    
+        output_path = h5file.replace(".h5", f"{s}_labeled.mp4")
 
     clip = vp(
         fname=video,

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -896,9 +896,7 @@ def proc_video(
         return True
     
     print(f"Loading {video} and data.")
-
     try:
-        
         df, filepath, _, _ = auxiliaryfunctions.load_analyzed_data(
             destfolder, vname, DLCscorer, filtered, track_method
         )
@@ -912,7 +910,6 @@ def proc_video(
         
         filepath = Path(filepath) # NOTE: temp until refactor auxiliaryfunctions.load_analyzed_data functions 
         videooutname = filepath.with_name(f"{filepath.stem}{s}_p{int(100 * pcutoff)}_labeled.mp4")
-
         if videooutname.is_file() and not overwrite:
             print("Labeled video already created. Skipping...")
             return None

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -880,8 +880,8 @@ def proc_video(
     vname = Path(video).stem
     if init_weights is not None:
         init_weights_name = Path(init_weights).stem
-        DLCscorer = "_DLC" + init_weights_name
-        DLCscorerlegacy = "_DLC" + init_weights_name
+        DLCscorer = "DLC_" + init_weights_name
+        DLCscorerlegacy = "DLC_" + init_weights_name
         if filtered:
             videooutname1 = destfolder / f"{vname}{DLCscorer}_filtered_labeled.mp4"
             videooutname2 = destfolder / f"{vname}{DLCscorerlegacy}_filtered_labeled.mp4"

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -876,20 +876,23 @@ def proc_video(
     if pcutoff is None:
         pcutoff = cfg["pcutoff"]
 
-    print("Starting to process video: {}".format(video))
+     # NOTE: THE VIDEO IS STILL IN THE VIDEO FOLDER
+    print(f"Starting to process video: {video}")
     vname = Path(video).stem
     if init_weights is not None:
         init_weights_name = Path(init_weights).stem
         DLCscorer = "DLC_" + init_weights_name
         DLCscorerlegacy = "DLC_" + init_weights_name
-        if filtered:
-            videooutname1 = destfolder / f"{vname}{DLCscorer}_filtered_labeled.mp4"
-            videooutname2 = destfolder / f"{vname}{DLCscorerlegacy}_filtered_labeled.mp4"
-        else:
-            videooutname1 = destfolder / f"{vname}{DLCscorer}_labeled.mp4"
-            videooutname2 = destfolder / f"{vname}{DLCscorerlegacy}_labeled.mp4"
+    
+    if filtered:
+        videooutname1 = destfolder / f"{vname}{DLCscorer}filtered_labeled.mp4"
+        videooutname2 = destfolder / f"{vname}{DLCscorerlegacy}filtered_labeled.mp4"
+    else:
+        videooutname1 = destfolder / f"{vname}{DLCscorer}_labeled.mp4"
+        videooutname2 = destfolder / f"{vname}{DLCscorerlegacy}_labeled.mp4"
 
     if (videooutname1.is_file() or videooutname2.is_file()) and not overwrite:
+        print(f"Labeled video {vname} already created.")
         return True
     
     print(f"Loading {video} and data.")

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -711,6 +711,7 @@ def create_labeled_video(
                 bboxes_pcutoff = 0.6
 
     if init_weights == "":
+        # TODO: cfg breaks if config == ""
         DLCscorer, DLCscorerlegacy = auxiliaryfunctions.get_scorer_name(
             cfg,
             shuffle,
@@ -906,9 +907,8 @@ def proc_video(
             s = "_id" if color_by == "individual" else "_bp"
         else:
             s = ""
-
-        # temp until refactor auxiliaryfunctions.load_analyzed_data functions
-        filepath = Path(filepath) 
+        
+        filepath = Path(filepath) # NOTE: temp until refactor auxiliaryfunctions.load_analyzed_data functions 
         videooutname = filepath.with_name(f"{filepath.stem}{s}_p{int(100 * pcutoff)}_labeled.mp4")
 
         if videooutname.is_file() and not overwrite:
@@ -975,7 +975,7 @@ def proc_video(
 
             tmpfolder = videofolder / f"temp-{vname}"
             if save_frames:
-                tmpfolder.folder.mkdir(exist_ok=True)
+                tmpfolder.mkdir(exist_ok=True)
 
             clip = vp(video)
             CreateVideoSlow(
@@ -1054,7 +1054,7 @@ def create_video(
     display_cropped=False,
     codec="mp4v",
     fps=None,
-    output_path=None,
+    output_path: str | Path | None = None,
     confidence_to_alpha=None,
     plot_bboxes=True,
     bboxes_list=None,
@@ -1065,13 +1065,12 @@ def create_video(
         raise ValueError("`color_by` should be either 'bodypart' or 'individual'.")
 
     if output_path is None:
-        h5_path = Path(h5file)
         s = "_id" if color_by == "individual" else "_bp"
-        output_path = h5_path.parent / f"{h5_path.stem}{s}_labeled.mp4"    
+        output_path = h5file.replace(".h5", f"{s}_labeled.mp4")    
 
     clip = vp(
         fname=video,
-        sname=output_path,
+        sname=str(output_path), # NOTE: inelegant solution for cv2, but probably better at this step
         codec=codec,
         sw=bbox[1] - bbox[0] if display_cropped else "",
         sh=bbox[3] - bbox[2] if display_cropped else "",


### PR DESCRIPTION
Path handling is currently inconsistent (strings vs Path objects, mixed os.path and pathlib), making code hard to follow. This also causes subtle bugs (e.g., scorer.replace() on a Path attempts filesystem operations instead of string replacement).

Proposal: Standardize on pathlib.Path internally with proper type hints. This is consistent with newer parts of the codebase, eliminates helper functions like grab_files_in_folder(), improves readability, and catches type errors earlier.

Open to feedback on approach and scope.