### PR TITLE
Refactor list_videos_in_folder for clarity and correctness

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/apis/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/utils.py
@@ -344,7 +344,15 @@ def list_videos_in_folder(
             videos.append(path)
 
     # Remove duplicates while preserving order (using resolved paths to handle symlinks)
-    videos = list({v.resolve(): v for v in videos}.values())
+    seen = set()
+    unique_videos: list[Path] = []
+    for v in videos:
+        resolved = v.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        unique_videos.append(v)
+    videos = unique_videos
 
     if shuffle:
         random.shuffle(videos)

--- a/deeplabcut/pose_estimation_pytorch/apis/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/utils.py
@@ -319,7 +319,7 @@ def list_videos_in_folder(
             in sorted order for deterministic behavior.
 
     Returns:
-        The paths of videos to analyze.
+        The paths of videos to analyze. Duplicate paths are removed.
 
     Raises:
         FileNotFoundError: If any path in data_path does not exist.
@@ -342,6 +342,9 @@ def list_videos_in_folder(
             videos.extend(f for f in path.iterdir() if f.is_file() and f.suffix.lower() in video_suffixes)
         elif path.is_file() and path.suffix.lower() in video_suffixes:
             videos.append(path)
+
+    # Remove duplicates while preserving order (using resolved paths to handle symlinks)
+    videos = list({v.resolve(): v for v in videos}.values())
 
     if shuffle:
         random.shuffle(videos)

--- a/deeplabcut/pose_estimation_pytorch/apis/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/utils.py
@@ -9,7 +9,6 @@
 # Licensed under GNU Lesser General Public License v3.0
 #
 from __future__ import annotations
-from testscript_cli import video
 
 import logging
 import random

--- a/deeplabcut/pose_estimation_pytorch/apis/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/utils.py
@@ -324,7 +324,7 @@ def list_videos_in_folder(
     Raises:
         FileNotFoundError: If any path in data_path does not exist.
     """
-    if not isinstance(data_path, list):
+    if isinstance(data_path, (str, Path)):
         data_path = [data_path]
 
     if not video_type:

--- a/deeplabcut/pose_estimation_pytorch/apis/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/utils.py
@@ -331,32 +331,24 @@ def list_videos_in_folder(
         video_suffixes = {f".{ext.lower()}" for ext in auxfun_videos.SUPPORTED_VIDEOS}
     else:
         video_suffixes = {f".{video_type.lstrip('.').lower()}"}
-    
+
     videos = []
     for path in map(Path, data_path):
         if not path.exists():
             raise FileNotFoundError(
                 f"Could not find: {path}. Check access rights."
             )
+
         if path.is_dir():
             videos.extend(f for f in path.iterdir() if f.is_file() and f.suffix.lower() in video_suffixes)
         elif path.is_file() and path.suffix.lower() in video_suffixes:
             videos.append(path)
 
-    # Remove duplicates while preserving order (using resolved paths to handle symlinks)
-    seen = set()
-    unique_videos: list[Path] = []
-    for v in videos:
-        resolved = v.resolve()
-        if resolved in seen:
-            continue
-        seen.add(resolved)
-        unique_videos.append(v)
-    videos = unique_videos
-
+    # Resolve video paths and remove duplicates
+    unique_videos = list(dict.fromkeys(v.resolve() for v in videos))
     if shuffle:
-        random.shuffle(videos)
-    return videos
+        random.shuffle(unique_videos)
+    return unique_videos
 
 
 def ensure_multianimal_df_format(df_predictions: pd.DataFrame) -> pd.DataFrame:


### PR DESCRIPTION
Refactors `list_videos_in_folder` to improve code clarity, fix bugs, and streamline logic:

**Key changes:**
- **Moved suffix normalization out of loop**: Video suffixes are now computed once before iteration instead of being recalculated for each directory
- **Replaced list with set for O(1) lookups**: Changed `video_suffixes` from list to set for more efficient suffix matching
- **Simplified suffix normalization**: Consolidated duplicate normalization logic using `lstrip('.')` instead of conditional checks
- **Added file validation for non-directory paths**: Individual files are now validated against `video_suffixes` before being added to results
- **Improved error handling**: Moved `path.exists()` check before path type determination to catch errors earlier
- **Fixed shuffle behavior**: Shuffle now applies to the complete video list instead of per-directory, ensuring consistent behavior
- **Enhanced type hints**: Added `Path` to `data_path` type annotation for better type safety

These changes reduce code duplication, improve performance with set-based lookups, and ensure only valid video files are returned.