### PR TITLE
Update docs TOC and Sphinx excludes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,13 @@ sphinx:
   config:
     autodoc_mock_imports: ["wx", "matplotlib", "qtpy", "PySide6", "napari", "shiboken6"]
     mermaid_output_format: raw
+    exclude_patterns:
+      - ".venv/**"
+      - "venv/**"
+      - "**/site-packages/**"
+      - "_build/**"
+      - "**/_build/**"
+
   extra_extensions:
     - numpydoc
     - sphinxcontrib.mermaid

--- a/_config.yml
+++ b/_config.yml
@@ -11,9 +11,7 @@ sphinx:
       - ".venv/**"
       - "venv/**"
       - "**/site-packages/**"
-      - "_build/**"
       - "**/_build/**"
-
   extra_extensions:
     - numpydoc
     - sphinxcontrib.mermaid

--- a/_toc.yml
+++ b/_toc.yml
@@ -4,106 +4,106 @@ root: README
 parts:
 - caption: Getting Started
   chapters:
-    - file: docs/UseOverviewGuide
-    - file: docs/course
+  - file: docs/UseOverviewGuide
+  - file: docs/course
 
 - caption: Installation
   chapters:
-    - file: docs/installation
-    - file: docs/recipes/installTips
-    - file: docs/docker
+  - file: docs/installation
+  - file: docs/recipes/installTips
+  - file: docs/docker
 
 - caption: Main User Guides
   chapters:
-    - file: docs/standardDeepLabCut_UserGuide
-    - file: docs/maDLC_UserGuide
-    - file: docs/Overviewof3D
-    - file: docs/HelperFunctions
+  - file: docs/standardDeepLabCut_UserGuide
+  - file: docs/maDLC_UserGuide
+  - file: docs/Overviewof3D
+  - file: docs/HelperFunctions
 
 - caption: Graphical User Interfaces (GUIs)
   chapters:
-    - file: docs/gui/PROJECT_GUI
-    - file: docs/gui/napari_GUI
+  - file: docs/gui/PROJECT_GUI
+  - file: docs/gui/napari_GUI
 
 - caption: DLC3 PyTorch Specific Docs
   chapters:
-    - file: docs/pytorch/user_guide.md
-    - file: docs/pytorch/pytorch_config.md
-    - file: docs/pytorch/architectures.md
+  - file: docs/pytorch/user_guide.md
+  - file: docs/pytorch/pytorch_config.md
+  - file: docs/pytorch/architectures.md
 
 - caption: Quick Start Tutorials
   chapters:
-    - file: docs/quick-start/single_animal_quick_guide
-    - file: docs/quick-start/tutorial_maDLC
+  - file: docs/quick-start/single_animal_quick_guide
+  - file: docs/quick-start/tutorial_maDLC
 
 - caption: "🚀 Beginner's Guide to DeepLabCut"
   chapters:
-    - file: docs/beginner-guides/beginners-guide
-    - file: docs/beginner-guides/manage-project
-    - file: docs/beginner-guides/labeling
-    - file: docs/beginner-guides/Training-Evaluation
-    - file: docs/beginner-guides/video-analysis
+  - file: docs/beginner-guides/beginners-guide
+  - file: docs/beginner-guides/manage-project
+  - file: docs/beginner-guides/labeling
+  - file: docs/beginner-guides/Training-Evaluation
+  - file: docs/beginner-guides/video-analysis
 
 - caption: "🚀 Main Demo Notebooks"
   chapters:
-    - file: examples/COLAB/COLAB_DEMO_SuperAnimal
-    - file: examples/COLAB/COLAB_DEMO_mouse_openfield
-    - file: examples/COLAB/COLAB_3miceDemo
-    - file: examples/COLAB/COLAB_HumanPose_with_RTMPose
+  - file: examples/COLAB/COLAB_DEMO_SuperAnimal
+  - file: examples/COLAB/COLAB_DEMO_mouse_openfield
+  - file: examples/COLAB/COLAB_3miceDemo
+  - file: examples/COLAB/COLAB_HumanPose_with_RTMPose
 
 - caption: "🚀 Notebooks For Your Data"
   chapters:
