### PR TITLE
bump albumentation to >2 and fix breaking changes

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/data/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/data/utils.py
@@ -499,7 +499,7 @@ def _apply_transform(
     """
     transformed = transform(
         image=image,
-        keypoints=keypoints,
+        keypoints=np.array(keypoints),
         class_labels=class_labels,
         bboxes=bboxes,
         bbox_labels=np.arange(len(bboxes)),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # novel for pytorch DLC:
-albumentations<=1.4.3
+albumentations>=2
 einops
 pycocotools<=2.0.8
 timm

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/DeepLabCut/DeepLabCut",
     install_requires=[
-        "albumentations<=1.4.3",
+        "albumentations>=2",
         "dlclibrary>=0.0.7",
         "einops",
         "filterpy>=1.4.4",

--- a/tests/pose_estimation_pytorch/data/test_transforms.py
+++ b/tests/pose_estimation_pytorch/data/test_transforms.py
@@ -69,16 +69,16 @@ def test_dlc_resize_pad_bad_aspect_ratio(data):
             "width": 200,
             "in_shape": (100, 50, 3),
             "out_shape": (200, 100, 3),
-            "in_keypoints": [(50.0, 50.0), (25.0, 10.0)],
-            "out_keypoints": [(100.0, 100.0), (50.0, 20.0)],
+            "in_keypoints": [[50.0, 50.0], [25.0, 10.0]],
+            "out_keypoints": [[100.0, 100.0], [50.0, 20.0]],
         },
         {
             "height": 512,
             "width": 256,
             "in_shape": (1024, 1024, 3),
             "out_shape": (256, 256, 3),
-            "in_keypoints": [(512.0, 512.0), (100.0, 10.0)],
-            "out_keypoints": [(128.0, 128.0), (25.0, 2.5)],
+            "in_keypoints": [[512.0, 512.0], [100.0, 10.0]],
+            "out_keypoints": [[128.0, 128.0], [25.0, 2.5]],
         },
     ],
 )
@@ -151,7 +151,7 @@ def test_random_bbox_transform_does_not_modify_with_base_config(data: dict) -> N
     print("bboxes")
     print(bboxes_out)
     print()
-    np.testing.assert_array_almost_equal(bboxes, bboxes_out)
+    np.testing.assert_array_almost_equal(bboxes, bboxes_out, decimal=4)
 
 
 @pytest.mark.parametrize(

--- a/tests/pose_estimation_pytorch/other/test_custom_transforms.py
+++ b/tests/pose_estimation_pytorch/other/test_custom_transforms.py
@@ -17,7 +17,7 @@ from deeplabcut.pose_estimation_pytorch.data import transforms
 @pytest.mark.parametrize("width, height", [(200, 200), (300, 300), (400, 400)])
 def test_keypoint_aware_cropping(width, height):
     fake_image = np.empty((600, 600, 3))
-    fake_keypoints = [(i * 100, i * 100, 0, 0) for i in range(1, 6)]
+    fake_keypoints = np.array([(i * 100, i * 100, 0, 0) for i in range(1, 6)])
     aug = transforms.KeypointAwareCrop(
         width=width, height=height, crop_sampling="density"
     )


### PR DESCRIPTION
- The [albumentation](https://github.com/albumentations-team/albumentations/tree/66212d77a44927a29d6a0e81621d3c27afbd929c?tab=readme-ov-file) package that is being used here is no longer actively maintained. The last update was in June 2025, and no further bug fixes, features, or compatibility updates will be provided.
- This PR updates albumentation to its latest release and fixes all the breaking changes.
- It also makes it easier to move to [AlbumentationsX](https://github.com/albumentations-team/AlbumentationsX), the next-generation successor to Albumentations.
- This required a bit of whack a mole until all the tests passed.

We may need some additional tests for ElasticTransform. I'm not sure if it's being tested anywhere. ( @deruyter92 )
