### PR TITLE
fix non-deterministic unintended failing of `test_coarse_dropout`

### DIFF
--- a/tests/pose_estimation_pytorch/other/test_custom_transforms.py
+++ b/tests/pose_estimation_pytorch/other/test_custom_transforms.py
@@ -49,7 +49,7 @@ def test_coarse_dropout():
     fake_image *= np.random.uniform(0, 255, size=fake_image.shape)
     fake_image = fake_image.astype(np.uint8)
     cd = transforms.CoarseDropout(max_height=0.9999, max_width=0.9999, p=1)
-    kpts = np.random.rand(10, 2) * 300
+    kpts = np.random.rand(10, 2) * 298 + 1
     aug_kpts = cd(image=fake_image, keypoints=kpts)["keypoints"]
     assert len(aug_kpts) == kpts.shape[0]
     assert np.isnan([c for kpt in aug_kpts for c in kpt]).all()


### PR DESCRIPTION
This PR fixes a small issue in one of the pytests testing the dropout transformation.

**problem:**
The test fails non-deterministically because of an issue in the test implementation unrelated to the codebase. 
Dropout is applied over nearly (!) the entire image (e,g. max_width=.9999), to test that randomly placed keypoints always become nan. However, the boundaries for the randomly generated keypoints exceeded the boundaries of the dropout. In rare cases the test fails when the keypoints are placed at the border of the image. 

**changes:**
Fixed test implementation: keypoints are randomly generated at maximally 1 pixel distance of the image border.