-    - file: examples/COLAB/COLAB_YOURDATA_SuperAnimal
-    - file: examples/COLAB/COLAB_YOURDATA_TrainNetwork_VideoAnalysis
-    - file: examples/COLAB/COLAB_YOURDATA_maDLC_TrainNetwork_VideoAnalysis
+  - file: examples/COLAB/COLAB_YOURDATA_SuperAnimal
+  - file: examples/COLAB/COLAB_YOURDATA_TrainNetwork_VideoAnalysis
+  - file: examples/COLAB/COLAB_YOURDATA_maDLC_TrainNetwork_VideoAnalysis
 
 - caption: "🚀 Special Feature Demos"
   chapters:
-    - file: examples/COLAB/COLAB_transformer_reID
-    - file: examples/COLAB/COLAB_BUCTD_and_CTD_tracking
-    - file: examples/JUPYTER/Demo_3D_DeepLabCut
-    - file: examples/COLAB/COLAB_DLC_ModelZoo
+  - file: examples/COLAB/COLAB_transformer_reID
+  - file: examples/COLAB/COLAB_BUCTD_and_CTD_tracking
+  - file: examples/JUPYTER/Demo_3D_DeepLabCut
+  - file: examples/COLAB/COLAB_DLC_ModelZoo
 
 - caption: "🧑‍🍳 Cookbook (detailed helper guides)"
   chapters:
-    - file: docs/convert_maDLC
-    - file: docs/recipes/OtherData
-    - file: docs/recipes/io
-    - file: docs/recipes/nn
-    - file: docs/recipes/post
-    - file: docs/recipes/BatchProcessing
-    - file: docs/recipes/DLCMethods
-    - file: docs/recipes/ClusteringNapari
-    - file: docs/recipes/OpenVINO
-    - file: docs/recipes/flip_and_rotate
-    - file: docs/recipes/pose_cfg_file_breakdown
-    - file: docs/recipes/publishing_notebooks_into_the_DLC_main_cookbook
+  - file: docs/convert_maDLC
+  - file: docs/recipes/OtherData
+  - file: docs/recipes/io
+  - file: docs/recipes/nn
+  - file: docs/recipes/post
+  - file: docs/recipes/BatchProcessing
+  - file: docs/recipes/DLCMethods
+  - file: docs/recipes/ClusteringNapari
+  - file: docs/recipes/OpenVINO
+  - file: docs/recipes/flip_and_rotate
+  - file: docs/recipes/pose_cfg_file_breakdown
+  - file: docs/recipes/publishing_notebooks_into_the_DLC_main_cookbook
 
 - caption: Hardware Tips
   chapters:
-    - file: docs/recipes/TechHardware
+  - file: docs/recipes/TechHardware
 
 - caption: DeepLabCut-Live!
   chapters:
-    - file: docs/deeplabcutlive
+  - file: docs/deeplabcutlive
 
 - caption: "🦄 DeepLabCut Model Zoo"
   chapters:
-    - file: docs/ModelZoo
-    - file: docs/recipes/UsingModelZooPupil
+  - file: docs/ModelZoo
+  - file: docs/recipes/UsingModelZooPupil
 
 - caption: DeepLabCut Benchmarking
   chapters:
-    - file: docs/benchmark
-    - file: docs/pytorch/Benchmarking_shuffle_guide
+  - file: docs/benchmark
+  - file: docs/pytorch/Benchmarking_shuffle_guide
 
 - caption: "Mission & Contribute"
   chapters:
-    - file: docs/MISSION_AND_VALUES
-    - file: docs/roadmap
-    - file: docs/Governance
-    - file: CONTRIBUTING
+  - file: docs/MISSION_AND_VALUES
+  - file: docs/roadmap
+  - file: docs/Governance
+  - file: CONTRIBUTING
 
 - caption: Citations for DeepLabCut
   chapters:
-    - file: docs/citation
+  - file: docs/citation

--- a/_toc.yml
+++ b/_toc.yml
@@ -1,103 +1,109 @@
 format: jb-book
 root: README
+
 parts:
-- caption: Getting Started
-  chapters:
-  - file: docs/UseOverviewGuide
-  - file: docs/course
-- caption: Installation
-  chapters:
-  - file: docs/installation
-  - file: docs/recipes/installTips
-  - file: docs/docker
+  - caption: Getting Started
+    chapters:
+      - file: docs/UseOverviewGuide
+      - file: docs/course
 
