### PR TITLE
Fix CSVLogger: read existing learning_stats.csv file when resuming previous training

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/runners/logger.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/logger.py
@@ -459,21 +459,21 @@ class CSVLogger(BaseLogger):
         try:
             with open(self.log_file, "r", newline="") as f:
                 reader = csv.DictReader(f)
-                
+
                 # Update logged metrics from header
                 if "step" not in reader.fieldnames:
                     return  # Invalid format
-                    
+
                 metric_names = [m for m in reader.fieldnames if m != "step"]
                 self._logged_metrics.update(metric_names)
-                
+
                 # Load data rows
                 for row in reader:
                     try:
                         step = int(row["step"])
                     except (ValueError, KeyError):
                         continue
-                    
+
                     # Convert metric values: empty strings -> None, numeric strings -> float
                     step_metrics = {}
                     for metric in metric_names:
@@ -485,10 +485,10 @@ class CSVLogger(BaseLogger):
                                 step_metrics[metric] = float(value)
                             except ValueError:
                                 step_metrics[metric] = value
-                    
+
                     self._steps.append(step)
                     self._metric_store.append(step_metrics)
-                
+
         except Exception as e:
             logging.warning(
                 f"Failed to load existing CSV data from {self.log_file}: {e}. "

--- a/deeplabcut/pose_estimation_pytorch/runners/logger.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/logger.py
@@ -438,7 +438,7 @@ class CSVLogger(BaseLogger):
     def save(self):
         """Saves the metrics to the file system"""
         logs = self._prepare_logs()
-        with open(self.log_file, "a", newline="") as f:
+        with open(self.log_file, "w", newline="") as f:
             writer = csv.writer(f)
             writer.writerows(logs)
 

--- a/deeplabcut/pose_estimation_pytorch/runners/logger.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/logger.py
@@ -413,6 +413,10 @@ class CSVLogger(BaseLogger):
         self._metric_store: list[dict] = []
         self._logged_metrics: set[str] = set()
 
+        # Load existing data if the file exists (e.g., when resuming from snapshot)
+        if self.log_file.exists():
+            self._load_existing_data()
+
     def log(self, metrics: dict[str, Any], step: Optional[int] = None) -> None:
         """Logs metrics from runs
 
@@ -450,6 +454,47 @@ class CSVLogger(BaseLogger):
         """
         pass
 
+    def _load_existing_data(self) -> None:
+        """Loads existing CSV data if the log file exists"""
+        try:
+            with open(self.log_file, "r", newline="") as f:
+                reader = csv.DictReader(f)
+                
+                # Update logged metrics from header
+                if "step" not in reader.fieldnames:
+                    return  # Invalid format
+                    
+                metric_names = [m for m in reader.fieldnames if m != "step"]
+                self._logged_metrics.update(metric_names)
+                
+                # Load data rows
+                for row in reader:
+                    try:
+                        step = int(row["step"])
+                    except (ValueError, KeyError):
+                        continue
+                    
+                    # Convert metric values: empty strings -> None, numeric strings -> float
+                    step_metrics = {}
+                    for metric in metric_names:
+                        value = row.get(metric, "").strip()
+                        if not value:
+                            step_metrics[metric] = None
+                        else:
+                            try:
+                                step_metrics[metric] = float(value)
+                            except ValueError:
+                                step_metrics[metric] = value
+                    
+                    self._steps.append(step)
+                    self._metric_store.append(step_metrics)
+                
+        except Exception as e:
+            logging.warning(
+                f"Failed to load existing CSV data from {self.log_file}: {e}. "
+                "Starting with empty log."
+            )
+
     def _prepare_logs(self) -> list[list]:
         """Prepares the data to log as a list of strings"""
         if len(self._metric_store) == 0:
@@ -458,6 +503,11 @@ class CSVLogger(BaseLogger):
         metrics = list(sorted(self._logged_metrics))
         logs = [["step"] + metrics]
         for step, step_metrics in zip(self._steps, self._metric_store):
-            logs.append([step] + [step_metrics.get(m) for m in metrics])
+            # Convert None values to empty strings for proper CSV formatting
+            row = [step] + [
+                "" if step_metrics.get(m) is None else step_metrics.get(m)
+                for m in metrics
+            ]
+            logs.append(row)
 
         return logs

--- a/tests/pose_estimation_pytorch/runners/test_logger.py
+++ b/tests/pose_estimation_pytorch/runners/test_logger.py
@@ -79,22 +79,22 @@ def test_prepare_image(keypoints: list[list[float]], denormalize: bool) -> None:
 def test_csv_logger_resume(tmp_path: Path) -> None:
     """Test CSVLogger preserves data when resuming from snapshot"""
     log_file = tmp_path / "learning_stats.csv"
-    
+
     # Initial training: log some metrics
     logger1 = logging.CSVLogger(str(tmp_path), "learning_stats.csv")
     logger1.log({"loss": 0.5, "accuracy": 0.8}, step=1)
     logger1.log({"loss": 0.4, "accuracy": 0.9}, step=2)
-    
+
     assert log_file.exists()
     assert len(logger1._steps) == 2
-    
+
     # Resume training: should load existing data
     logger2 = logging.CSVLogger(str(tmp_path), "learning_stats.csv")
     assert len(logger2._steps) == 2
     assert logger2._steps == [1, 2]
     assert logger2._metric_store[0]["loss"] == 0.5
     assert logger2._metric_store[1]["accuracy"] == 0.9
-    
+
     # Log new data: should append, not overwrite
     logger2.log({"loss": 0.3, "accuracy": 0.95}, step=3)
     assert len(logger2._steps) == 3

--- a/tests/pose_estimation_pytorch/runners/test_logger.py
+++ b/tests/pose_estimation_pytorch/runners/test_logger.py
@@ -9,6 +9,7 @@
 # Licensed under GNU Lesser General Public License v3.0
 #
 """Tests loggers"""
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -73,3 +74,28 @@ def test_prepare_image(keypoints: list[list[float]], denormalize: bool) -> None:
         keypoints=keypoints,
         bboxes=None,
     )
+
+
+def test_csv_logger_resume(tmp_path: Path) -> None:
+    """Test CSVLogger preserves data when resuming from snapshot"""
+    log_file = tmp_path / "learning_stats.csv"
+    
+    # Initial training: log some metrics
+    logger1 = logging.CSVLogger(str(tmp_path), "learning_stats.csv")
+    logger1.log({"loss": 0.5, "accuracy": 0.8}, step=1)
+    logger1.log({"loss": 0.4, "accuracy": 0.9}, step=2)
+    
+    assert log_file.exists()
+    assert len(logger1._steps) == 2
+    
+    # Resume training: should load existing data
+    logger2 = logging.CSVLogger(str(tmp_path), "learning_stats.csv")
+    assert len(logger2._steps) == 2
+    assert logger2._steps == [1, 2]
+    assert logger2._metric_store[0]["loss"] == 0.5
+    assert logger2._metric_store[1]["accuracy"] == 0.9
+    
+    # Log new data: should append, not overwrite
+    logger2.log({"loss": 0.3, "accuracy": 0.95}, step=3)
+    assert len(logger2._steps) == 3
+    assert logger2._steps == [1, 2, 3]


### PR DESCRIPTION
Previously, when resuming training the CSVLogger created a new learning_stats.csv file for the second training run, overwriting previously saved training metrics.

This commit addresses feature request #3176 and changes the behaviour to reading any previously saved log metrics and appending new epochs to the learning_stats.csv file.

- added `_load_existing_data` method to CSVLogger
- added unit test for `_load_existing_data`