### PR TITLE
Restrict pandas dependency to version <3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ numba>=0.54.0
 matplotlib>=3.3, <3.8.4
 networkx>=2.6
 numpy>=1.18.5,<2.0.0
-pandas>=1.0.1,!=1.5.0
+pandas>=1.0.1,!=1.5.0,<3.0
 Pillow>=7.1
 pyyaml
 scikit-image>=0.17

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setuptools.setup(
         "matplotlib>=3.3,<3.9,!=3.7.0,!=3.7.1",
         "networkx>=2.6",
         "numpy>=1.18.5,<2.0.0",
-        "pandas>=1.0.1,!=1.5.0",
+        "pandas>=1.0.1,!=1.5.0,<3.0",
         "scikit-image>=0.17",
         "scikit-learn>=1.0",
         "scipy>=1.9",


### PR DESCRIPTION
**Motivation**
Pandas just released version 3.0, which is incompatible for our codebase. This causes installation issues and also causes our CI workflows to fail. 

This PR restricts the requirement to version <3.0 as a quick fix. 

**Changes:**
added upperbound for pandas <3.0 in setup.py and requirements.txt

**Possible follow-up**
Some minor adjustments are required later if we want to allow installation of this newer pandas version (to_hdf method currently fails for positional arg `key`, some hdf5 files become read-only causing issues). Meanwhile we can work on migration to polars as replacement of pandas.