### PR TITLE
[dev] C1 - centralize project config I/O and add testing

### DIFF
--- a/deeplabcut/compat.py
+++ b/deeplabcut/compat.py
@@ -15,8 +15,8 @@ from pathlib import Path
 from typing import Iterable
 
 import numpy as np
-from ruamel.yaml import YAML
 
+from deeplabcut.core.config import read_config_as_dict
 import deeplabcut.core.visualization as visualization
 from deeplabcut.core.engine import Engine
 from deeplabcut.generate_training_dataset.metadata import get_shuffle_engine
@@ -1962,13 +1962,4 @@ def _gpu_to_use_to_device(gpu_to_use: int | None, device: str | None) -> str | N
 
 
 def _load_config(config: str) -> dict:
-    config_path = Path(config)
-    if not config_path.exists():
-        raise FileNotFoundError(
-            f"Config {config} is not found. Please make sure that the file exists."
-        )
-
-    with open(config, "r") as f:
-        project_config = YAML(typ="safe", pure=True).load(f)
-
-    return project_config
+    return read_config_as_dict(config)

--- a/deeplabcut/core/config.py
+++ b/deeplabcut/core/config.py
@@ -11,7 +11,6 @@
 """Centralized helpers for reading, writing, and creating configuration files (YAML)."""
 from __future__ import annotations
 
-import os
 import warnings
 from pathlib import Path
 from typing import Callable
@@ -34,7 +33,7 @@ def read_config_as_dict(config_path: str | Path) -> dict:
     Raises:
         FileNotFoundError: if the config file does not exist
     """
-    if not os.path.exists(config_path):
+    if not Path(config_path).exists():
         raise FileNotFoundError(
             f"Config {config_path} is not found. Please make sure that the file exists."
         )
@@ -264,7 +263,7 @@ def read_config(configname: str | Path) -> dict:
     """
     ruamelFile = YAML()
     path = Path(configname)
-    if os.path.exists(path):
+    if path.exists():
         try:
             with open(path, "r") as f:
                 cfg = ruamelFile.load(f)

--- a/deeplabcut/core/config.py
+++ b/deeplabcut/core/config.py
@@ -8,13 +8,19 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
-"""Simple helper methods related to configuration files stored in yaml files"""
+"""Centralized helpers for reading, writing, and creating configuration files (YAML)."""
 from __future__ import annotations
 
+import os
+import warnings
 from pathlib import Path
 from typing import Callable
 
+import yaml
+import ruamel.yaml.representer
 from ruamel.yaml import YAML
+
+from deeplabcut.core.engine import Engine
 
 
 def read_config_as_dict(config_path: str | Path) -> dict:
@@ -24,7 +30,14 @@ def read_config_as_dict(config_path: str | Path) -> dict:
 
     Returns:
         The configuration file with pure Python classes
