### PR TITLE
Add custom styling options for docs (custom.css)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,8 @@ sphinx:
   config:
     autodoc_mock_imports: ["wx", "matplotlib", "qtpy", "PySide6", "napari", "shiboken6"]
     mermaid_output_format: raw
+    html_static_path: ["docs/_static"]
+    html_css_files: ["custom.css"]
   extra_extensions:
     - numpydoc
     - sphinxcontrib.mermaid

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -64,7 +64,7 @@ html[data-theme="dark"] {
 
 /* Logo (top of sidebar) */
 .navbar-brand img {
-  filter: var(--logo-filter);
+  filter: var(--logo-filter, none);
 }
 
 /* Header */
@@ -102,11 +102,3 @@ html[data-theme="dark"] {
   z-index: 1;
 }
 
-.article-header-buttons .btn:hover {
-  opacity: 0.8;
-  -index: 1;
-}
-
-.article-header-buttons .btn:hover {
-  opacity: 0.8;
-}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,113 @@
+/* custom.css */
+
+html[data-theme="light"] {
+  --sidebar-bg-color: #fefefe; /* #d2efff; */
+  --sidebar-text-color: #000000;
+  --sidebar-highlight-color: #95489c;
+  --sidebar-hover-text-color: #de6be8; /* #0044bd; */
+  --header-bg-color: #ffffff;
+  --logo-filter: none;
+  --button-color: #fff;
+  --footer-text-color: #000000;
+}
+
+html[data-theme="dark"] {
+  --sidebar-bg-color: #455364; /* #053346; */
+  --sidebar-text-color: #ffffff;
+  --sidebar-highlight-color: #95489c;
+  --sidebar-hover-text-color: #de6be8; /* #00aeef; */
+  --header-bg-color: #414141;
+  --logo-filter: grayscale(100%) brightness(20);
+  --button-color: #fff;
+  --footer-text-color: #b9b9b9;
+}
+
+/* Sidebar */
+.bd-sidebar-primary.bd-sidebar {
+  background-color: var(--sidebar-bg-color);
+  color: var(--sidebar-text-color);
+}
+
+.bd-sidebar-primary.bd-sidebar a {
+  color: var(--sidebar-text-color);
+}
+
+.bd-sidebar-primary.bd-sidebar a:hover {
+  color: var(--sidebar-hover-text-color);
+}
+
+/* Sidebar ToC */
+.toctree-l1.current.active {
+  color: var(--sidebar-highlight-color);
+}
+
+.toctree-l1.current.active * {
+  color: inherit;
+}
+
+/* Sidebar footer */
+.sidebar-primary-items__end::after {
+  content: "DeepLabCut";
+  display: block;
+  text-align: center;
+  font-size: 12px;
+  color: var(--footer-text-color);
+  /* If you want an image at the footer */
+  /* background-image: url("images/logo_background.png"); */
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  padding-top: 150px;
+  height: 100px;
+  z-index: 1;
+}
+
+/* Logo (top of sidebar) */
+.navbar-brand img {
+  filter: var(--logo-filter);
+}
+
+/* Header */
+.bd-header-article {
+  /* position: fixed; */
+  /* background-color: var(--header-bg-color); */
+  background-color: rgba(0, 0, 0, 0);
+  backdrop-filter: blur(2px);
+  z-index: 1000;
+}
+
+/* Header background image */
+.bd-header-article::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  /* background-image: url("images/header.jpg"); */
+  /* background-size: cover; */
+  /* background-repeat: no-repeat; */
+  /* background-position: center; */
+  opacity: 0.75;
+  z-index: -1;
+}
+
+/* Header buttons */
+.article-header-buttons .btn {
+  color: var(--button-color);
+  z-index: 1;
+}
+
+.article-header-buttons .btn:hover {
+  opacity: 0.8;
+  z-index: 1;
+}
+
+.article-header-buttons .btn:hover {
+  opacity: 0.8;
+  -index: 1;
+}
+
+.article-header-buttons .btn:hover {
+  opacity: 0.8;
+}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,11 +1,11 @@
 /* custom.css */
 
 html[data-theme="light"] {
-  --sidebar-bg-color: #fefefe; /* #d2efff; */
+  --sidebar-bg-color: #ac64e67f; /* #d2efff; */
   --sidebar-text-color: #000000;
-  --sidebar-highlight-color: #95489c;
-  --sidebar-hover-text-color: #de6be8; /* #0044bd; */
-  --header-bg-color: #ffffff;
+  --sidebar-highlight-color: #73439a;
+  --sidebar-hover-text-color: #39214d; /* #0044bd; */
+  --header-bg-color: rgba(115, 67, 154, 0.75); /* #053346; */
   --logo-filter: none;
   --button-color: #fff;
   --footer-text-color: #000000;
@@ -14,10 +14,10 @@ html[data-theme="light"] {
 html[data-theme="dark"] {
   --sidebar-bg-color: #455364; /* #053346; */
   --sidebar-text-color: #ffffff;
-  --sidebar-highlight-color: #95489c;
-  --sidebar-hover-text-color: #de6be8; /* #00aeef; */
-  --header-bg-color: #414141;
-  --logo-filter: grayscale(100%) brightness(20);
+  --sidebar-highlight-color: #de6be8;
+  --sidebar-hover-text-color: #ea57f8; /* #00aeef; */
+  --header-bg-color: rgba(115, 67, 154, 0.45); /* #053346; */
+  /* --logo-filter: grayscale(100%) brightness(20); */
   --button-color: #fff;
   --footer-text-color: #b9b9b9;
 }
@@ -47,7 +47,7 @@ html[data-theme="dark"] {
 
 /* Sidebar footer */
 .sidebar-primary-items__end::after {
-  content: "DeepLabCut";
+  content: "The DeepLabCut Community";
   display: block;
   text-align: center;
   font-size: 12px;
@@ -70,8 +70,7 @@ html[data-theme="dark"] {
 /* Header */
 .bd-header-article {
   /* position: fixed; */
-  /* background-color: var(--header-bg-color); */
-  background-color: rgba(0, 0, 0, 0);
+  background-color: var(--header-bg-color);
   backdrop-filter: blur(2px);
   z-index: 1000;
 }


### PR DESCRIPTION
# Purpose

- Adds custom handles for the style of the Jupyter Book.
   - Custom sidebar color and footer
   - "Frosted glass" effect on header
   - Color palette based on main logo/GUI

⚠️ **NOTE** The current colors & theme is not to be considered final. This is meant to provide customizations handles, not enforce a particular theme. Feedback is welcome. 

- Even it the entire CCS file were merged commented, this could still be useful.
- Not compatible with Jupyter Book >= 2.0 (Sphinx theme)
- **Custom banners/sidebar footer images can look really nice, if available we could add some**

## Preview

Again, color theme is **not final**. This is an example of what can be done.

| Mode       | Screenshot |
|------------|------------|
| **Dark mode** | ![Dark mode screenshot](https://github.com/user-attachments/assets/c9caf912-3c11-4504-87de-69fd9c147840) |
| **Light mode** | ![Light mode screenshot](https://github.com/user-attachments/assets/91bc16da-bd9f-490c-b550-beeba3c2054c) |



## TODO

- Check :
    - [ ] Ensure readability of all content
    - [ ] Make sure the theme is well-accepted and accessible
- [x] _(Optional)_ Merge #3201 first to help local builds


## Details

This pull request introduces custom styling to the Sphinx documentation by adding a new CSS file and updating the Sphinx configuration to include it. The main goal is to enhance the documentation's appearance with a custom sidebar, header, and footer design for both light and dark themes.

**Sphinx documentation theming:**

* Added a new `custom.css` file in `docs/_static/` that defines custom colors and styles for sidebar, header, footer, and buttons, supporting both light and dark themes.
* Updated `_config.yml` to include `docs/_static` as a static path and load the new `custom.css` file for HTML output.