-- caption: Main User Guides
-  chapters:
-  - file: docs/standardDeepLabCut_UserGuide
-  - file: docs/maDLC_UserGuide
-  - file: docs/Overviewof3D
-  - file: docs/HelperFunctions
-  
-- caption: Graphical User Interfaces (GUIs)
-  chapters:
-  - file: docs/gui/PROJECT_GUI
-  - file: docs/gui/napari_GUI
-- caption: DLC3 PyTorch Specific Docs
-  chapters:
-  - file: docs/pytorch/user_guide.md
-  - file: docs/pytorch/pytorch_config.md
-  - file: docs/pytorch/architectures.md
-- caption: Quick Start Tutorials
-  chapters:
-  - file: docs/quick-start/single_animal_quick_guide
-  - file: docs/quick-start/tutorial_maDLC
-- caption: 🚀 Beginner's Guide to DeepLabCut
-  chapters:
-  - file: docs/beginner-guides/beginners-guide
-  - file: docs/beginner-guides/manage-project
-  - file: docs/beginner-guides/labeling
-  - file: docs/beginner-guides/Training-Evaluation
-  - file: docs/beginner-guides/video-analysis
-- caption: 🚀 Main Demo Notebooks
-  chapters:
-  - file: examples/COLAB/COLAB_DEMO_SuperAnimal
-  - file: examples/COLAB/COLAB_DEMO_mouse_openfield
-  - file: examples/COLAB/COLAB_3miceDemo
-  - file: examples/COLAB/COLAB_HumanPose_with_RTMPose
+  - caption: Installation
+    chapters:
+      - file: docs/installation
+      - file: docs/recipes/installTips
+      - file: docs/docker
 
+  - caption: Main User Guides
+    chapters:
+      - file: docs/standardDeepLabCut_UserGuide
+      - file: docs/maDLC_UserGuide
+      - file: docs/Overviewof3D
+      - file: docs/HelperFunctions
 
-  
-- caption: 🚀 Notebooks For Your Data
-  chapters:
-  - file: examples/COLAB/COLAB_YOURDATA_SuperAnimal
-  - file: examples/COLAB/COLAB_YOURDATA_TrainNetwork_VideoAnalysis
-  - file: examples/COLAB/COLAB_YOURDATA_maDLC_TrainNetwork_VideoAnalysis
+  - caption: Graphical User Interfaces (GUIs)
+    chapters:
+      - file: docs/gui/PROJECT_GUI
+      - file: docs/gui/napari_GUI
 
-- caption: 🚀 Special Feature Demos
-  chapters:
-  - file: examples/COLAB/COLAB_transformer_reID
-  - file: examples/COLAB/COLAB_BUCTD_and_CTD_tracking
-  - file: examples/JUPYTER/Demo_3D_DeepLabCut
-  - file: examples/COLAB/COLAB_DLC_ModelZoo
+  - caption: DLC3 PyTorch Specific Docs
+    chapters:
+      - file: docs/pytorch/user_guide.md
+      - file: docs/pytorch/pytorch_config.md
+      - file: docs/pytorch/architectures.md
 
-- caption: 🧑‍🍳 Cookbook (detailed helper guides)
-  chapters:
-  - file: docs/convert_maDLC
-  - file: docs/recipes/OtherData
-  - file: docs/recipes/io
-  - file: docs/recipes/nn
-  - file: docs/recipes/post
-  - file: docs/recipes/BatchProcessing
-  - file: docs/recipes/DLCMethods
-  - file: docs/recipes/ClusteringNapari
-  - file: docs/recipes/OpenVINO
-  - file: docs/recipes/flip_and_rotate
-  - file: docs/recipes/pose_cfg_file_breakdown
-  - file: docs/recipes/publishing_notebooks_into_the_DLC_main_cookbook
+  - caption: Quick Start Tutorials
+    chapters:
+      - file: docs/quick-start/single_animal_quick_guide
+      - file: docs/quick-start/tutorial_maDLC
 
