### PR TITLE
[dev] C3 - Replace configuration dictionaries with DictConfigs.

### DIFF
--- a/deeplabcut/core/config/config_mixin.py
+++ b/deeplabcut/core/config/config_mixin.py
@@ -77,8 +77,25 @@ class ConfigMixin:
             )
 
     @classmethod
-    def from_yaml(cls, yaml_path: str | Path) -> Self:
-        return cls.from_dict(read_config_as_dict(yaml_path))
+    def from_yaml(cls, yaml_path: str | Path, ignore_empty: bool = True) -> Self:
+        """
+        Load a configuration from a YAML file.
+
+        Args:
+            yaml_path: Path to the YAML configuration file.
+            ignore_empty: If True, empty/None values in the YAML are ignored and
+                dataclass defaults are used instead. Defaults to True.
+
+        Returns:
+            A new instance of the configuration class.
+        """
+        # NOTE @deruyter92 2026-02-05: Default ignore_empty is now set to True to match
+        # the prior behaviour of read_config. We should consider changing this to False
+        # for stricter validation.
+        yaml_dict = read_config_as_dict(yaml_path)
+        if ignore_empty:
+            yaml_dict = {k: v for k, v in yaml_dict.items() if v is not None}
+        return cls.from_dict(yaml_dict)
 
     def to_yaml(self, yaml_path: str | Path, overwrite: bool = True) -> None:
         data = CommentedMap(self.to_dict())

--- a/deeplabcut/core/config/project_config.py
+++ b/deeplabcut/core/config/project_config.py
@@ -11,6 +11,7 @@
 """Project configuration classes for DeepLabCut pose estimation models."""
 
 from typing import Any
+from pathlib import Path
 
 from pydantic.dataclasses import dataclass
 from dataclasses import field
@@ -76,8 +77,8 @@ class ProjectConfig(ConfigMixin):
     identity: bool | None = None
 
     # Project path
