### PR TITLE
Keyword-only `key` argument for pd.DataFrame.to_hdf()

### DIFF
--- a/deeplabcut/modelzoo/generalized_data_converter/utils.py
+++ b/deeplabcut/modelzoo/generalized_data_converter/utils.py
@@ -236,7 +236,7 @@ def create_video_h5_from_pickle(proj_root, cfg, reference_pickle, videopath):
     with open(metadata_path, "wb") as f:
         pickle.dump(metadata, f, pickle.HIGHEST_PROTOCOL)
 
-    df.to_hdf(dataname, "df_with_missing", format="table", mode="w")
+    df.to_hdf(dataname, key="df_with_missing", format="table", mode="w")
 
 
 def add_skeleton(config_path, pretrain_model_name):

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -887,7 +887,7 @@ def evaluate_network(
                         DataMachine = pd.DataFrame(
                             PredicteData, columns=index, index=Data.index
                         )
-                        DataMachine.to_hdf(resultsfilename, "df_with_missing")
+                        DataMachine.to_hdf(resultsfilename, key="df_with_missing")
 
                         print(
                             "Analysis is done and the results are stored (see evaluation-results) for snapshot: ",

--- a/deeplabcut/post_processing/analyze_skeleton.py
+++ b/deeplabcut/post_processing/analyze_skeleton.py
@@ -303,7 +303,7 @@ def analyzeskeleton(
 
         skeleton = pd.concat(bones, axis=1)
         video_to_skeleton_df[video] = skeleton
-        skeleton.to_hdf(output_name, "df_with_missing", format="table", mode="w")
+        skeleton.to_hdf(output_name, key="df_with_missing", format="table", mode="w")
         if save_as_csv:
             skeleton.to_csv(output_name.replace(".h5", ".csv"))
 

--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -638,7 +638,7 @@ def compute_deviations(
     if storeoutput == "full":
         data.to_hdf(
             dataname.split(".h5")[0] + "filtered.h5",
-            "df_with_missing",
+            key="df_with_missing",
             format="table",
             mode="w",
         )

--- a/deeplabcut/refine_training_dataset/stitch.py
+++ b/deeplabcut/refine_training_dataset/stitch.py
@@ -938,7 +938,7 @@ class TrackletStitcher:
             if suffix:
                 suffix = "_" + suffix
             output_name = self.filename.replace(".pickle", f"{suffix}.h5")
-        df.to_hdf(output_name, "tracks", format="table", mode="w")
+        df.to_hdf(output_name, key="tracks", format="table", mode="w")
         if save_as_csv:
             df.to_csv(output_name.replace(".h5", ".csv"))
 

--- a/deeplabcut/refine_training_dataset/tracklets.py
+++ b/deeplabcut/refine_training_dataset/tracklets.py
@@ -382,4 +382,4 @@ class TrackletManager:
         df = self.format_data()
         if not output_name:
             output_name = self.filename.replace("pickle", "h5")
-        df.to_hdf(output_name, "df_with_missing", format="table", mode="w")
+        df.to_hdf(output_name, key="df_with_missing", format="table", mode="w")

--- a/examples/testscript_deterministicwithResNet152.py
+++ b/examples/testscript_deterministicwithResNet152.py
@@ -106,7 +106,7 @@ dataFrame.to_hdf(
         videoname,
         "CollectedData_" + scorer + ".h5",
     ),
-    "df_with_missing",
+    key="df_with_missing",
     format="table",
     mode="w",
 )

--- a/examples/testscript_mobilenets.py
+++ b/examples/testscript_mobilenets.py
@@ -143,7 +143,7 @@ if __name__ == "__main__":
             videoname,
             "CollectedData_" + scorer + ".h5",
         ),
-        "df_with_missing",
+        key="df_with_missing",
         format="table",
         mode="w",
     )
@@ -261,7 +261,7 @@ if __name__ == "__main__":
                 vname,
                 "CollectedData_" + scorer + ".h5",
             ),
-            "df_with_missing",
+            key="df_with_missing",
             format="table",
             mode="w",
         )

--- a/examples/testscript_multianimal.py
+++ b/examples/testscript_multianimal.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
     output_path = os.path.join(image_folder, f"CollectedData_{SCORER}.csv")
     df.to_csv(output_path)
     df.to_hdf(
-        output_path.replace("csv", "h5"), "df_with_missing", format="table", mode="w"
+        output_path.replace("csv", "h5"), key="df_with_missing", format="table", mode="w"
     )
     print("Artificial data created.")
 
@@ -295,7 +295,7 @@ if __name__ == "__main__":
             vname,
             "CollectedData_" + SCORER + ".h5",
         ),
-        "df_with_missing",
+        key="df_with_missing",
     )
 
     print("MERGING")

--- a/examples/testscript_pretrained_models.py
+++ b/examples/testscript_pretrained_models.py
@@ -91,7 +91,7 @@ dataFrame.to_hdf(
         videoname,
         "CollectedData_" + cfg["scorer"] + ".h5",
     ),
-    "df_with_missing",
+    key="df_with_missing",
     format="table",
     mode="w",
 )
@@ -167,7 +167,7 @@ dataFrame.to_hdf(
         videoname,
         "CollectedData_" + cfg["scorer"] + ".h5",
     ),
-    "df_with_missing",
+    key="df_with_missing",
     format="table",
     mode="w",
 )

--- a/examples/testscript_transreid.py
+++ b/examples/testscript_transreid.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     output_path = os.path.join(image_folder, f"CollectedData_{SCORER}.csv")
     df.to_csv(output_path)
     df.to_hdf(
-        output_path.replace("csv", "h5"), "df_with_missing", format="table", mode="w"
+        output_path.replace("csv", "h5"), key="df_with_missing", format="table", mode="w"
     )
     print("Artificial data created.")
 
@@ -303,7 +303,7 @@ if __name__ == "__main__":
             vname,
             "CollectedData_" + scorer + ".h5",
         ),
-        "df_with_missing",
+        key="df_with_missing",
         format="table",
         mode="w",
     )

--- a/testscript_cli.py
+++ b/testscript_cli.py
@@ -108,7 +108,7 @@ dataFrame.to_hdf(
         videoname,
         "CollectedData_" + scorer + ".h5",
     ),
-    "df_with_missing",
+    key="df_with_missing",
     format="table",
     mode="w",
 )


### PR DESCRIPTION
**Motivation:**
Pandas officially released version 3.0 (January 2026), but our code is not compatible with this version.
- Positional usage of the `key` argument in pd.DataFrame.to_hdf() is no longer be supported. Pandas 2.2 and higher raise a warning for keyword-only usage of the `key` parameter, and raise an error for pandas version 3.0. This was already implemented in most of the code, but this PR addresses the remaining places where that was not the case. 

**Changes:**
This PR replaces `df.to_hdf(dataname, "df_with_missing", ...)` with `df.to_hdf(dataname, key="df_with_missing", ...)` (and similar) where that was not yet implemented.