-- caption: Hardware Tips
-  chapters:
-  - file: docs/recipes/TechHardware
-- caption: DeepLabCut-Live!
-  chapters:
-  - file: docs/deeplabcutlive
-- caption: 🦄 DeepLabCut Model Zoo
-  chapters:
-  - file: docs/ModelZoo
-  - file: docs/recipes/UsingModelZooPupil
+  - caption: "🚀 Beginner's Guide to DeepLabCut"
+    chapters:
+      - file: docs/beginner-guides/beginners-guide
+      - file: docs/beginner-guides/manage-project
+      - file: docs/beginner-guides/labeling
+      - file: docs/beginner-guides/Training-Evaluation
+      - file: docs/beginner-guides/video-analysis
 
-- caption: DeepLabCut Benchmarking
-  chapters:
-  - file: docs/benchmark
-  - file: docs/pytorch/Benchmarking_shuffle_guide
+  - caption: "🚀 Main Demo Notebooks"
+    chapters:
+      - file: examples/COLAB/COLAB_DEMO_SuperAnimal
+      - file: examples/COLAB/COLAB_DEMO_mouse_openfield
+      - file: examples/COLAB/COLAB_3miceDemo
+      - file: examples/COLAB/COLAB_HumanPose_with_RTMPose
 
-- caption: Mission & Contribute
-  chapters:
-  - file: docs/MISSION_AND_VALUES
-  - file: docs/roadmap
-  - file: docs/Governance
-  - file: CONTRIBUTING
+  - caption: "🚀 Notebooks For Your Data"
+    chapters:
+      - file: examples/COLAB/COLAB_YOURDATA_SuperAnimal
+      - file: examples/COLAB/COLAB_YOURDATA_TrainNetwork_VideoAnalysis
+      - file: examples/COLAB/COLAB_YOURDATA_maDLC_TrainNetwork_VideoAnalysis
 
-- caption: Citations for DeepLabCut
-  chapters:
-  - file: docs/citation
+  - caption: "🚀 Special Feature Demos"
+    chapters:
+      - file: examples/COLAB/COLAB_transformer_reID
+      - file: examples/COLAB/COLAB_BUCTD_and_CTD_tracking
+      - file: examples/JUPYTER/Demo_3D_DeepLabCut
+      - file: examples/COLAB/COLAB_DLC_ModelZoo
+
+  - caption: "🧑‍🍳 Cookbook (detailed helper guides)"
+    chapters:
+      - file: docs/convert_maDLC
+      - file: docs/recipes/OtherData
+      - file: docs/recipes/io
+      - file: docs/recipes/nn
+      - file: docs/recipes/post
+      - file: docs/recipes/BatchProcessing
+      - file: docs/recipes/DLCMethods
+      - file: docs/recipes/ClusteringNapari
+      - file: docs/recipes/OpenVINO
+      - file: docs/recipes/flip_and_rotate
+      - file: docs/recipes/pose_cfg_file_breakdown
+      - file: docs/recipes/publishing_notebooks_into_the_DLC_main_cookbook
+
+  - caption: Hardware Tips
+    chapters:
+      - file: docs/recipes/TechHardware
+
+  - caption: DeepLabCut-Live!
+    chapters:
+      - file: docs/deeplabcutlive
+
+  - caption: "🦄 DeepLabCut Model Zoo"
+    chapters:
+      - file: docs/ModelZoo
+      - file: docs/recipes/UsingModelZooPupil
+
+  - caption: DeepLabCut Benchmarking
+    chapters:
+      - file: docs/benchmark
+      - file: docs/pytorch/Benchmarking_shuffle_guide
+
+  - caption: "Mission & Contribute"
+    chapters:
+      - file: docs/MISSION_AND_VALUES
+      - file: docs/roadmap
+      - file: docs/Governance
+      - file: CONTRIBUTING
+
+  - caption: Citations for DeepLabCut
+    chapters:
+      - file: docs/citation

--- a/_toc.yml
+++ b/_toc.yml
@@ -2,108 +2,108 @@ format: jb-book
 root: README
 
 parts:
-  - caption: Getting Started
-    chapters:
-      - file: docs/UseOverviewGuide
-      - file: docs/course
+- caption: Getting Started
+  chapters:
+    - file: docs/UseOverviewGuide
+    - file: docs/course
 
-  - caption: Installation
-    chapters:
-      - file: docs/installation
-      - file: docs/recipes/installTips
-      - file: docs/docker
+- caption: Installation
+  chapters:
+    - file: docs/installation
+    - file: docs/recipes/installTips
+    - file: docs/docker
 