+
+    Raises:
+        FileNotFoundError: if the config file does not exist
     """
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(
+            f"Config {config_path} is not found. Please make sure that the file exists."
+        )
     with open(config_path, "r") as f:
         cfg = YAML(typ="safe", pure=True).load(f)
 
@@ -72,3 +85,294 @@ def pretty_print(
             pretty_print(v, indent + 2, print_fn=print_fn)
         else:
             print_fn(f"{indent * ' '}{k}: {v}")
+
+# -----------------------------------------------------------------------------
+# Project config (config.yaml with template and defaults)
+# -----------------------------------------------------------------------------
+
+
+def create_config_template(multianimal: bool = False) -> tuple:
+    """
+    Creates a template for config.yaml file. This specific order is preserved while saving as yaml file.
+
+    Returns:
+        (cfg_file, ruamelFile) for further editing and dumping.
+    """
+    if multianimal:
+        yaml_str = """\
+# Project definitions (do not edit)
+Task:
+scorer:
+date:
+multianimalproject:
+identity:
+\n
+# Project path (change when moving around)
+project_path:
+\n
+# Default DeepLabCut engine to use for shuffle creation (either pytorch or tensorflow)
+engine: pytorch
+\n
+# Annotation data set configuration (and individual video cropping parameters)
+video_sets:
+individuals:
+uniquebodyparts:
+multianimalbodyparts:
+bodyparts:
+\n
+# Fraction of video to start/stop when extracting frames for labeling/refinement
+start:
+stop:
+numframes2pick:
+\n
+# Plotting configuration
+skeleton:
+skeleton_color:
+pcutoff:
+dotsize:
+alphavalue:
+colormap:
+\n
+# Training,Evaluation and Analysis configuration
+TrainingFraction:
+iteration:
+default_net_type:
+default_augmenter:
+default_track_method:
+snapshotindex:
+detector_snapshotindex:
+batch_size:
+\n
+# Cropping Parameters (for analysis and outlier frame detection)
+cropping:
+#if cropping is true for analysis, then set the values here:
+x1:
+x2:
+y1:
+y2:
+\n
+# Refinement configuration (parameters from annotation dataset configuration also relevant in this stage)
+corner2move2:
+move2corner:
+\n
+# Conversion tables to fine-tune SuperAnimal weights
+SuperAnimalConversionTables:
+        """
+    else:
+        yaml_str = """\
+# Project definitions (do not edit)
+Task:
+scorer:
+date:
+multianimalproject:
+identity:
+\n
+# Project path (change when moving around)
+project_path:
+\n
+# Default DeepLabCut engine to use for shuffle creation (either pytorch or tensorflow)
+engine: pytorch
+\n
+# Annotation data set configuration (and individual video cropping parameters)
+video_sets:
+bodyparts:
+\n
+# Fraction of video to start/stop when extracting frames for labeling/refinement
+start:
+stop:
+numframes2pick:
+\n
+# Plotting configuration
+skeleton:
+skeleton_color:
+pcutoff:
+dotsize:
+alphavalue:
+colormap:
+\n
+# Training,Evaluation and Analysis configuration
+TrainingFraction:
+iteration:
+default_net_type:
+default_augmenter:
+snapshotindex:
+detector_snapshotindex:
+batch_size:
+detector_batch_size:
+\n
+# Cropping Parameters (for analysis and outlier frame detection)
+cropping:
+#if cropping is true for analysis, then set the values here:
+x1:
+x2:
+y1:
+y2:
+\n
+# Refinement configuration (parameters from annotation dataset configuration also relevant in this stage)
+corner2move2:
+move2corner:
+\n
+# Conversion tables to fine-tune SuperAnimal weights
+SuperAnimalConversionTables:
+        """
+
+    ruamelFile = YAML()
+    cfg_file = ruamelFile.load(yaml_str)
+    return cfg_file, ruamelFile
+
+
+def create_config_template_3d() -> tuple:
+    """
+    Creates a template for config.yaml file for 3d project. This specific order is preserved while saving as yaml file.
+
+    Returns:
+        (cfg_file_3d, ruamelFile_3d) for further editing and dumping.
+    """
+    yaml_str = """\
+# Project definitions (do not edit)
+Task:
+scorer:
+date:
+\n
+# Project path (change when moving around)
+project_path:
+\n
+# Plotting configuration
+skeleton: # Note that the pairs must be defined, as you want them linked!
+skeleton_color:
+pcutoff:
+colormap:
+dotsize:
+alphaValue:
+markerType:
+markerColor:
+\n
+# Number of cameras, camera names, path of the config files, shuffle index and trainingsetindex used to analyze videos:
+num_cameras:
+camera_names:
+scorername_3d: # Enter the scorer name for the 3D output
+    """
+    ruamelFile_3d = YAML()
+    cfg_file_3d = ruamelFile_3d.load(yaml_str)
+    return cfg_file_3d, ruamelFile_3d
+
+
+def read_config(configname: str | Path) -> dict:
+    """
+    Reads structured config file defining a project.
+    Applies default values and repairs (engine, detector_snapshotindex, project_path) and writes back if needed.
+    """
+    ruamelFile = YAML()
+    path = Path(configname)
+    if os.path.exists(path):
+        try:
+            with open(path, "r") as f:
+                cfg = ruamelFile.load(f)
+                curr_dir = str(Path(configname).parent.resolve())
+
+                if cfg.get("engine") is None:
+                    cfg["engine"] = Engine.TF.aliases[0]
+                    write_project_config(configname, cfg)
+
+                if cfg.get("detector_snapshotindex") is None:
+                    cfg["detector_snapshotindex"] = -1
+
+                if cfg.get("detector_batch_size") is None:
+                    cfg["detector_batch_size"] = 1
+
+                if cfg["project_path"] != curr_dir:
+                    cfg["project_path"] = curr_dir
+                    write_project_config(configname, cfg)
+        except Exception as err:
+            if len(err.args) > 2:
+                if (
+                    err.args[2]
+                    == "could not determine a constructor for the tag '!!python/tuple'"
+                ):
+                    with open(path, "r") as ymlfile:
+                        cfg = yaml.load(ymlfile, Loader=yaml.SafeLoader)
+                        write_project_config(configname, cfg)
+                else:
+                    raise
+    else:
+        raise FileNotFoundError(
+            f"Config file at {path} not found. Please make sure that the file exists and/or that you passed the path of the config file correctly!"
+        )
+    return cfg
+
+
+def write_project_config(configname: str | Path, cfg: dict) -> None:
+    """Write structured project config file (config.yaml) preserving template order."""
+    with open(configname, "w") as cf:
+        cfg_file, ruamelFile = create_config_template(
+            cfg.get("multianimalproject", False)
+        )
+        for key in cfg.keys():
+            cfg_file[key] = cfg[key]
+
+        # Adding default value for variable skeleton and skeleton_color for backward compatibility.
+        if "skeleton" not in cfg.keys():
+            cfg_file["skeleton"] = []
+            cfg_file["skeleton_color"] = "black"
+        ruamelFile.dump(cfg_file, cf)
+
+
+def edit_config(
+    configname: str | Path, edits: dict, output_name: str | Path = ""
+) -> dict:
+    """
+    Convenience function to edit and save a config file from a dictionary.
+
+    Parameters
+    ----------
+    configname : string
+        String containing the full path of the config file in the project.
+    edits : dict
+        Key–value pairs to edit in config
+    output_name : string, optional (default='')
+        Overwrite the original config.yaml by default.
+        If passed in though, new filename of the edited config.
+
+    Examples
+    --------
+    config_path = 'my_stellar_lab/dlc/config.yaml'
+
+    edits = {'numframes2pick': 5,
+             'trainingFraction': [0.5, 0.8],
+             'skeleton': [['a', 'b'], ['b', 'c']]}
+
+    deeplabcut.core.config.edit_config(config_path, edits)
+    """
+    cfg = read_config_as_dict(configname)
+    for key, value in edits.items():
+        cfg[key] = value
+    if not output_name:
+        output_name = configname
+    try:
+        write_config(output_name, cfg)
+    except ruamel.yaml.representer.RepresenterError:
+        warnings.warn(
+            "Some edits could not be written. "
+            "The configuration file will be left unchanged."
+        )
+        for key in edits:
+            cfg.pop(key)
+        write_config(output_name, cfg)
+    return cfg
+
+
+def write_config_3d(configname: str | Path, cfg: dict) -> None:
+    """Write structured 3D project config file."""
+    with open(configname, "w") as cf:
+        cfg_file, ruamelFile = create_config_template_3d()
+        for key in cfg.keys():
+            cfg_file[key] = cfg[key]
+        ruamelFile.dump(cfg_file, cf)
+
+
+def write_config_3d_template(
+    projconfigfile: str | Path, cfg_file_3d: dict, ruamelFile_3d: YAML
+) -> None:
+    """Write 3D config from pre-built template and YAML instance."""
+    with open(projconfigfile, "w") as cf:
+        ruamelFile_3d.dump(cfg_file_3d, cf)

--- a/deeplabcut/modelzoo/generalized_data_converter/datasets/materialize.py
+++ b/deeplabcut/modelzoo/generalized_data_converter/datasets/materialize.py
@@ -117,7 +117,7 @@ class SingleDLC_config:
 
     def create_cfg(self, proj_root, kwargs):
         self.cfg.update(kwargs)
-        write_project_config(os.path.join(proj_root, "config.yaml"), self.cfg)
+        write_project_config(Path(proj_root) / "config.yaml", self.cfg)
 
 
 class MaDLC_config:
@@ -167,7 +167,7 @@ class MaDLC_config:
 
     def create_cfg(self, proj_root, kwargs):
         self.cfg.update(kwargs)
-        write_project_config(os.path.join(proj_root, "config.yaml"), self.cfg)
+        write_project_config(Path(proj_root) / "config.yaml", self.cfg)
 
 
 def _generic2madlc(

--- a/deeplabcut/modelzoo/generalized_data_converter/datasets/materialize.py
+++ b/deeplabcut/modelzoo/generalized_data_converter/datasets/materialize.py
@@ -17,9 +17,9 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import scipy.io as sio
-import yaml
 
 import deeplabcut.compat as compat
+from deeplabcut.core.config import write_project_config
 from deeplabcut.generate_training_dataset.multiple_individuals_trainingsetmanipulation import (
     create_multianimaltraining_dataset,
     format_multianimal_training_data,
@@ -117,8 +117,7 @@ class SingleDLC_config:
 
     def create_cfg(self, proj_root, kwargs):
         self.cfg.update(kwargs)
-        with open(os.path.join(proj_root, "config.yaml"), "w") as f:
-            yaml.dump(self.cfg, f)
+        write_project_config(os.path.join(proj_root, "config.yaml"), self.cfg)
 
 
 class MaDLC_config:
@@ -168,8 +167,7 @@ class MaDLC_config:
 
     def create_cfg(self, proj_root, kwargs):
         self.cfg.update(kwargs)
-        with open(os.path.join(proj_root, "config.yaml"), "w") as f:
-            yaml.dump(self.cfg, f)
+        write_project_config(os.path.join(proj_root, "config.yaml"), self.cfg)
 
 
 def _generic2madlc(

--- a/deeplabcut/modelzoo/generalized_data_converter/datasets/materialize.py
+++ b/deeplabcut/modelzoo/generalized_data_converter/datasets/materialize.py
@@ -108,7 +108,7 @@ class SingleDLC_config:
         x2 = 640
         y1 = 277
         y2 = 624
-        corer2move2 = [50, 50]
+        corner2move2 = [50, 50]
         move2corner = True
         identity = False
         self.cfg = {
@@ -158,7 +158,7 @@ class MaDLC_config:
         x2 = 640
         y1 = 277
         y2 = 624
-        corer2move2 = [50, 50]
+        corner2move2 = [50, 50]
         move2corner = True
         identity = False
         self.cfg = {

--- a/deeplabcut/modelzoo/video_inference.py
+++ b/deeplabcut/modelzoo/video_inference.py
@@ -17,9 +17,7 @@ from typing import Optional, Union
 
 import torch
 from dlclibrary.dlcmodelzoo.modelzoo_download import download_huggingface_model
-from ruamel.yaml import YAML
-
-from deeplabcut.core.config import read_config_as_dict
+from deeplabcut.core.config import read_config_as_dict, write_config
 from deeplabcut.modelzoo.utils import get_super_animal_scorer
 from deeplabcut.pose_estimation_pytorch.modelzoo.train_from_coco import adaptation_train
 from deeplabcut.pose_estimation_pytorch.modelzoo.utils import (
@@ -489,9 +487,7 @@ def video_inference_superanimal(
 
             # the model config's parameters need to be updated for adaptation training
             model_config_path = model_folder / "pytorch_config.yaml"
-            with open(model_config_path, "w") as f:
-                yaml = YAML()
-                yaml.dump(config, f)
+            write_config(model_config_path, config)
 
             # get the current epoch of the pose model
             current_pose_epoch = get_checkpoint_epoch(pose_model_path)

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -29,27 +29,27 @@ from typing import List
 import numpy as np
 import pandas as pd
 
-from deeplabcut.core import config as _config
+from deeplabcut.core import config as core_config
 from deeplabcut.core.engine import Engine
 from deeplabcut.core.trackingutils import TRACK_METHODS
 from deeplabcut.utils import auxfun_videos, auxfun_multianimal
 
-# NOTE JR 2026-01-29: Configuration I/O is now centralized in deeplabcut.core.config
+# NOTE @deruyter92 2026-01-29: Configuration I/O is now centralized in deeplabcut.core.config
 # These functions are exported here for backwards compatibility with existing code. 
-create_config_template = _config.create_config_template
-create_config_template_3d = _config.create_config_template_3d
-read_config = _config.read_config
-write_config = _config.write_project_config
+create_config_template = core_config.create_config_template
+create_config_template_3d = core_config.create_config_template_3d
+read_config = core_config.read_config
+write_config = core_config.write_project_config
 def read_plainconfig(configname: str | Path) -> dict:
     """Load a YAML config (alias for read_config_as_dict). See deeplabcut.core.config."""
-    return _config.read_config_as_dict(config_path=configname)
+    return core_config.read_config_as_dict(config_path=configname)
 
 def write_plainconfig(configname: str | Path, cfg: dict, overwrite: bool = True) -> None:
     """Write a config dict to YAML (alias for write_config). See deeplabcut.core.config."""
-    _config.write_config(config_path=configname, config=cfg, overwrite=overwrite)
-edit_config = _config.edit_config
-write_config_3d = _config.write_config_3d
-write_config_3d_template = _config.write_config_3d_template
+    core_config.write_config(config_path=configname, config=cfg, overwrite=overwrite)
+edit_config = core_config.edit_config
+write_config_3d = core_config.write_config_3d
+write_config_3d_template = core_config.write_config_3d_template
 
 
 def get_bodyparts(cfg: dict) -> typing.List[str]:

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -35,18 +35,25 @@ from deeplabcut.core.trackingutils import TRACK_METHODS
 from deeplabcut.utils import auxfun_videos, auxfun_multianimal
 
 # NOTE @deruyter92 2026-01-29: Configuration I/O is now centralized in deeplabcut.core.config
-# These functions are exported here for backwards compatibility with existing code. 
+# These functions are exported here for backwards compatibility with existing code.
 create_config_template = core_config.create_config_template
 create_config_template_3d = core_config.create_config_template_3d
 read_config = core_config.read_config
 write_config = core_config.write_project_config
+
+
 def read_plainconfig(configname: str | Path) -> dict:
     """Load a YAML config (alias for read_config_as_dict). See deeplabcut.core.config."""
     return core_config.read_config_as_dict(config_path=configname)
 
-def write_plainconfig(configname: str | Path, cfg: dict, overwrite: bool = True) -> None:
+
+def write_plainconfig(
+    configname: str | Path, cfg: dict, overwrite: bool = True
+) -> None:
     """Write a config dict to YAML (alias for write_config). See deeplabcut.core.config."""
     core_config.write_config(config_path=configname, config=cfg, overwrite=overwrite)
+
+
 edit_config = core_config.edit_config
 write_config_3d = core_config.write_config_3d
 write_config_3d_template = core_config.write_config_3d_template

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -28,277 +28,28 @@ from typing import List
 
 import numpy as np
 import pandas as pd
-import ruamel.yaml.representer
-import yaml
-from ruamel.yaml import YAML
 
+from deeplabcut.core import config as _config
 from deeplabcut.core.engine import Engine
 from deeplabcut.core.trackingutils import TRACK_METHODS
 from deeplabcut.utils import auxfun_videos, auxfun_multianimal
 
+# NOTE JR 2026-01-29: Configuration I/O is now centralized in deeplabcut.core.config
+# These functions are exported here for backwards compatibility with existing code. 
+create_config_template = _config.create_config_template
+create_config_template_3d = _config.create_config_template_3d
+read_config = _config.read_config
+write_config = _config.write_project_config
+def read_plainconfig(configname: str | Path) -> dict:
+    """Load a YAML config (alias for read_config_as_dict). See deeplabcut.core.config."""
+    return _config.read_config_as_dict(config_path=configname)
 
-def create_config_template(multianimal=False):
-    """
-    Creates a template for config.yaml file. This specific order is preserved while saving as yaml file.
-    """
-    if multianimal:
-        yaml_str = """\
-# Project definitions (do not edit)
-Task:
-scorer:
-date:
-multianimalproject:
-identity:
-\n
-# Project path (change when moving around)
-project_path:
-\n
-# Default DeepLabCut engine to use for shuffle creation (either pytorch or tensorflow)
-engine: pytorch
-\n
-# Annotation data set configuration (and individual video cropping parameters)
-video_sets:
-individuals:
-uniquebodyparts:
-multianimalbodyparts:
-bodyparts:
-\n
-# Fraction of video to start/stop when extracting frames for labeling/refinement
-start:
-stop:
-numframes2pick:
-\n
-# Plotting configuration
-skeleton:
-skeleton_color:
-pcutoff:
-dotsize:
-alphavalue:
-colormap:
-\n
-# Training,Evaluation and Analysis configuration
-TrainingFraction:
-iteration:
-default_net_type:
-default_augmenter:
-default_track_method:
-snapshotindex:
-detector_snapshotindex:
-batch_size:
-\n
-# Cropping Parameters (for analysis and outlier frame detection)
-cropping:
-#if cropping is true for analysis, then set the values here:
-x1:
-x2:
-y1:
-y2:
-\n
-# Refinement configuration (parameters from annotation dataset configuration also relevant in this stage)
-corner2move2:
-move2corner:
-\n
-# Conversion tables to fine-tune SuperAnimal weights
-SuperAnimalConversionTables:
-        """
-    else:
-        yaml_str = """\
-# Project definitions (do not edit)
-Task:
-scorer:
-date:
-multianimalproject:
-identity:
-\n
-# Project path (change when moving around)
-project_path:
-\n
-# Default DeepLabCut engine to use for shuffle creation (either pytorch or tensorflow)
-engine: pytorch
-\n
-# Annotation data set configuration (and individual video cropping parameters)
-video_sets:
-bodyparts:
-\n
-# Fraction of video to start/stop when extracting frames for labeling/refinement
-start:
-stop:
-numframes2pick:
-\n
-# Plotting configuration
-skeleton:
-skeleton_color:
-pcutoff:
-dotsize:
-alphavalue:
-colormap:
-\n
-# Training,Evaluation and Analysis configuration
-TrainingFraction:
-iteration:
-default_net_type:
-default_augmenter:
-snapshotindex:
-detector_snapshotindex:
-batch_size:
-detector_batch_size:
-\n
-# Cropping Parameters (for analysis and outlier frame detection)
-cropping:
-#if cropping is true for analysis, then set the values here:
-x1:
-x2:
-y1:
-y2:
-\n
-# Refinement configuration (parameters from annotation dataset configuration also relevant in this stage)
-corner2move2:
-move2corner:
-\n
-# Conversion tables to fine-tune SuperAnimal weights
-SuperAnimalConversionTables:
-        """
-
-    ruamelFile = YAML()
-    cfg_file = ruamelFile.load(yaml_str)
-    return cfg_file, ruamelFile
-
-
-def create_config_template_3d():
-    """
-    Creates a template for config.yaml file for 3d project. This specific order is preserved while saving as yaml file.
-    """
-    yaml_str = """\
-# Project definitions (do not edit)
-Task:
-scorer:
-date:
-\n
-# Project path (change when moving around)
-project_path:
-\n
-# Plotting configuration
-skeleton: # Note that the pairs must be defined, as you want them linked!
-skeleton_color:
-pcutoff:
-colormap:
-dotsize:
-alphaValue:
-markerType:
-markerColor:
-\n
-# Number of cameras, camera names, path of the config files, shuffle index and trainingsetindex used to analyze videos:
-num_cameras:
-camera_names:
-scorername_3d: # Enter the scorer name for the 3D output
-    """
-    ruamelFile_3d = YAML()
-    cfg_file_3d = ruamelFile_3d.load(yaml_str)
-    return cfg_file_3d, ruamelFile_3d
-
-
-def read_config(configname):
-    """
-    Reads structured config file defining a project.
-    """
-    ruamelFile = YAML()
-    path = Path(configname)
-    if os.path.exists(path):
-        try:
-            with open(path, "r") as f:
-                cfg = ruamelFile.load(f)
-                curr_dir = str(Path(configname).parent.resolve())
-
-                if cfg.get("engine") is None:
-                    cfg["engine"] = Engine.TF.aliases[0]
-                    write_config(configname, cfg)
-
-                if cfg.get("detector_snapshotindex") is None:
-                    cfg["detector_snapshotindex"] = -1
-
-                if cfg.get("detector_batch_size") is None:
-                    cfg["detector_batch_size"] = 1
-
-                if cfg["project_path"] != curr_dir:
-                    cfg["project_path"] = curr_dir
-                    write_config(configname, cfg)
-        except Exception as err:
-            if len(err.args) > 2:
-                if (
-                    err.args[2]
-                    == "could not determine a constructor for the tag '!!python/tuple'"
-                ):
-                    with open(path, "r") as ymlfile:
-                        cfg = yaml.load(ymlfile, Loader=yaml.SafeLoader)
-                        write_config(configname, cfg)
-                else:
-                    raise
-
-    else:
-        raise FileNotFoundError(
-            f"Config file at {path} not found. Please make sure that the file exists and/or that you passed the path of the config file correctly!"
-        )
-    return cfg
-
-
-def write_config(configname, cfg):
-    """
-    Write structured config file.
-    """
-    with open(configname, "w") as cf:
-        cfg_file, ruamelFile = create_config_template(
-            cfg.get("multianimalproject", False)
-        )
-        for key in cfg.keys():
-            cfg_file[key] = cfg[key]
-
-        # Adding default value for variable skeleton and skeleton_color for backward compatibility.
-        if not "skeleton" in cfg.keys():
-            cfg_file["skeleton"] = []
-            cfg_file["skeleton_color"] = "black"
-        ruamelFile.dump(cfg_file, cf)
-
-
-def edit_config(configname, edits, output_name=""):
-    """
-    Convenience function to edit and save a config file from a dictionary.
-
-    Parameters
-    ----------
-    configname : string
-        String containing the full path of the config file in the project.
-    edits : dict
-        Key–value pairs to edit in config
-    output_name : string, optional (default='')
-        Overwrite the original config.yaml by default.
-        If passed in though, new filename of the edited config.
-
-    Examples
-    --------
-    config_path = 'my_stellar_lab/dlc/config.yaml'
-
-    edits = {'numframes2pick': 5,
-             'trainingFraction': [0.5, 0.8],
-             'skeleton': [['a', 'b'], ['b', 'c']]}
-
-    deeplabcut.auxiliaryfunctions.edit_config(config_path, edits)
-    """
-    cfg = read_plainconfig(configname)
-    for key, value in edits.items():
-        cfg[key] = value
-    if not output_name:
-        output_name = configname
-    try:
-        write_plainconfig(output_name, cfg)
-    except ruamel.yaml.representer.RepresenterError:
-        warnings.warn(
-            "Some edits could not be written. "
-            "The configuration file will be left unchanged."
-        )
-        for key in edits:
-            cfg.pop(key)
-        write_plainconfig(output_name, cfg)
-    return cfg
+def write_plainconfig(configname: str | Path, cfg: dict, overwrite: bool = True) -> None:
+    """Write a config dict to YAML (alias for write_config). See deeplabcut.core.config."""
+    _config.write_config(config_path=configname, config=cfg, overwrite=overwrite)
+edit_config = _config.edit_config
+write_config_3d = _config.write_config_3d
+write_config_3d_template = _config.write_config_3d_template
 
 
 def get_bodyparts(cfg: dict) -> typing.List[str]:
@@ -335,36 +86,6 @@ def get_unique_bodyparts(cfg: dict) -> typing.List[str]:
         return unique_bodyparts
 
     return []
-
-
-def write_config_3d(configname, cfg):
-    """
-    Write structured 3D config file.
-    """
-    with open(configname, "w") as cf:
-        cfg_file, ruamelFile = create_config_template_3d()
-        for key in cfg.keys():
-            cfg_file[key] = cfg[key]
-        ruamelFile.dump(cfg_file, cf)
-
-
-def write_config_3d_template(projconfigfile, cfg_file_3d, ruamelFile_3d):
-    with open(projconfigfile, "w") as cf:
-        ruamelFile_3d.dump(cfg_file_3d, cf)
-
-
-def read_plainconfig(configname):
-    if not os.path.exists(configname):
-        raise FileNotFoundError(
-            f"Config {configname} is not found. Please make sure that the file exists."
-        )
-    with open(configname) as file:
-        return YAML().load(file)
-
-
-def write_plainconfig(configname, cfg):
-    with open(configname, "w") as file:
-        YAML().dump(cfg, file)
 
 
 def attempt_to_make_folder(foldername, recursive=False):

--- a/deeplabcut/utils/skeleton.py
+++ b/deeplabcut/utils/skeleton.py
@@ -28,29 +28,16 @@ import pandas as pd
 from matplotlib.collections import LineCollection
 from matplotlib.path import Path
 from matplotlib.widgets import Button, LassoSelector
-from ruamel.yaml import YAML
 from scipy.spatial import cKDTree as KDTree
 from skimage import io
 
-
-def read_config(configname):
-    if not os.path.exists(configname):
-        raise FileNotFoundError(
-            f"Config {configname} is not found. Please make sure that the file exists."
-        )
-    with open(configname) as file:
-        return YAML().load(file)
-
-
-def write_config(configname, cfg):
-    with open(configname, "w") as file:
-        YAML().dump(cfg, file)
+from deeplabcut.core.config import read_config_as_dict, write_config
 
 
 class SkeletonBuilder:
     def __init__(self, config_path):
         self.config_path = config_path
-        self.cfg = read_config(config_path)
+        self.cfg = read_config_as_dict(config_path)
         # Find uncropped labeled data
         self.df = None
         found = False

--- a/tests/core/config/test_core_config.py
+++ b/tests/core/config/test_core_config.py
@@ -1,0 +1,314 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Tests for deeplabcut.core.config."""
+from pathlib import Path
+
+import pytest
+
+from deeplabcut.core.config import (
+    create_config_template,
+    create_config_template_3d,
+    edit_config,
+    pretty_print,
+    read_config,
+    read_config_as_dict,
+    write_config,
+    write_config_3d,
+    write_config_3d_template,
+    write_project_config,
+)
+
+
+# -----------------------------------------------------------------------------
+# read_config_as_dict
+# -----------------------------------------------------------------------------
+
+def test_read_config_as_dict_loads_yaml(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("a: 1\nb: [2, 3]\nc:\n  d: 4\n")
+    cfg = read_config_as_dict(str(config_path))
+    assert cfg == {"a": 1, "b": [2, 3], "c": {"d": 4}}
+
+def test_read_config_as_dict_raises_when_file_missing():
+    with pytest.raises(FileNotFoundError):
+        read_config_as_dict(Path("/nonexistent/config.yaml"))
+
+# -----------------------------------------------------------------------------
+# write_config
+# -----------------------------------------------------------------------------
+
+def test_write_config_creates_file(tmp_path):
+    config_path = tmp_path / "out.yaml"
+    write_config(config_path, {"a": 1, "b": 2})
+    assert config_path.exists()
+    cfg = read_config_as_dict(config_path)
+    assert cfg["a"] == 1 and cfg["b"] == 2
+
+
+def test_write_config_overwrites_existing(tmp_path):
+    config_path = tmp_path / "out.yaml"
+    config_path.write_text("old: true\n")
+    write_config(config_path, {"new": True}, overwrite=True)
+    cfg = read_config_as_dict(config_path)
+    assert "new" in cfg and "old" not in cfg
+
+
+def test_write_config_raises_when_overwrite_false_and_file_exists(tmp_path):
+    config_path = tmp_path / "out.yaml"
+    config_path.write_text("x: 1\n")
+    with pytest.raises(FileExistsError):
+        write_config(config_path, {"x": 2}, overwrite=False)
+
+
+def test_write_config_allows_overwrite_false_when_file_missing(tmp_path):
+    config_path = tmp_path / "new.yaml"
+    write_config(config_path, {"x": 1}, overwrite=False)
+    assert read_config_as_dict(config_path) == {"x": 1}
+
+
+# -----------------------------------------------------------------------------
+# pretty_print
+# -----------------------------------------------------------------------------
+
+
+def test_pretty_print_flat_config(capsys):
+    pretty_print({"a": 1, "b": 2})
+    out, _ = capsys.readouterr()
+    assert "a: 1" in out and "b: 2" in out
+
+
+def test_pretty_print_nested_config(capsys):
+    pretty_print({"top": {"nested": 42}})
+    out, _ = capsys.readouterr()
+    assert "top:" in out and "nested: 42" in out
+
+
+def test_pretty_print_with_indent(capsys):
+    pretty_print({"k": "v"}, indent=4)
+    out, _ = capsys.readouterr()
+    assert out.startswith("    k:")
+
+
+def test_pretty_print_with_custom_print_fn():
+    lines = []
+
+    def capture(s):
+        lines.append(s)
+
+    pretty_print({"a": 1}, print_fn=capture)
+    assert any("a: 1" in line for line in lines)
+
+
+# -----------------------------------------------------------------------------
+# create_config_template
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("multianimal", [False, True])
+def test_create_config_template_returns_tuple(multianimal):
+    cfg_file, ruamel_file = create_config_template(multianimal=multianimal)
+    assert isinstance(cfg_file, dict)
+    assert ruamel_file is not None
+
+
+def test_create_config_template_single_animal_has_expected_keys():
+    cfg_file, _ = create_config_template(multianimal=False)
+    assert "Task" in cfg_file
+    assert "project_path" in cfg_file
+    assert "bodyparts" in cfg_file
+    assert "engine" in cfg_file
+    assert "video_sets" in cfg_file
+    assert "multianimalproject" in cfg_file
+    assert "detector_batch_size" in cfg_file
+    assert "individuals" not in cfg_file
+    assert "uniquebodyparts" not in cfg_file
+    assert "multianimalbodyparts" not in cfg_file
+
+
+def test_create_config_template_multianimal_has_extra_keys():
+    cfg_file, _ = create_config_template(multianimal=True)
+    assert "individuals" in cfg_file
+    assert "uniquebodyparts" in cfg_file
+    assert "multianimalbodyparts" in cfg_file
+    assert "bodyparts" in cfg_file
+
+
+# -----------------------------------------------------------------------------
+# create_config_template_3d
+# -----------------------------------------------------------------------------
+
+
+def test_create_config_template_3d_returns_tuple():
+    cfg_file_3d, ruamel_file_3d = create_config_template_3d()
+    assert isinstance(cfg_file_3d, dict)
+    assert ruamel_file_3d is not None
+
+
+def test_create_config_template_3d_has_expected_keys():
+    cfg_file, _ = create_config_template_3d()
+    assert "Task" in cfg_file
+    assert "project_path" in cfg_file
+    assert "skeleton" in cfg_file
+    assert "num_cameras" in cfg_file
+    assert "camera_names" in cfg_file
+    assert "scorername_3d" in cfg_file
+
+
+# -----------------------------------------------------------------------------
+# read_config
+# -----------------------------------------------------------------------------
+
+
+def test_read_config_raises_when_file_missing(tmp_path):
+    with pytest.raises(FileNotFoundError, match="Config file at .* not found"):
+        read_config(tmp_path / "missing.yaml")
+
+
+def test_read_config_sets_missing_engine_and_writes_back(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("project_path: /other/path\n")
+    cfg = read_config(config_path)
+    assert cfg["engine"] == "tensorflow"
+    assert cfg["project_path"] == str(tmp_path)
+    # File should have been updated
+    cfg_again = read_config_as_dict(config_path)
+    assert cfg_again["engine"] == "tensorflow"
+
+
+def test_read_config_sets_detector_snapshotindex_when_missing(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    write_project_config(config_path, {"project_path": str(tmp_path), "engine": "pytorch"})
+    cfg = read_config(config_path)
+    assert cfg["detector_snapshotindex"] == -1
+
+
+def test_read_config_sets_detector_batch_size_when_missing(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    write_project_config(config_path, {"project_path": str(tmp_path), "engine": "pytorch"})
+    cfg = read_config(config_path)
+    assert cfg["detector_batch_size"] == 1
+
+
+def test_read_config_updates_project_path_when_different(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    write_project_config(
+        config_path,
+        {"project_path": "/old/path", "engine": "pytorch"},
+    )
+    cfg = read_config(config_path)
+    assert cfg["project_path"] == str(tmp_path)
+
+
+def test_read_config_preserves_existing_engine_and_project_path(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    write_project_config(
+        config_path,
+        {"project_path": str(tmp_path), "engine": "pytorch"},
+    )
+    cfg = read_config(config_path)
+    assert cfg["engine"] == "pytorch"
+    assert cfg["project_path"] == str(tmp_path)
+
+
+# -----------------------------------------------------------------------------
+# write_project_config
+# -----------------------------------------------------------------------------
+
+
+def test_write_project_config_writes_valid_yaml(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    write_project_config(
+        config_path,
+        {"project_path": str(tmp_path), "Task": "mytask", "bodyparts": ["a", "b"]},
+    )
+    cfg = read_config_as_dict(config_path)
+    assert cfg["project_path"] == str(tmp_path)
+    assert cfg["Task"] == "mytask"
+    assert cfg["bodyparts"] == ["a", "b"]
+
+
+def test_write_project_config_adds_skeleton_defaults_when_missing(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    write_project_config(
+        config_path,
+        {"project_path": str(tmp_path), "multianimalproject": False},
+    )
+    cfg = read_config_as_dict(config_path)
+    assert cfg["skeleton"] == []
+    assert cfg["skeleton_color"] == "black"
+
+
+def test_write_project_config_uses_multianimal_template_when_flag_true(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    write_project_config(
+        config_path,
+        {"project_path": str(tmp_path), "multianimalproject": True},
+    )
+    cfg = read_config_as_dict(config_path)
+    assert "individuals" in cfg
+    assert "uniquebodyparts" in cfg
+
+
+# -----------------------------------------------------------------------------
+# edit_config
+# -----------------------------------------------------------------------------
+
+
+def test_edit_config_applies_edits_and_overwrites_original(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("a: 1\nb: 2\n")
+    cfg = edit_config(config_path, {"b": 99, "c": 3})
+    assert cfg["a"] == 1 and cfg["b"] == 99 and cfg["c"] == 3
+    loaded = read_config_as_dict(config_path)
+    assert loaded["b"] == 99 and loaded["c"] == 3
+
+
+def test_edit_config_writes_to_output_name_when_given(tmp_path):
+    src = tmp_path / "src.yaml"
+    src.write_text("x: 1\n")
+    out = tmp_path / "out.yaml"
+    cfg = edit_config(src, {"x": 2}, output_name=out)
+    assert cfg["x"] == 2
+    assert read_config_as_dict(out)["x"] == 2
+    assert read_config_as_dict(src)["x"] == 1
+
+
+# -----------------------------------------------------------------------------
+# write_config_3d
+# -----------------------------------------------------------------------------
+
+
+def test_write_config_3d_writes_valid_yaml(tmp_path):
+    config_path = tmp_path / "config_3d.yaml"
+    write_config_3d(
+        config_path,
+        {"project_path": str(tmp_path), "Task": "3dtask", "num_cameras": 2},
+    )
+    cfg = read_config_as_dict(config_path)
+    assert cfg["project_path"] == str(tmp_path)
+    assert cfg["Task"] == "3dtask"
+    assert cfg["num_cameras"] == 2
+
+
+# -----------------------------------------------------------------------------
+# write_config_3d_template
+# -----------------------------------------------------------------------------
+
+
+def test_write_config_3d_template_writes_given_template(tmp_path):
+    config_path = tmp_path / "config_3d.yaml"
+    cfg_file, ruamel_file = create_config_template_3d()
+    cfg_file["Task"] = "custom_3d"
+    cfg_file["num_cameras"] = 3
+    write_config_3d_template(config_path, cfg_file, ruamel_file)
+    cfg = read_config_as_dict(config_path)
+    assert cfg["Task"] == "custom_3d"
+    assert cfg["num_cameras"] == 3

--- a/tests/pose_estimation_pytorch/modelzoo/test_generalized_data_converter_config.py
+++ b/tests/pose_estimation_pytorch/modelzoo/test_generalized_data_converter_config.py
@@ -60,7 +60,7 @@ SINGLE_DLC_DEFAULTS = {
     "x2": 640,
     "y1": 277,
     "y2": 624,
-    "corer2move2": [50, 50],
+    "corner2move2": [50, 50],
     "move2corner": True,
     "identity": False,
 }

--- a/tests/pose_estimation_pytorch/modelzoo/test_generalized_data_converter_config.py
+++ b/tests/pose_estimation_pytorch/modelzoo/test_generalized_data_converter_config.py
@@ -1,0 +1,175 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Tests capturing the current state of the generalized_data_converter configuration.
+
+These tests document default values and behavior so that a migration to a new
+configuration system can preserve existing behavior. Add or adjust assertions
+if you intentionally change defaults.
+"""
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+from deeplabcut.modelzoo.generalized_data_converter.datasets.materialize import (
+    MaDLC_config,
+    SingleDLC_config,
+    modify_train_test_cfg,
+)
+
+
+# Modelzoo SingleDLC_config defaults
+# 2026-01-29 config version 0, before centralized typed configs were added
+SINGLE_DLC_DEFAULTS = {
+    "Task": "",
+    "project_path": "",
+    "scorer": "",
+    "date": "",
+    "video_sets": "",
+    "skeleton": "",
+    "bodyparts": "",
+    "start": 0,
+    "stop": 1,
+    "numframes2pick": 42,
+    "skeleton_color": "black",
+    "pcutoff": 0.6,
+    "dotsize": 8,
+    "alphavalue": 0.7,
+    "colormap": "rainbow",
+    "TrainingFraction": "",
+    "iteration": 0,
+    "default_net_type": "resnet_50",
+    "default_augmenter": "imgaug",
+    "snapshotindex": -1,
+    "batch_size": 8,
+    "cropping": False,
+    "croppedtraining": False,
+    "multianimalproject": False,
+    "uniquebodyparts": [],
+    "x1": 0,
+    "x2": 640,
+    "y1": 277,
+    "y2": 624,
+    "corer2move2": [50, 50],
+    "move2corner": True,
+    "identity": False,
+}
+
+
+# MaDLC_config defaults; only differences from Single are listed in tests
+MA_DLC_DEFAULTS_OVERRIDES = {
+    "default_augmenter": "multi-animal-imgaug",
+    "croppedtraining": True,
+    "multianimalproject": True,
+}
+MA_DLC_EXTRA_KEYS = {"individuals", "multianimalbodyparts"}
+
+
+class TestModelzooProjectConfigDefaults:
+    def test_single_dlc_config_defaults(self):
+        config = SingleDLC_config()
+        assert set(config.cfg.keys()) == set(SINGLE_DLC_DEFAULTS.keys())
+        for key, expected in SINGLE_DLC_DEFAULTS.items():
+            assert config.cfg[key] == expected, f"SingleDLC_config.cfg[{key!r}]"
+
+    def test_ma_dlc_config_has_all_single_keys_plus_ma_specific(self):
+        single_keys = set(SINGLE_DLC_DEFAULTS.keys())
+        ma_config = MaDLC_config()
+        ma_keys = set(ma_config.cfg.keys())
+        assert single_keys <= ma_keys
+        assert MA_DLC_EXTRA_KEYS <= ma_keys
+
+    def test_ma_dlc_config_overrides_vs_single(self):
+        single_config = SingleDLC_config()
+        ma_config = MaDLC_config()
+        for key, expected in MA_DLC_DEFAULTS_OVERRIDES.items():
+            assert ma_config.cfg[key] == expected, f"MaDLC_config.cfg[{key!r}]"
+            assert ma_config.cfg[key] != single_config.cfg[key], (
+                f"MaDLC should differ from Single for {key!r}"
+            )
+
+    def test_ma_dlc_config_shared_defaults_match_single(self):
+        """Keys not overridden in Ma should match Single defaults."""
+        single_config = SingleDLC_config()
+        ma_config = MaDLC_config()
+        for key in SINGLE_DLC_DEFAULTS:
+            if key in MA_DLC_DEFAULTS_OVERRIDES:
+                continue
+            assert ma_config.cfg[key] == single_config.cfg[key], (
+                f"MaDLC_config.cfg[{key!r}] should match Single"
+            )
+
+
+class TestModelzooCreateProjectConfig:
+    """Behavior of create_cfg: file location, format, and update semantics."""
+
+    def test_single_dlc_create_cfg_writes_config_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = SingleDLC_config()
+            config.create_cfg(tmpdir, {"Task": "mytask"})
+            path = Path(tmpdir) / "config.yaml"
+            assert path.exists()
+            with open(path) as f:
+                data = yaml.safe_load(f)
+            assert data["Task"] == "mytask"
+            assert data["default_net_type"] == "resnet_50"
+
+    def test_create_cfg_overwrites_with_kwargs(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = SingleDLC_config()
+            config.create_cfg(tmpdir, {"Task": "mytask", "batch_size": 16})
+            path = Path(tmpdir) / "config.yaml"
+            with open(path) as f:
+                data = yaml.safe_load(f)
+            assert data["Task"] == "mytask"
+            assert data["batch_size"] == 16
+
+    def test_ma_dlc_create_cfg_writes_config_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = MaDLC_config()
+            config.create_cfg(tmpdir, {"Task": "matask"})
+            path = Path(tmpdir) / "config.yaml"
+            assert path.exists()
+            with open(path) as f:
+                data = yaml.safe_load(f)
+            assert data["Task"] == "matask"
+            assert data["multianimalproject"] is True
+
+
+class TestModifyTrainTestCfg:
+    """Behavior of modify_train_test_cfg (train/test pose config updates)."""
+
+    def test_modify_train_test_cfg_requires_existing_config_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, "config.yaml")
+            # Non-existent config must not silently succeed
+            with pytest.raises(FileNotFoundError):
+                modify_train_test_cfg(config_path)
+
+    def test_modify_train_test_cfg_sets_expected_values(self):
+        """When a valid project layout exists, train/test configs get multi_stage, batch_size, gradient_masking.
+        We only assert the intended defaults; full integration would need a real project.
+        """
+        from deeplabcut.utils import auxiliaryfunctions
+
+        # Document intended behavior: multi_stage=True, batch_size=8, gradient_masking=True
+        # Actual call requires compat.return_train_network_path to resolve paths;
+        # this test just documents the intended defaults for migration.
+        intended_train_test_defaults = {
+            "multi_stage": True,
+            "batch_size": 8,
+            "gradient_masking": True,
+        }
+        assert intended_train_test_defaults["multi_stage"] is True
+        assert intended_train_test_defaults["batch_size"] == 8
+        assert intended_train_test_defaults["gradient_masking"] is True


### PR DESCRIPTION
This PR is part of the WIP for migrating from dictionary configs to typed & validated configurations (see #3193 for an overview). 

**Goal of this PR:**
Centralize the logic for reading, writing and adjusting configurations. And improve test coverage of the current behavior (before changing to a different configuration setup).
 
**Motivation:**
Currently reading and writing yaml files, and the logic for adjusting configuration files is spread across different places in the repository. 
- Keeping the input/output and config adjustment logic in a centralized place facilitates easier maintenance / migration, better testing and makes it clear for users which methods are available. 
- Before making larger adjustments, such as typed configurations, or different field names, it is important to capture the current behavior using tests. 

**Changes**
 1. Move all reading and writing functions for yaml files to `core.config`
 2. exporting to `auxiliaryfunctions` to keep existing references in place for backwards compatibility
 3. add pytests for core.config and the modelzoo `generalized_data_converter`
 
 This PR only pertains to project configs and core yaml reading / writing. The pose configs in pytorch pose estimation are kept unchanged. 