### PR TITLE
Fix hardcoded GUI icon path

### DIFF
--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -18,6 +18,7 @@ from typing import List
 from urllib.error import URLError
 import warnings
 import qdarkstyle
+from importlib.resources import files
 
 import deeplabcut
 from deeplabcut import auxiliaryfunctions, VERSION, compat
@@ -517,17 +518,8 @@ class MainWindow(QMainWindow):
         engine_icon.setStyleSheet("background: transparent;")
 
         def _update_icon(engine: str):
-            
-from importlib.resources import files
-
-def _update_icon(engine):
-    file = files("deeplabcut.gui.media") / f"dlc-{engine}.png"
-    pixmap = QPixmap(str(file))
-    if not pixmap.isNull():
-        engine_icon.setPixmap(
-            pixmap.scaled(56, 56, Qt.AspectRatioMode.KeepAspectRatio)
-        )
-
+            file = files("deeplabcut.gui.media") / f"dlc-{engine}.png"
+            pixmap = QPixmap(str(file))
             if not pixmap.isNull():
                 engine_icon.setPixmap(
                     pixmap.scaled(56, 56, Qt.AspectRatioMode.KeepAspectRatio)

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -517,10 +517,11 @@ class MainWindow(QMainWindow):
         engine_icon.setStyleSheet("background: transparent;")
 
         def _update_icon(engine: str):
-            pixmap = QPixmap(f"deeplabcut/gui/media/dlc-{engine}.png")
-            engine_icon.setPixmap(
-                pixmap.scaled(56, 56, Qt.AspectRatioMode.KeepAspectRatio)
-            )
+            pixmap = QPixmap(os.path.join(BASE_DIR, "media", f"dlc-{engine}.png"))
+            if not pixmap.isNull():
+                engine_icon.setPixmap(
+                    pixmap.scaled(56, 56, Qt.AspectRatioMode.KeepAspectRatio)
+                )
 
         _update_icon("pt" if self.engine == Engine.PYTORCH else "tf")
 

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -517,7 +517,17 @@ class MainWindow(QMainWindow):
         engine_icon.setStyleSheet("background: transparent;")
 
         def _update_icon(engine: str):
-            pixmap = QPixmap(os.path.join(BASE_DIR, "media", f"dlc-{engine}.png"))
+            
+from importlib.resources import files
+
+def _update_icon(engine):
+    file = files("deeplabcut.gui.media") / f"dlc-{engine}.png"
+    pixmap = QPixmap(str(file))
+    if not pixmap.isNull():
+        engine_icon.setPixmap(
+            pixmap.scaled(56, 56, Qt.AspectRatioMode.KeepAspectRatio)
+        )
+
             if not pixmap.isNull():
                 engine_icon.setPixmap(
                     pixmap.scaled(56, 56, Qt.AspectRatioMode.KeepAspectRatio)


### PR DESCRIPTION
This PR addresses a small issue regarding the scaling of the GUI icon pixmap in `window.py`.

The hardcoded path:
```
pixmap = QPixmap(f"deeplabcut/gui/media/dlc-{engine}.png")
```
fails when the GUI is launched from any directory other than the project root, causing QPixmap to return a null pixmap. When scaled() is then called on this null pixmap, Qt raises an error. 

This is now fixed by using a relative path and a null-check for the pixmap.