-  - caption: Main User Guides
-    chapters:
-      - file: docs/standardDeepLabCut_UserGuide
-      - file: docs/maDLC_UserGuide
-      - file: docs/Overviewof3D
-      - file: docs/HelperFunctions
+- caption: Main User Guides
+  chapters:
+    - file: docs/standardDeepLabCut_UserGuide
+    - file: docs/maDLC_UserGuide
+    - file: docs/Overviewof3D
+    - file: docs/HelperFunctions
 
-  - caption: Graphical User Interfaces (GUIs)
-    chapters:
-      - file: docs/gui/PROJECT_GUI
-      - file: docs/gui/napari_GUI
+- caption: Graphical User Interfaces (GUIs)
+  chapters:
+    - file: docs/gui/PROJECT_GUI
+    - file: docs/gui/napari_GUI
 
-  - caption: DLC3 PyTorch Specific Docs
-    chapters:
-      - file: docs/pytorch/user_guide.md
-      - file: docs/pytorch/pytorch_config.md
-      - file: docs/pytorch/architectures.md
+- caption: DLC3 PyTorch Specific Docs
+  chapters:
+    - file: docs/pytorch/user_guide.md
+    - file: docs/pytorch/pytorch_config.md
+    - file: docs/pytorch/architectures.md
 
-  - caption: Quick Start Tutorials
-    chapters:
-      - file: docs/quick-start/single_animal_quick_guide
-      - file: docs/quick-start/tutorial_maDLC
+- caption: Quick Start Tutorials
+  chapters:
+    - file: docs/quick-start/single_animal_quick_guide
+    - file: docs/quick-start/tutorial_maDLC
 
-  - caption: "🚀 Beginner's Guide to DeepLabCut"
-    chapters:
-      - file: docs/beginner-guides/beginners-guide
-      - file: docs/beginner-guides/manage-project
-      - file: docs/beginner-guides/labeling
-      - file: docs/beginner-guides/Training-Evaluation
-      - file: docs/beginner-guides/video-analysis
+- caption: "🚀 Beginner's Guide to DeepLabCut"
+  chapters:
+    - file: docs/beginner-guides/beginners-guide
+    - file: docs/beginner-guides/manage-project
+    - file: docs/beginner-guides/labeling
+    - file: docs/beginner-guides/Training-Evaluation
+    - file: docs/beginner-guides/video-analysis
 
-  - caption: "🚀 Main Demo Notebooks"
-    chapters:
-      - file: examples/COLAB/COLAB_DEMO_SuperAnimal
-      - file: examples/COLAB/COLAB_DEMO_mouse_openfield
-      - file: examples/COLAB/COLAB_3miceDemo
-      - file: examples/COLAB/COLAB_HumanPose_with_RTMPose
+- caption: "🚀 Main Demo Notebooks"
+  chapters:
+    - file: examples/COLAB/COLAB_DEMO_SuperAnimal
+    - file: examples/COLAB/COLAB_DEMO_mouse_openfield
+    - file: examples/COLAB/COLAB_3miceDemo
+    - file: examples/COLAB/COLAB_HumanPose_with_RTMPose
 
-  - caption: "🚀 Notebooks For Your Data"
-    chapters:
-      - file: examples/COLAB/COLAB_YOURDATA_SuperAnimal
-      - file: examples/COLAB/COLAB_YOURDATA_TrainNetwork_VideoAnalysis
-      - file: examples/COLAB/COLAB_YOURDATA_maDLC_TrainNetwork_VideoAnalysis
+- caption: "🚀 Notebooks For Your Data"
+  chapters:
+    - file: examples/COLAB/COLAB_YOURDATA_SuperAnimal
+    - file: examples/COLAB/COLAB_YOURDATA_TrainNetwork_VideoAnalysis
+    - file: examples/COLAB/COLAB_YOURDATA_maDLC_TrainNetwork_VideoAnalysis
 
