### PR TITLE
Replace str, os.path with pathlib.Path

### DIFF
--- a/deeplabcut/modelzoo/utils.py
+++ b/deeplabcut/modelzoo/utils.py
@@ -61,8 +61,8 @@ def get_super_animal_project_cfg(super_animal: str) -> dict:
 
 def get_super_animal_scorer(
     super_animal: str,
-    model_snapshot_path: Path,
-    detector_snapshot_path: Path | None,
+    model_snapshot_path: Path | str,
+    detector_snapshot_path: Path | str | None,
     torchvision_detector_name: str | None = None,
 ) -> str:
     """
@@ -83,18 +83,14 @@ def get_super_animal_scorer(
         )
     super_animal_prefix = super_animal + "_"
     # Always use model name first
-    model_name = (
-        model_snapshot_path.stem
-        if hasattr(model_snapshot_path, "stem")
-        else str(model_snapshot_path)
-    )
+    model_name = Path(model_snapshot_path).stem
     if model_name.startswith(super_animal_prefix):
         model_name = model_name[len(super_animal_prefix) :]
     dlc_scorer = f"{super_animal_prefix}{model_name}"
 
     # Then add detector name if provided
     if detector_snapshot_path is not None:
-        detector_name = detector_snapshot_path.stem
+        detector_name = Path(detector_snapshot_path).stem
         if detector_name.startswith(super_animal_prefix):
             detector_name = detector_name[len(super_animal_prefix) :]
         dlc_scorer += f"_{detector_name}"

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -938,8 +938,9 @@ def find_video_full_data(folder, videoname, scorer):
     return full_files[0]
 
 
-def find_video_metadata(folder, videoname, scorer):
+def find_video_metadata(folder, videoname: str, scorer: str):
     """For backward compatibility, let us search the substring 'meta'"""
+    
     scorer_legacy = scorer.replace("DLC", "DeepCut")
     meta_files = filter_files_by_patterns(
         folder=folder,
@@ -963,50 +964,53 @@ def load_video_full_data(folder, videoname, scorer):
     return read_pickle(find_video_full_data(folder, videoname, scorer))
 
 
-def find_analyzed_data(folder, videoname, scorer, filtered=False, track_method=""):
+def find_analyzed_data(folder, videoname: str, scorer: str, filtered=False, track_method=""):
     """Find potential data files from the hints given to the function."""
+    
     scorer_legacy = scorer.replace("DLC", "DeepCut")
     suffix = "_filtered" if filtered else ""
     tracker = TRACK_METHODS.get(track_method, "")
 
-    candidates = []
-    for file in grab_files_in_folder(folder, "h5"):
-        stem = Path(file).stem.replace("_filtered", "")
-        starts_by_scorer = file.startswith(videoname + scorer) or file.startswith(
-            videoname + scorer_legacy
-        )
-        if tracker:
-            matches_tracker = stem.endswith(tracker)
-        else:
-            matches_tracker = not any(stem.endswith(s) for s in TRACK_METHODS.values())
-        if all(
-            (
-                starts_by_scorer,
-                "skeleton" not in file,
-                matches_tracker,
-                (filtered and "filtered" in file)
-                or (not filtered and "filtered" not in file),
-            )
-        ):
-            candidates.append(file)
+    candidates = [] 
+    folder = Path(folder)
+    for p in folder.glob("*.h5"):
+        file = p.name
 
+        if "skeleton" in file:
+            continue
+
+        if filtered != ("filtered" in file):
+            continue
+
+        stem = p.stem.removesuffix("_filtered")
+        if not stem.startswith((videoname+scorer, videoname+scorer_legacy)):
+            continue
+
+        if tracker:
+            if not stem.endswith(tracker):
+                continue
+        else:
+            if stem.endswith(tuple(TRACK_METHODS.values())):
+                continue
+        candidates.append(file)
+    
     if not len(candidates):
+        filtered_type = "unfiltered" if not filtered else "filtered"
+        tracker_info = f" and {track_method} tracker" if track_method else ""
         msg = (
-            f'No {"un" if not filtered else ""}filtered data file found in {folder} '
-            f"for video {videoname} and scorer {scorer}"
-        )
-        if track_method:
-            msg += f" and {track_method} tracker"
-        msg += "."
+            f"No {filtered_type} data file found in {folder}"
+            f" for video {videoname} and scorer {scorer}{tracker_info}."
+        ) 
         raise FileNotFoundError(msg)
 
-    n_candidates = len(candidates)
-    if n_candidates > 1:  # This should not be happening anyway...
+    if len(candidates) > 1:
         print(
-            f"{n_candidates} possible data files were found: {candidates}.\n"
+            f"{len(candidates)} possible data files were found: {candidates}.\n"
             f"Picking the first by default..."
         )
-    filepath = os.path.join(folder, candidates[0])
+
+    # Inelegant way to check 'scorer in filepath', but preserves compatibility returning str 
+    filepath = str(folder / candidates[0])
     scorer = scorer if scorer in filepath else scorer_legacy
     return filepath, scorer, suffix
 

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -711,7 +711,6 @@ def create_labeled_video(
                 bboxes_pcutoff = 0.6
 
     if init_weights == "":
-        # TODO: cfg breaks if config == ""
         DLCscorer, DLCscorerlegacy = auxiliaryfunctions.get_scorer_name(
             cfg,
             shuffle,
@@ -849,7 +848,7 @@ def proc_video(
     keypoints_only,
     overwrite,
     video,
-    init_weights=None,
+    init_weights="",
     pcutoff: float | None = None,
     confidence_to_alpha: Optional[Callable[[float], float]] = None,
     plot_bboxes: bool = True,
@@ -869,21 +868,22 @@ def proc_video(
     videofolder = Path(video).parent
     if destfolder is None:
         destfolder = videofolder  # where your folder with videos is.
-
-    destfolder = Path(destfolder)
-    destfolder.mkdir(exist_ok=True)
+    else:
+        destfolder = Path(destfolder)
 
     if pcutoff is None:
         pcutoff = cfg["pcutoff"]
 
-     # NOTE: THE VIDEO IS STILL IN THE VIDEO FOLDER
-    print(f"Starting to process video: {video}")
-    vname = Path(video).stem
-    if init_weights is not None:
-        init_weights_name = Path(init_weights).stem
-        DLCscorer = "DLC_" + init_weights_name
-        DLCscorerlegacy = "DLC_" + init_weights_name
-    
+    auxiliaryfunctions.attempt_to_make_folder(destfolder)
+
+    os.chdir(destfolder)  # THE VIDEO IS STILL IN THE VIDEO FOLDER
+    print("Starting to process video: {}".format(video))
+    vname = str(Path(video).stem)
+
+    if init_weights != "":
+        DLCscorer = "DLC_" + Path(init_weights).stem
+        DLCscorerlegacy = "DLC_" + Path(init_weights).stem
+
     if filtered:
         videooutname1 = destfolder / f"{vname}{DLCscorer}filtered_labeled.mp4"
         videooutname2 = destfolder / f"{vname}{DLCscorerlegacy}filtered_labeled.mp4"
@@ -894,147 +894,146 @@ def proc_video(
     if (videooutname1.is_file() or videooutname2.is_file()) and not overwrite:
         print(f"Labeled video {vname} already created.")
         return True
-    
-    print(f"Loading {video} and data.")
-    try:
-        df, filepath, _, _ = auxiliaryfunctions.load_analyzed_data(
-            destfolder, vname, DLCscorer, filtered, track_method
-        )
-        metadata = auxiliaryfunctions.load_video_metadata(
-            destfolder, vname, DLCscorer
-        )
-        if cfg.get("multianimalproject", False):
-            s = "_id" if color_by == "individual" else "_bp"
-        else:
-            s = ""
-        
-        filepath = Path(filepath) # NOTE: temp until refactor auxiliaryfunctions.load_analyzed_data functions 
-        videooutname = filepath.with_name(f"{filepath.stem}{s}_p{int(100 * pcutoff)}_labeled.mp4")
-        if videooutname.is_file() and not overwrite:
-            print("Labeled video already created. Skipping...")
-            return True
-
-        if individuals != "all":
-            if isinstance(individuals, str):
-                individuals = [individuals]
-
-            if all(individuals) and "individuals" in df.columns.names:
-                mask = df.columns.get_level_values("individuals").isin(individuals)
-                df = df.loc[:, mask]
-
-        cropping = metadata["data"]["cropping"]
-        [x1, x2, y1, y2] = metadata["data"]["cropping_parameters"]
-        labeled_bpts = [
-            bp
-            for bp in df.columns.get_level_values("bodyparts").unique()
-            if bp in bodyparts
-        ]
-
-        # The full data file is not created for single-animal TensorFlow models
+    else:
+        print("Loading {} and data.".format(video))
         try:
-            full_data = auxiliaryfunctions.load_video_full_data(
+            df, filepath, _, _ = auxiliaryfunctions.load_analyzed_data(
+                destfolder, vname, DLCscorer, filtered, track_method
+            )
+            metadata = auxiliaryfunctions.load_video_metadata(
                 destfolder, vname, DLCscorer
             )
-            frames_dict = {
-                int(key.replace("frame", "")): value
-                for key, value in full_data.items()
-                if key.startswith("frame") and key[5:].isdigit()
-            }
-            bboxes_list = None
-            if "bboxes" in frames_dict.get(min(frames_dict.keys()), {}):
-                bboxes_list = [
-                    frames_dict[key] for key in sorted(frames_dict.keys())
-                ]
-        except FileNotFoundError:
-            bboxes_list = None
+            if cfg.get("multianimalproject", False):
+                s = "_id" if color_by == "individual" else "_bp"
+            else:
+                s = ""
 
-        if keypoints_only:
-            # Mask rather than drop unwanted bodyparts to ensure consistent coloring
-            mask = df.columns.get_level_values("bodyparts").isin(bodyparts)
-            df.loc[:, ~mask] = np.nan
-            inds = None
-            if bodyparts2connect:
-                all_bpts = df.columns.get_level_values("bodyparts")[::3]
-                inds = get_segment_indices(bodyparts2connect, all_bpts)
-            clip = vp(fname=video, fps=outputframerate)
-            create_video_with_keypoints_only(
-                df,
-                videooutname,
-                inds,
-                pcutoff,
-                cfg["dotsize"],
-                cfg["alphavalue"],
-                skeleton_color=skeleton_color,
-                color_by=color_by,
-                colormap=cfg["colormap"],
-                fps=clip.fps(),
+            videooutname = filepath.replace(
+                ".h5", f"{s}_p{int(100 * pcutoff)}_labeled.mp4"
             )
-            clip.close()
-        elif not fastmode:
+            if os.path.isfile(videooutname) and not overwrite:
+                print("Labeled video already created. Skipping...")
+                return
 
-            tmpfolder = videofolder / f"temp-{vname}"
-            if save_frames:
-                tmpfolder.mkdir(exist_ok=True)
+            if individuals != "all":
+                if isinstance(individuals, str):
+                    individuals = [individuals]
 
-            clip = vp(video)
-            CreateVideoSlow(
-                videooutname,
-                clip,
-                df,
-                tmpfolder,
-                cfg["dotsize"],
-                cfg["colormap"],
-                cfg["alphavalue"],
-                pcutoff,
-                trailpoints,
-                cropping,
-                x1,
-                x2,
-                y1,
-                y2,
-                save_frames,
-                labeled_bpts,
-                outputframerate,
-                Frames2plot,
-                bodyparts2connect,
-                skeleton_color,
-                draw_skeleton,
-                displaycropped,
-                color_by,
-                plot_bboxes=plot_bboxes,
-                bboxes_list=bboxes_list,
-                bboxes_pcutoff=bboxes_pcutoff,
-            )
-            clip.close()
-        else:
-            create_video(
-                video,
-                filepath,
-                keypoints2show=labeled_bpts,
-                animals2show=individuals,
-                bbox=(x1, x2, y1, y2),
-                codec=codec,
-                output_path=videooutname,
-                pcutoff=pcutoff,
-                dotsize=cfg["dotsize"],
-                cmap=cfg["colormap"],
-                color_by=color_by,
-                skeleton_edges=bodyparts2connect,
-                skeleton_color=skeleton_color,
-                trailpoints=trailpoints,
-                fps=outputframerate,
-                display_cropped=displaycropped,
-                confidence_to_alpha=confidence_to_alpha,
-                plot_bboxes=plot_bboxes,
-                bboxes_list=bboxes_list,
-                bboxes_pcutoff=bboxes_pcutoff,
-            )
+                if all(individuals) and "individuals" in df.columns.names:
+                    mask = df.columns.get_level_values("individuals").isin(individuals)
+                    df = df.loc[:, mask]
 
-        return True
+            cropping = metadata["data"]["cropping"]
+            [x1, x2, y1, y2] = metadata["data"]["cropping_parameters"]
+            labeled_bpts = [
+                bp
+                for bp in df.columns.get_level_values("bodyparts").unique()
+                if bp in bodyparts
+            ]
 
-    except FileNotFoundError as e:
-        print(e)
-        return False
+            # The full data file is not created for single-animal TensorFlow models
+            try:
+                full_data = auxiliaryfunctions.load_video_full_data(
+                    destfolder, vname, DLCscorer
+                )
+                frames_dict = {
+                    int(key.replace("frame", "")): value
+                    for key, value in full_data.items()
+                    if key.startswith("frame") and key[5:].isdigit()
+                }
+                bboxes_list = None
+                if "bboxes" in frames_dict.get(min(frames_dict.keys()), {}):
+                    bboxes_list = [
+                        frames_dict[key] for key in sorted(frames_dict.keys())
+                    ]
+            except FileNotFoundError:
+                bboxes_list = None
+
+            if keypoints_only:
+                # Mask rather than drop unwanted bodyparts to ensure consistent coloring
+                mask = df.columns.get_level_values("bodyparts").isin(bodyparts)
+                df.loc[:, ~mask] = np.nan
+                inds = None
+                if bodyparts2connect:
+                    all_bpts = df.columns.get_level_values("bodyparts")[::3]
+                    inds = get_segment_indices(bodyparts2connect, all_bpts)
+                clip = vp(fname=video, fps=outputframerate)
+                create_video_with_keypoints_only(
+                    df,
+                    videooutname,
+                    inds,
+                    pcutoff,
+                    cfg["dotsize"],
+                    cfg["alphavalue"],
+                    skeleton_color=skeleton_color,
+                    color_by=color_by,
+                    colormap=cfg["colormap"],
+                    fps=clip.fps(),
+                )
+                clip.close()
+            elif not fastmode:
+                tmpfolder = os.path.join(str(videofolder), "temp-" + vname)
+                if save_frames:
+                    auxiliaryfunctions.attempt_to_make_folder(tmpfolder)
+                clip = vp(video)
+                CreateVideoSlow(
+                    videooutname,
+                    clip,
+                    df,
+                    tmpfolder,
+                    cfg["dotsize"],
+                    cfg["colormap"],
+                    cfg["alphavalue"],
+                    pcutoff,
+                    trailpoints,
+                    cropping,
+                    x1,
+                    x2,
+                    y1,
+                    y2,
+                    save_frames,
+                    labeled_bpts,
+                    outputframerate,
+                    Frames2plot,
+                    bodyparts2connect,
+                    skeleton_color,
+                    draw_skeleton,
+                    displaycropped,
+                    color_by,
+                    plot_bboxes=plot_bboxes,
+                    bboxes_list=bboxes_list,
+                    bboxes_pcutoff=bboxes_pcutoff,
+                )
+                clip.close()
+            else:
+                create_video(
+                    video,
+                    filepath,
+                    keypoints2show=labeled_bpts,
+                    animals2show=individuals,
+                    bbox=(x1, x2, y1, y2),
+                    codec=codec,
+                    output_path=videooutname,
+                    pcutoff=pcutoff,
+                    dotsize=cfg["dotsize"],
+                    cmap=cfg["colormap"],
+                    color_by=color_by,
+                    skeleton_edges=bodyparts2connect,
+                    skeleton_color=skeleton_color,
+                    trailpoints=trailpoints,
+                    fps=outputframerate,
+                    display_cropped=displaycropped,
+                    confidence_to_alpha=confidence_to_alpha,
+                    plot_bboxes=plot_bboxes,
+                    bboxes_list=bboxes_list,
+                    bboxes_pcutoff=bboxes_pcutoff,
+                )
+
+            return True
+
+        except FileNotFoundError as e:
+            print(e)
+            return False
 
 
 def create_video(
@@ -1053,7 +1052,7 @@ def create_video(
     display_cropped=False,
     codec="mp4v",
     fps=None,
-    output_path: str | Path | None = None,
+    output_path="",
     confidence_to_alpha=None,
     plot_bboxes=True,
     bboxes_list=None,
@@ -1063,13 +1062,13 @@ def create_video(
     if color_by not in ("bodypart", "individual"):
         raise ValueError("`color_by` should be either 'bodypart' or 'individual'.")
 
-    if output_path is None:
+    if not output_path:
         s = "_id" if color_by == "individual" else "_bp"
         output_path = h5file.replace(".h5", f"{s}_labeled.mp4")
 
     clip = vp(
         fname=video,
-        sname=str(output_path), # NOTE: inelegant solution for cv2, but probably better at this step
+        sname=str(output_path),
         codec=codec,
         sw=bbox[1] - bbox[0] if display_cropped else "",
         sh=bbox[3] - bbox[2] if display_cropped else "",


### PR DESCRIPTION
Replacement PR for #3170

**Motivation (as phrased by @juan-cobos in the original PR):**
Path handling is currently inconsistent (strings vs Path objects, mixed os.path and pathlib), making code hard to follow. This also causes subtle bugs (e.g., scorer.replace() on a Path attempts filesystem operations instead of string replacement). Standardizing on pathlib.Path would help to make older code consistent with newer parts of the codebase. 

**Changes:**
Standardize on pathlib.Path internally with proper type hints in the following files:
- deeplabcut/utils/make_labeled_video.py
- deeplabcut/modelzoo/utils.py
- deeplabcut/pose_estimation_pytorch/modelzoo/inference.py
- deeplabcut/utils/auxiliaryfunctions.py