### PR TITLE
Update napari plugin activation in launch_napari

### DIFF
--- a/deeplabcut/gui/widgets.py
+++ b/deeplabcut/gui/widgets.py
@@ -38,10 +38,10 @@ def launch_napari(files=None, plugin="napari-deeplabcut", stack=False):
     viewer = napari.Viewer()
     if plugin == "napari-deeplabcut":
         # Automatically activate the napari-deeplabcut plugin
-        for action in viewer.window.plugins_menu.actions():
-            if "deeplabcut" in action.text():
-                action.trigger()
-                break
+        _, _ = viewer.window.add_plugin_dock_widget(
+            "napari-deeplabcut",
+            "Keypoint controls",
+        )
     if files is not None:
         viewer.open(files, plugin=plugin, stack=stack)
     return viewer


### PR DESCRIPTION
Replaces the menu action trigger for activating the 'napari-deeplabcut' plugin with a direct, safer call to add the 'Keypoint controls' dock widget.

This pull request updates how the `napari-deeplabcut` plugin is activated when launching Napari from the `launch_napari` function. Instead of searching for and triggering the plugin via the plugins menu actions, the code now directly adds the plugin's dock widget to the Napari window.

---
**NOTE**
- This is compatible with previous versions of napari-dlc and is not a breaking change
- Required for upcoming new version of napari-dlc from https://github.com/DeepLabCut/napari-deeplabcut/pull/153.

---
**Plugin activation improvement:**

* Changed the plugin activation method in `launch_napari` within `deeplabcut/gui/widgets.py` to directly add the `napari-deeplabcut` dock widget using `add_plugin_dock_widget`, making the process more straightforward and reliable.