-  - caption: "🚀 Special Feature Demos"
-    chapters:
-      - file: examples/COLAB/COLAB_transformer_reID
-      - file: examples/COLAB/COLAB_BUCTD_and_CTD_tracking
-      - file: examples/JUPYTER/Demo_3D_DeepLabCut
-      - file: examples/COLAB/COLAB_DLC_ModelZoo
+- caption: "🚀 Special Feature Demos"
+  chapters:
+    - file: examples/COLAB/COLAB_transformer_reID
+    - file: examples/COLAB/COLAB_BUCTD_and_CTD_tracking
+    - file: examples/JUPYTER/Demo_3D_DeepLabCut
+    - file: examples/COLAB/COLAB_DLC_ModelZoo
 
-  - caption: "🧑‍🍳 Cookbook (detailed helper guides)"
-    chapters:
-      - file: docs/convert_maDLC
-      - file: docs/recipes/OtherData
-      - file: docs/recipes/io
-      - file: docs/recipes/nn
-      - file: docs/recipes/post
-      - file: docs/recipes/BatchProcessing
-      - file: docs/recipes/DLCMethods
-      - file: docs/recipes/ClusteringNapari
-      - file: docs/recipes/OpenVINO
-      - file: docs/recipes/flip_and_rotate
-      - file: docs/recipes/pose_cfg_file_breakdown
-      - file: docs/recipes/publishing_notebooks_into_the_DLC_main_cookbook
+- caption: "🧑‍🍳 Cookbook (detailed helper guides)"
+  chapters:
+    - file: docs/convert_maDLC
+    - file: docs/recipes/OtherData
+    - file: docs/recipes/io
+    - file: docs/recipes/nn
+    - file: docs/recipes/post
+    - file: docs/recipes/BatchProcessing
+    - file: docs/recipes/DLCMethods
+    - file: docs/recipes/ClusteringNapari
+    - file: docs/recipes/OpenVINO
+    - file: docs/recipes/flip_and_rotate
+    - file: docs/recipes/pose_cfg_file_breakdown
+    - file: docs/recipes/publishing_notebooks_into_the_DLC_main_cookbook
 
-  - caption: Hardware Tips
-    chapters:
-      - file: docs/recipes/TechHardware
+- caption: Hardware Tips
+  chapters:
+    - file: docs/recipes/TechHardware
 
-  - caption: DeepLabCut-Live!
-    chapters:
-      - file: docs/deeplabcutlive
+- caption: DeepLabCut-Live!
+  chapters:
+    - file: docs/deeplabcutlive
 
-  - caption: "🦄 DeepLabCut Model Zoo"
-    chapters:
-      - file: docs/ModelZoo
-      - file: docs/recipes/UsingModelZooPupil
+- caption: "🦄 DeepLabCut Model Zoo"
+  chapters:
+    - file: docs/ModelZoo
+    - file: docs/recipes/UsingModelZooPupil
 
-  - caption: DeepLabCut Benchmarking
-    chapters:
-      - file: docs/benchmark
-      - file: docs/pytorch/Benchmarking_shuffle_guide
+- caption: DeepLabCut Benchmarking
+  chapters:
+    - file: docs/benchmark
+    - file: docs/pytorch/Benchmarking_shuffle_guide
 
-  - caption: "Mission & Contribute"
-    chapters:
-      - file: docs/MISSION_AND_VALUES
-      - file: docs/roadmap
-      - file: docs/Governance
-      - file: CONTRIBUTING
+- caption: "Mission & Contribute"
+  chapters:
+    - file: docs/MISSION_AND_VALUES
+    - file: docs/roadmap
+    - file: docs/Governance
+    - file: CONTRIBUTING
 
-  - caption: Citations for DeepLabCut
-    chapters:
-      - file: docs/citation
+- caption: Citations for DeepLabCut
+  chapters:
+    - file: docs/citation


### PR DESCRIPTION
# Purpose

- Cleans up the config to ignore unwanted build/venv directories to focus on package folders.
- Normlaize _toc.yml to minimize issues with the latest `jupyter-book<2` version.

This will also speed up local and potentially CI docs build.

## TODO

- Check :
    - [x] No content changes
    - [x] No ordering changes 

## Related

Required by/upstream of #3206. If **3206** is merged this PR is not relevant anymore.

## Details
- Add Sphinx exclude_patterns to _config.yml to ignore virtual environments, site-packages, and build directories during doc builds (".venv/**", "venv/**", "**/site-packages/**", "_build/**", "**/_build/**"). 
- Reformat _toc.yml : normalize emoji-bearing captions with quotes