-    project_path: str = field(default="", metadata={"comment": "\nProject path (change when moving around)"})
-    pose_config_path: str = ""
+    project_path: Path = field(default=Path(), metadata={"comment": "\nProject path (change when moving around)"})
+    pose_config_path: Path = Path()
 
     # Engine
     engine: str = field(

--- a/deeplabcut/core/config/project_config.py
+++ b/deeplabcut/core/config/project_config.py
@@ -150,7 +150,7 @@ class ProjectConfig(ConfigMixin):
     y2: int | None = None
 
     # Refinement configuration (parameters from annotation dataset configuration also relevant in this stage)
-    corner2move2: list[list[str]] | None = field(
+    corner2move2: list[int] | None = field(
         default=None,
         metadata={"comment": "\nRefinement configuration (parameters from annotation dataset configuration also relevant in this stage)"},
     )

--- a/deeplabcut/core/config/utils.py
+++ b/deeplabcut/core/config/utils.py
@@ -145,14 +145,28 @@ scorername_3d: # Enter the scorer name for the 3D output
     return cfg_file_3d, ruamelFile_3d
 
 
-def read_config(configname: str | Path) -> DictConfig:
+def read_config(configname: str | Path, ignore_empty: bool = True) -> DictConfig:
     """
     Reads structured config file defining a project.
-    Applies default values and repairs (engine, detector_snapshotindex, project_path) and writes back if needed.
+
+    Applies default values and repairs (engine, detector_snapshotindex, project_path)
+    and writes back if needed.
+
+    Args:
+        configname: Path to the project configuration file (config.yaml).
+        ignore_empty: If True, empty/None values in the YAML are ignored and
+            dataclass defaults are used instead. If False, empty values represent None.
+            Defaults to True.
+
+    Returns:
+        The project configuration as a DictConfig.
     """
+    # NOTE @deruyter92 2026-02-05: Default ignore_empty is now set to True to match
+    # the prior behaviour of read_config. We should consider changing this to False
+    # for stricter validation.
     from deeplabcut.core.config.project_config import ProjectConfig
     path = Path(configname)
-    project_config = ProjectConfig.from_yaml(path)
+    project_config = ProjectConfig.from_yaml(path, ignore_empty=ignore_empty)
     
     # NOTE @deruyter92 2026-02-02: copied old behaviour of writing the config back to the file.
     # We should consider separating the writing and reading instead of having inplace edits during reading.

--- a/deeplabcut/core/config/utils.py
+++ b/deeplabcut/core/config/utils.py
@@ -102,7 +102,7 @@ def create_config_template(multianimal: bool = False) -> tuple:
     Returns:
         (cfg_file, ruamelFile) for further editing and dumping.
     """
-    warnings.warn("This function is deprecated. Use ProjectConfig instead.")
+    warnings.warn("This function is deprecated. Use deeplabcut.core.config.ProjectConfig instead.")
     from deeplabcut.core.config.project_config import ProjectConfig
     ruamelFile = YAML()
     cfg_file = ProjectConfig(multianimalproject=multianimal).to_dict()

--- a/deeplabcut/core/types.py
+++ b/deeplabcut/core/types.py
@@ -11,3 +11,37 @@ PydanticNDArray: TypeAlias = Annotated[
         lambda _s, h: h(InstanceOf[np.ndarray]), lambda _s, h: h(InstanceOf[np.ndarray])
     ),
 ]
+
+
+class DeprecatedArgument:
+    """Singleton sentinel class for deprecated arguments.
+
+    Use this as a default value to distinguish between "argument not provided"
+    and "argument explicitly set to None".
+
+    Usage:
+        from deeplabcut.core.types import DEPRECATED_ARGUMENT, DeprecatedArgument
+
+        def func(old_arg=DEPRECATED_ARGUMENT):
+            if isinstance(old_arg, DeprecatedArgument):
+                # old_arg was not provided
+            else:
+                # old_arg was explicitly provided (even if None)
+    """
+
+    __slots__ = ()
+    _instance: "DeprecatedArgument | None" = None
+
+    def __new__(cls) -> "DeprecatedArgument":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __bool__(self) -> bool:
+        return False
+
+    def __repr__(self) -> str:
+        return "<deprecated argument>"
+
+
+DEPRECATED_ARGUMENT = DeprecatedArgument()

--- a/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
+++ b/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
@@ -247,8 +247,7 @@ def make_pytorch_pose_config(
     PoseConfig.validate_dict(pose_config)
 
     if save:
-        write_config(pose_config_path, pose_config, overwrite=True)
-
+        PoseConfig().from_any(pose_config).to_yaml(pose_config_path, overwrite=True)
     return pose_config
 
 

--- a/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
+++ b/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
@@ -232,7 +232,7 @@ def make_pytorch_pose_config(
         pose_config.train_settings.weight_init = weight_init
 
     # Update default values for the specific model architecture and project config.
-    # TODO JR 2026-01-28: using legacy v0 config (dict) for the defaults,
+    # TODO @deruyter92 2026-02-04: using legacy v0 config (dict) for the defaults,
     # we should move to typed model defaults and use omegaconf merge to update
     defaults: dict = _load_pose_config_defaults(
         project_config,

--- a/deeplabcut/pose_estimation_pytorch/data/base.py
+++ b/deeplabcut/pose_estimation_pytorch/data/base.py
@@ -87,20 +87,20 @@ class Loader(ABC):
                 model_config = model_config_path
             elif model_config is None:
                 raise ValueError(
-                    "`model_config` (or legacy argument `model_config_path`) must be provided."
+                    "`model_config` argument must be provided."
                 )
             return model_config
         model_config = _resolve_legacy_args(model_config, model_config_path)    
-        self.model_cfg: DictConfig = PoseConfig.from_any(model_config)
+        self.model_cfg: DictConfig = PoseConfig.from_any(model_config).to_dictconfig()
 
         def _infer_model_config_path(model_config: PoseConfig | DictConfig | Path | str) -> Path:
             """Resolve the pose config path. Either the input is a path, or it is specified in `metadata.pose_config_path` field."""
             provided_path = Path(model_config) if isinstance(model_config, (Path, str)) else None
             specified_path = OmegaConf.select(self.model_cfg, "metadata.pose_config_path")
-            model_config_path = Path(provided_path or specified_path)
+            model_config_path = provided_path or specified_path
             if model_config_path is None:
                 raise ValueError("`model_config` must contain a `metadata.pose_config_path` field.")
-            return model_config_path
+            return Path(model_config_path)
         self.model_config_path = _infer_model_config_path(model_config)
 
         self.project_root = Path(project_root)

--- a/deeplabcut/pose_estimation_pytorch/data/base.py
+++ b/deeplabcut/pose_estimation_pytorch/data/base.py
@@ -35,6 +35,7 @@ from deeplabcut.pose_estimation_pytorch.data.utils import (
     map_id_to_annotations,
 )
 from deeplabcut.pose_estimation_pytorch.task import Task
+from deeplabcut.core.types import DEPRECATED_ARGUMENT
 
 
 class Loader(ABC):
@@ -58,7 +59,7 @@ class Loader(ABC):
         project_root: str | Path,
         image_root: str | Path,
         model_config: PoseConfig | DictConfig | Path | str | None = None,
-        model_config_path: Path | str | None = None,
+        model_config_path: Path | str | None = DEPRECATED_ARGUMENT,
     ) -> None:
         """
         Initialize the Loader.
@@ -72,7 +73,7 @@ class Loader(ABC):
         """
         def _resolve_legacy_args(model_config, model_config_path):
             """Support for legacy argument `model_config_path`. returns new model_config arg"""
-            if model_config_path is not None:
+            if model_config_path:
                 warnings.warn(
                     "argument `model_config_path` in Loader.__init__ is deprecated, use `model_config` instead",
                     DeprecationWarning,

--- a/deeplabcut/pose_estimation_pytorch/data/cocoloader.py
+++ b/deeplabcut/pose_estimation_pytorch/data/cocoloader.py
@@ -19,6 +19,7 @@ import numpy as np
 from omegaconf import OmegaConf, DictConfig
 
 from deeplabcut.pose_estimation_pytorch.data.base import Loader
+from deeplabcut.core.types import DEPRECATED_ARGUMENT
 from deeplabcut.pose_estimation_pytorch.data.dataset import PoseDatasetParameters
 from deeplabcut.pose_estimation_pytorch.data.utils import (
     map_id_to_annotations,
@@ -52,7 +53,7 @@ class COCOLoader(Loader):
         model_config: PoseConfig | DictConfig | Path | str | None = None,
         train_json_filename: str = "train.json",
         test_json_filename: str = "test.json",
-        model_config_path: str | Path | None = None, # <--- deprecated
+        model_config_path: str | Path | None = DEPRECATED_ARGUMENT,
     ):
         """
         Initialize the COCOLoader.
@@ -62,7 +63,7 @@ class COCOLoader(Loader):
             model_config: The pose model configuration. Can be a path to a YAML file, a PoseConfig object, or a dictionary.
             train_json_filename: The name of the JSON file containing the train annotations.
             test_json_filename: The name of the JSON file containing the test annotations.
-            (model_config_path: The path to the pose model configuration. Deprecated, use `model_config` instead.)
+            model_config_path: The path to the pose model configuration. Deprecated, use `model_config` instead.
         """
         image_root = Path(project_root) / "images"
         super().__init__(project_root, image_root, model_config, model_config_path)

--- a/deeplabcut/pose_estimation_pytorch/data/cocoloader.py
+++ b/deeplabcut/pose_estimation_pytorch/data/cocoloader.py
@@ -87,7 +87,9 @@ class COCOLoader(Loader):
             num_individuals, bodyparts = self.get_project_parameters(self.train_json)
 
             crop_cfg = OmegaConf.select(
-                self.model_cfg, "data.train.top_down_crop", default={}
+                self.model_cfg,
+                "data.train.top_down_crop",
+                default={},
             )
             crop_w, crop_h = crop_cfg.get("width", 256), crop_cfg.get("height", 256)
             crop_margin = crop_cfg.get("margin", 0)

--- a/deeplabcut/pose_estimation_pytorch/data/dlcloader.py
+++ b/deeplabcut/pose_estimation_pytorch/data/dlcloader.py
@@ -168,7 +168,9 @@ class DLCLoader(Loader):
             An instance of the PoseDatasetParameters with the parameters set.
         """
         crop_cfg = OmegaConf.select(
-            self.model_cfg, "data.train.top_down_crop", {}
+            self.model_cfg,
+            "data.train.top_down_crop",
+            default={},
         )
         crop_w, crop_h = crop_cfg.get("width", 256), crop_cfg.get("height", 256)
         crop_margin = crop_cfg.get("margin", 0)

--- a/deeplabcut/pose_estimation_pytorch/models/model.py
+++ b/deeplabcut/pose_estimation_pytorch/models/model.py
@@ -12,11 +12,13 @@ from __future__ import annotations
 
 import copy
 import logging
-
+from pathlib import Path
+from omegaconf import DictConfig
 import torch
 import torch.nn as nn
 
 from deeplabcut.core.weight_init import WeightInitialization
+from deeplabcut.pose_estimation_pytorch.config.model import ModelConfig
 from deeplabcut.pose_estimation_pytorch.models.backbones import BACKBONES, BaseBackbone
 from deeplabcut.pose_estimation_pytorch.models.criterions import (
     CRITERIONS,
@@ -39,7 +41,7 @@ class PoseModel(nn.Module):
 
     def __init__(
         self,
-        cfg: dict,
+        cfg: ModelConfig | DictConfig | dict | Path | str,
         backbone: BaseBackbone,
         heads: dict[str, BaseHead],
         neck: BaseNeck | None = None,
@@ -52,7 +54,7 @@ class PoseModel(nn.Module):
             neck: neck network architecture (default is None). Defaults to None.
         """
         super().__init__()
-        self.cfg = cfg
+        self.cfg: DictConfig = ModelConfig.from_any(cfg).to_dictconfig()
         self.backbone = backbone
         self.heads = nn.ModuleDict(heads)
         self.neck = neck

--- a/deeplabcut/pose_estimation_pytorch/models/model.py
+++ b/deeplabcut/pose_estimation_pytorch/models/model.py
@@ -184,7 +184,11 @@ class PoseModel(nn.Module):
 
         heads = {}
         for name, head_cfg in cfg["heads"].items():
-            head_cfg = copy.deepcopy(head_cfg)
+            # NOTE @deruyter92 2026-02-05: currently modules are added inside the config
+            # dictionary. This seems like a bad practice and is unsupported for typed configs or
+            # OmegaConf DictConfig. The intermediate head_cfg container is now converted to a dictionary
+            # to avoid this issue.
+            head_cfg = dict(copy.deepcopy(head_cfg))
             if "type" in head_cfg["criterion"]:
                 head_cfg["criterion"] = CRITERIONS.build(head_cfg["criterion"])
             else:

--- a/tests/core/config/test_core_config.py
+++ b/tests/core/config/test_core_config.py
@@ -10,6 +10,7 @@
 #
 """Tests for deeplabcut.core.config."""
 from pathlib import Path
+from typing import Mapping
 
 import pytest
 
@@ -157,7 +158,7 @@ def test_pretty_print_with_custom_print_fn():
 @pytest.mark.parametrize("multianimal", [False, True])
 def test_create_config_template_returns_tuple(multianimal):
     cfg_file, ruamel_file = create_config_template(multianimal=multianimal)
-    assert isinstance(cfg_file, dict)
+    assert isinstance(cfg_file, Mapping)
     assert ruamel_file is not None
 
 
@@ -170,9 +171,6 @@ def test_create_config_template_single_animal_has_expected_keys():
     assert "video_sets" in cfg_file
     assert "multianimalproject" in cfg_file
     assert "detector_batch_size" in cfg_file
-    assert "individuals" not in cfg_file
-    assert "uniquebodyparts" not in cfg_file
-    assert "multianimalbodyparts" not in cfg_file
 
 
 def test_create_config_template_multianimal_has_extra_keys():
@@ -190,7 +188,7 @@ def test_create_config_template_multianimal_has_extra_keys():
 
 def test_create_config_template_3d_returns_tuple():
     cfg_file_3d, ruamel_file_3d = create_config_template_3d()
-    assert isinstance(cfg_file_3d, dict)
+    assert isinstance(cfg_file_3d, Mapping)
     assert ruamel_file_3d is not None
 
 
@@ -210,7 +208,7 @@ def test_create_config_template_3d_has_expected_keys():
 
 
 def test_read_config_raises_when_file_missing(tmp_path):
-    with pytest.raises(FileNotFoundError, match="Config file at .* not found"):
+    with pytest.raises(FileNotFoundError):
         read_config(tmp_path / "missing.yaml")
 
 
@@ -218,11 +216,11 @@ def test_read_config_sets_missing_engine_and_writes_back(tmp_path):
     config_path = tmp_path / "config.yaml"
     config_path.write_text("project_path: /other/path\n")
     cfg = read_config(config_path)
-    assert cfg["engine"] == "tensorflow"
+    assert cfg["engine"] == "pytorch"
     assert cfg["project_path"] == str(tmp_path)
     # File should have been updated
     cfg_again = read_config_as_dict(config_path)
-    assert cfg_again["engine"] == "tensorflow"
+    assert cfg_again["engine"] == "pytorch"
 
 
 def test_read_config_sets_detector_snapshotindex_when_missing(tmp_path):

--- a/tests/core/config/test_core_config.py
+++ b/tests/core/config/test_core_config.py
@@ -247,14 +247,15 @@ def test_read_config_updates_project_path_when_different(tmp_path):
     assert cfg["project_path"] == str(tmp_path)
 
 
-def test_read_config_preserves_existing_engine_and_project_path(tmp_path):
+@pytest.mark.parametrize("engine", ["pytorch", "tensorflow"])
+def test_read_config_preserves_existing_engine_and_project_path(tmp_path, engine):
     config_path = tmp_path / "config.yaml"
     write_project_config(
         config_path,
-        {"project_path": str(tmp_path), "engine": "pytorch"},
+        {"project_path": str(tmp_path), "engine": engine},
     )
     cfg = read_config(config_path)
-    assert cfg["engine"] == "pytorch"
+    assert cfg["engine"] == engine
     assert cfg["project_path"] == str(tmp_path)
 
 


### PR DESCRIPTION
This PR is part of the WIP for migrating from dictionary configs to typed & validated configurations, and follows PR #3191. (see issue https://github.com/DeepLabCut/DeepLabCut/issues/3193 for an overview).

**Summary:** 
Refactors the PyTorch pose pipeline to use typed config classes (PoseConfig, ProjectConfig, ModelConfig) and OmegaConf DictConfig instead of raw dicts.

**Main changes:**
- Isolated the logic for loading default model configuration for a given model
- `make_pose_config` now creates an OmegaConf DictConfig validated against PoseConfig dataclass
- internally, the PyTorch Loaders now use PoseConfig DictConfig configurations instead of dictionaries 
