### PR TITLE
fix rename_mapping in download_huggingface_model (change arg type str -> dict)

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/modelzoo/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/utils.py
@@ -144,7 +144,9 @@ def download_super_animal_snapshot(dataset: str, model_name: str) -> Path:
     model_path = snapshot_dir / model_filename
 
     download_huggingface_model(
-        model_name, target_dir=str(snapshot_dir), rename_mapping=model_filename
+        model_name,
+        target_dir=str(snapshot_dir),
+        rename_mapping={model_filename: model_filename},
     )
     if not model_path.exists():
         raise RuntimeError(f"Failed to download {model_name} to {model_path}")


### PR DESCRIPTION
Solves #3192

**Issue**
When downloading a model from huggingface for superanimal weight initialization, `download_huggingface_model` is called with argument rename_mapping=model_filename. Newer dlclibrary (version =>0.0.9, see https://github.com/DeepLabCut/DLClibrary/commit/0ce74732b828becc77cf07d560917789706fd802) can convert this string argument to a dict, but older versions expect a dict argument. Running the current code in DeepLabCut with an older dlclibrary installation will raise `AttributeError: 'str' object has no attribute 'get'`. 

**Changes**
This PR replaces the str-type argument `rename_mapping=model_filename` with a dictionary: `rename_mapping={model_filename:model_filename}`, so that it works both with older and newer dlclibrary versions. 
