### PR TITLE
[dev] C5 - Fully typed configs (remove intermediate OmegaConf DictConfig)

### DIFF
--- a/deeplabcut/core/config/__init__.py
+++ b/deeplabcut/core/config/__init__.py
@@ -10,5 +10,6 @@ from deeplabcut.core.config.utils import (
     write_config_3d_template,
     write_project_config,
 )
+from deeplabcut.core.config.change_tracking import ChangeTrackingMixin
 from deeplabcut.core.config.config_mixin import ConfigMixin
 from deeplabcut.core.config.project_config import ProjectConfig

--- a/deeplabcut/core/config/change_tracking.py
+++ b/deeplabcut/core/config/change_tracking.py
@@ -1,0 +1,120 @@
+"""Opt-in dirty-state tracking mixin for pydantic dataclass configs."""
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Any
+
+from dataclasses import fields
+
+logger = logging.getLogger(__name__)
+
+
+class ChangeTrackingMixin:
+    """Opt-in mixin that records which fields are *dirty* (modified but not
+    yet written to disk).
+
+    Tracking is installed lazily on first instantiation so it wraps previously
+    set up ``__setattr__`` (incl. pydantic's ``validate_assignment``).
+
+    A field is marked dirty when the validated write succeeds and the new
+    value differs from the old one.
+
+    Human-readable *change notes* can be attached to dirty fields via
+    :meth:`record_change_note`.  These are *not* generated automatically.
+
+    Tracking state is stored in ``__slots__`` so it survives pydantic's
+    ``__dict__`` rebuilds during validated assignment.
+
+    Example::
+
+        @dataclass(config=ConfigDict(extra="forbid", validate_assignment=True))
+        class MyConfig(ChangeTrackingMixin, ConfigMixin):
+            ...
+    """
+
+    __slots__ = ("_dirty_fields", "_change_notes")
+
+    def __post_init__(self) -> None:
+        if hasattr(super(), "__post_init__"):
+            super().__post_init__()
+        cls = type(self)
+        if not getattr(cls, "_change_tracking_installed", False):
+            original_setattr = cls.__setattr__
+
+            def __setattr__(self, name: str, value: Any) -> None:
+                field_names = [f.name for f in fields(self)]
+                dirty_fields = getattr(self, "_dirty_fields", None)
+                if dirty_fields is not None and name in field_names:
+                    old = getattr(self, name)
+                    original_setattr(self, name, value)
+                    if old != value:
+                        dirty_fields.add(name)
+                else:
+                    original_setattr(self, name, value)
+
+            cls.__setattr__ = __setattr__
+            cls._change_tracking_installed = True
+
+        object.__setattr__(self, "_dirty_fields", set())
+        object.__setattr__(self, "_change_notes", {})
+
+    @property
+    def is_dirty(self) -> bool:
+        """True if any field has been modified since construction or the last
+        call to :meth:`mark_clean`."""
+        return bool(self._dirty_fields)
+
+    @property
+    def dirty_fields(self) -> frozenset[str]:
+        """Field names modified since construction or the last call to
+        :meth:`mark_clean`."""
+        return frozenset(self._dirty_fields)
+
+    @property
+    def change_notes(self) -> list[str]:
+        """Human-readable notes describing dirty-field changes."""
+        return list(self._change_notes.values())
+
+    def record_change_note(
+        self,
+        field_name: str,
+        message: str,
+        *,
+        include_caller: bool = False,
+        _stack_depth: int = 1,
+    ) -> None:
+        """Attach a human-readable note to a dirty field.
+
+        Overwrites any previous note for the same *field_name*.
+
+        Args:
+            include_caller: If True, appends a ``[file:line]`` caller tag.
+            _stack_depth: Frames to skip when resolving the caller (increase
+                when wrapping this method).
+        """
+        if include_caller:
+            frame = sys._getframe(_stack_depth)
+            filename = frame.f_code.co_filename.rsplit("/", 1)[-1]
+            message = f"{message} [{filename}:{frame.f_lineno}]"
+        self._change_notes[field_name] = message
+
+    def log_changes(self) -> None:
+        """Log all dirty fields at INFO level.
+
+        Fields with an explicit change note show the note; the rest are
+        listed by name only.
+        """
+        if not self.is_dirty:
+            return
+        logger.info(f"Updates to {type(self).__name__}:")
+        for field_name in sorted(self._dirty_fields):
+            if field_name in self._change_notes:
+                logger.info(f"  {self._change_notes[field_name]}")
+            else:
+                logger.info(f"  {field_name} was modified")
+
+    def mark_clean(self) -> None:
+        """Reset dirty tracking, treating the current state as clean."""
+        self._dirty_fields.clear()
+        self._change_notes.clear()

--- a/deeplabcut/core/config/change_tracking.py
+++ b/deeplabcut/core/config/change_tracking.py
@@ -43,6 +43,10 @@ class ChangeTrackingMixin:
             original_setattr = cls.__setattr__
 
             def __setattr__(self, name: str, value: Any) -> None:
+                if name in ("_dirty_fields", "_change_notes"):
+                    # Bypass pydantic validation for ChangeTrackingMixin fields.
+                    object.__setattr__(self, name, value)
+                    return
                 field_names = [f.name for f in fields(self)]
                 dirty_fields = getattr(self, "_dirty_fields", None)
                 if dirty_fields is not None and name in field_names:

--- a/deeplabcut/core/config/config_mixin.py
+++ b/deeplabcut/core/config/config_mixin.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import logging
-from typing import Callable, Mapping
+import warnings
+from typing import Any, Callable, Iterator, Mapping
 from typing_extensions import Self
 from pathlib import Path
 from dataclasses import asdict, fields
@@ -27,26 +30,103 @@ class ConfigMixin:
     - Loading configurations from dictionaries or YAML files
     - Validating configuration data against pydantic models
     - Converting configurations to dictionaries
+    - Dict-like access (cfg["key"], cfg.get("key"), "key" in cfg, etc.)
     - Pretty printing configuration data
     """
 
-    @classmethod
-    def validate_dict(
-        cls,
-        cfg_dict: dict,
-    ) -> DictConfig:
-        """
-        Load a dictionary as DictConfig, validating it against the pydantic model.
+    # ------------------------------------------------------------------
+    # Dict-like access protocol
+    # ------------------------------------------------------------------
+
+    def __getitem__(self, key: str) -> Any:
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        if key not in self._field_names():
+            raise KeyError(
+                f"'{type(self).__name__}' has no field '{key}'"
+            )
+        object.__setattr__(self, key, value)
+
+    def __contains__(self, key: object) -> bool:
+        return isinstance(key, str) and key in self._field_names()
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._field_names())
+
+    def __len__(self) -> int:
+        return len(fields(self))
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Dict-compatible .get() with an optional default."""
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def keys(self) -> list[str]:
+        """Return field names (like dict.keys())."""
+        return self._field_names()
+
+    def values(self) -> list[Any]:
+        """Return field values (like dict.values())."""
+        return [getattr(self, f.name) for f in fields(self)]
+
+    def items(self) -> list[tuple[str, Any]]:
+        """Return (name, value) pairs (like dict.items())."""
+        return [(f.name, getattr(self, f.name)) for f in fields(self)]
+
+    def select(self, path: str, default: Any = None) -> Any:
+        """Nested dot-path access into this config.
+
+        Replacement for ``OmegaConf.select(cfg, "a.b.c")``.
+
         Args:
-            cfg_dict: the configuration as a dictionary
+            path: Dot-separated key path (e.g. ``"data.train.top_down_crop"``).
+            default: Value to return when a segment is missing.
 
         Returns:
-            The configuration file as a DictConfig
+            The value at the given path, or *default* if any segment is missing.
         """
-        cfg: DictConfig = OmegaConf.create(cfg_dict)
-        resolved: dict = OmegaConf.to_container(cfg, resolve=True)
-        TypeAdapter(cls).validate_python(resolved, extra="forbid")
-        return cfg
+        obj: Any = self
+        for part in path.split("."):
+            if obj is None:
+                return default
+            try:
+                obj = obj[part] if isinstance(obj, dict) else getattr(obj, part)
+            except (KeyError, AttributeError, TypeError):
+                return default
+        return obj
+
+    def _field_names(self) -> list[str]:
+        return [f.name for f in fields(self)]
+
+    # ------------------------------------------------------------------
+    # Validation helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def validate_dict(cls, cfg_dict: dict | DictConfig) -> Self:
+        """Validate a dictionary against this config's pydantic model.
+
+        Args:
+            cfg_dict: the configuration as a dictionary (or DictConfig during
+                the deprecation transition).
+
+        Returns:
+            A validated instance of this configuration class.
+        """
+        if isinstance(cfg_dict, DictConfig):
+            cfg_dict = OmegaConf.to_container(cfg_dict, resolve=True)
+        TypeAdapter(cls).validate_python(cfg_dict)
+        return cls(**cfg_dict)
+
+    # ------------------------------------------------------------------
+    # Construction helpers
+    # ------------------------------------------------------------------
 
     @classmethod
     def from_dict(cls, cfg_dict: dict) -> Self:
@@ -61,8 +141,9 @@ class ConfigMixin:
         Create a new instance from various configuration formats.
 
         Args:
-            config: Configuration as a ConfigMixin instance, dictionary, or DictConfig.
-                   If already a ConfigMixin instance, returns it as-is.
+            config: Configuration as a ConfigMixin instance, dictionary,
+                    DictConfig (deprecated), string, or Path.
+                    If already a ConfigMixin instance, returns it as-is.
 
         Returns:
             A new instance of the ConfigMixin subclass.
@@ -72,6 +153,12 @@ class ConfigMixin:
         elif isinstance(config, str | Path):
             return cls.from_yaml(config)
         elif isinstance(config, DictConfig):
+            warnings.warn(
+                "Passing an OmegaConf DictConfig is deprecated. "
+                "Pass a plain dict or a typed config instance instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             return cls.from_dict(OmegaConf.to_container(config, resolve=True))
         elif isinstance(config, dict):
             return cls.from_dict(config)
@@ -105,6 +192,10 @@ class ConfigMixin:
         cfg._log_updates(updates)
         return cfg
 
+    # ------------------------------------------------------------------
+    # Serialization
+    # ------------------------------------------------------------------
+
     def to_yaml(self, yaml_path: str | Path, overwrite: bool = True) -> None:
         dict_data = self.to_dict_normalized()
         data = CommentedMap(dict_data)
@@ -120,6 +211,19 @@ class ConfigMixin:
         return _normalize_for_serialization(self.to_dict())
 
     def to_dictconfig(self) -> DictConfig:
+        """Convert to an OmegaConf DictConfig.
+
+        .. deprecated::
+            This method will be removed in a future version.
+            Use the typed config instance directly (it supports dict-like access)
+            or call ``.to_dict()`` if a plain dict is needed.
+        """
+        warnings.warn(
+            "to_dictconfig() is deprecated. Use the typed config instance directly "
+            "(it supports dict-like access) or call .to_dict() for a plain dict.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return OmegaConf.create(self.to_dict())
 
     def print(

--- a/deeplabcut/core/config/utils.py
+++ b/deeplabcut/core/config/utils.py
@@ -187,7 +187,7 @@ scorername_3d: # Enter the scorer name for the 3D output
     return cfg_file_3d, ruamelFile_3d
 
 
-def read_config(configname: str | Path, ignore_empty: bool = True) -> DictConfig:
+def read_config(configname: str | Path, ignore_empty: bool = True) -> "ProjectConfig":
     """
     Reads structured config file defining a project.
 
@@ -201,11 +201,8 @@ def read_config(configname: str | Path, ignore_empty: bool = True) -> DictConfig
             Defaults to True.
 
     Returns:
-        The project configuration as a DictConfig.
+        The project configuration as a ProjectConfig instance (supports dict-like access).
     """
-    # NOTE @deruyter92 2026-02-05: Default ignore_empty is now set to True to match
-    # the prior behaviour of read_config. We should consider changing this to False
-    # for stricter validation.
     from deeplabcut.core.config.project_config import ProjectConfig
     path = Path(configname)
     project_config = ProjectConfig.from_yaml(path, ignore_empty=ignore_empty)
@@ -216,12 +213,12 @@ def read_config(configname: str | Path, ignore_empty: bool = True) -> DictConfig
     if project_config.project_path != curr_dir:
         project_config.project_path = curr_dir
         project_config.to_yaml(configname)
-    return project_config.to_dictconfig()
+    return project_config
 
 
 def write_project_config(
     configname: str | Path,
-    cfg: dict | ProjectConfig | DictConfig,
+    cfg: "dict | ProjectConfig",
 ) -> None:
     """Write structured project config file (config.yaml) preserving template order."""
     from deeplabcut.core.config.project_config import ProjectConfig

--- a/deeplabcut/core/config/utils.py
+++ b/deeplabcut/core/config/utils.py
@@ -206,13 +206,14 @@ def read_config(configname: str | Path, ignore_empty: bool = True) -> "ProjectCo
     from deeplabcut.core.config.project_config import ProjectConfig
     path = Path(configname)
     project_config = ProjectConfig.from_yaml(path, ignore_empty=ignore_empty)
-    
-    # NOTE @deruyter92 2026-02-02: copied old behaviour of writing the config back to the file.
-    # We should consider separating the writing and reading instead of having inplace edits during reading.
-    curr_dir = str(Path(configname).parent.resolve())
-    if project_config.project_path != curr_dir:
-        project_config.project_path = curr_dir
-        project_config.to_yaml(configname)
+
+    # If necessary, ProjectConfig automatically updates its project path via _post_yaml_load_updates.
+    # if that is the case (marked as dirty), we write the config back to the file.
+    if  "project_path" in project_config.dirty_fields:
+        # NOTE @deruyter92 2026-02-02: copied old behaviour of writing the config 
+        # immediately back to the file after reading it. We should consider separating 
+        # the writing and reading instead of having inplace edits during reading.
+        project_config.to_yaml(configname, log_changes=True, mark_clean=True)
     return project_config
 
 

--- a/deeplabcut/pose_estimation_pytorch/apis/analyze_images.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/analyze_images.py
@@ -335,7 +335,7 @@ def analyze_images(
                 config=config,
             )
         # TODO @deruyter92: decide on typed / plain dict
-        elif isinstance(ctd_conditions, (dict, DictConfig)):
+        elif isinstance(ctd_conditions, dict):
             cond_provider = get_condition_provider(
                 condition_cfg=ctd_conditions,
                 config=config,
@@ -472,7 +472,7 @@ def analyze_image_folder(
         ValueError: if the pose model is a top-down model but no detector path is given
     """
     # TODO @deruyter92: decide on typed / plain dict
-    if not isinstance(model_cfg, (dict, DictConfig)):
+    if not isinstance(model_cfg, dict):
         model_cfg = config_utils.read_config_as_dict(model_cfg)
 
     pose_task = Task(model_cfg["method"])

--- a/deeplabcut/pose_estimation_pytorch/apis/ctd.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/ctd.py
@@ -50,7 +50,7 @@ def get_condition_provider(
         ) + error_message
         raise ValueError(error_message)
     # TODO @deruyter92: decide on typed / plain dict
-    elif not isinstance(condition_cfg, (dict, DictConfig)):
+    elif not isinstance(condition_cfg, dict):
         raise ValueError(error_message)
 
     if config is not None:
@@ -120,7 +120,7 @@ def load_conditions_for_evaluation(
         condition_filepath = Path(condition_cfg)
         cond_provider = CondFromFile(filepath=condition_filepath)
     # TODO @deruyter92: decide on typed / plain dict
-    elif isinstance(condition_cfg, (dict, DictConfig)):
+    elif isinstance(condition_cfg, dict):
         if isinstance(loader, data.DLCLoader) and "config" not in condition_cfg:
             condition_cfg["config"] = loader.project_root / "config.yaml"
 

--- a/deeplabcut/pose_estimation_pytorch/apis/evaluation.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/evaluation.py
@@ -558,7 +558,7 @@ def evaluate_snapshot(
     if pcutoff is None:
         pcutoff = cfg.get("pcutoff", 0.6)
     # TODO @deruyter92: decide on typed / plain dict
-    elif isinstance(pcutoff, (dict, DictConfig)):
+    elif isinstance(pcutoff, dict):
         pcutoff = [
             pcutoff.get(bpt, 0.6)
             for bpt in eval_parameters.bodyparts + eval_parameters.unique_bpts
@@ -578,7 +578,7 @@ def evaluate_snapshot(
         "pcutoff": (
             ", ".join([str(v) for v in pcutoff])
             # TODO @deruyter92: decide on typed / plain list
-            if isinstance(pcutoff, (list, ListConfig))
+            if isinstance(pcutoff, list)
             else pcutoff
         ),
     }

--- a/deeplabcut/pose_estimation_pytorch/apis/export.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/export.py
@@ -15,6 +15,8 @@ from pathlib import Path
 import torch
 from omegaconf import DictConfig, OmegaConf
 
+from deeplabcut.core.config.config_mixin import ConfigMixin
+
 import deeplabcut.pose_estimation_pytorch.apis.utils as utils
 import deeplabcut.pose_estimation_pytorch.data as dlc3_data
 import deeplabcut.utils.auxiliaryfunctions as af
@@ -135,10 +137,10 @@ def export_model(
             if wipe_paths:
                 wipe_paths_from_model_config(model_cfg)
 
-            # Convert DictConfig to plain dict so torch.save doesn't pickle
-            # omegaconf types (which require weights_only=False to load)
-            if isinstance(model_cfg, DictConfig):
-                model_cfg = OmegaConf.to_container(model_cfg, resolve=True)
+            # Convert typed config to plain dict so torch.save doesn't pickle
+            # custom types (which require weights_only=False to load)
+            if isinstance(model_cfg, ConfigMixin):
+                model_cfg = model_cfg.to_dict()
 
             pose_weights = torch.load(snapshot.path, **load_kwargs)["model"]
             export_dict = dict(config=model_cfg, pose=pose_weights)

--- a/deeplabcut/pose_estimation_pytorch/apis/videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/videos.py
@@ -496,7 +496,7 @@ def analyze_videos(
                 config=config,
             )
         # TODO @deruyter92: decide on typed / plain dict
-        elif isinstance(ctd_conditions, (dict, DictConfig)):
+        elif isinstance(ctd_conditions, dict):
             cond_provider = get_condition_provider(
                 condition_cfg=ctd_conditions,
                 config=config,
@@ -505,7 +505,7 @@ def analyze_videos(
             cond_provider = ctd_conditions
 
     # TODO @deruyter92: decide on typed / plain dict
-    if isinstance(ctd_tracking, (dict, DictConfig)):
+    if isinstance(ctd_tracking, dict):
         # FIXME(niels) - add video FPS setting
         ctd_tracking = CTDTrackingConfig.build(ctd_tracking)
 

--- a/deeplabcut/pose_estimation_pytorch/data/base.py
+++ b/deeplabcut/pose_estimation_pytorch/data/base.py
@@ -16,7 +16,6 @@ import warnings
 
 import albumentations as A
 import numpy as np
-from omegaconf import DictConfig, OmegaConf
 
 from deeplabcut.pose_estimation_pytorch.config.pose import PoseConfig
 import deeplabcut.core.config as config_utils
@@ -58,7 +57,7 @@ class Loader(ABC):
         self,
         project_root: str | Path,
         image_root: str | Path,
-        model_config: PoseConfig | DictConfig | Path | str | None = None,
+        model_config: PoseConfig | dict | Path | str | None = None,
         model_config_path: Path | str | None = DEPRECATED_ARGUMENT,
     ) -> None:
         """
@@ -67,7 +66,7 @@ class Loader(ABC):
         Args:
             project_root: The root directory of the project.
             image_root: The root directory of the images.
-            model_config (Path | str | PoseConfig | DictConfig): 
+            model_config (Path | str | PoseConfig | dict): 
                 The pose model configuration. Can be a path to a YAML file, a PoseConfig object, or a dictionary.
             (model_config_path: The path to the pose model configuration. Deprecated, use `model_config` instead.)
         """
@@ -92,12 +91,12 @@ class Loader(ABC):
                 )
             return model_config
         model_config = _resolve_legacy_args(model_config, model_config_path)    
-        self.model_cfg: DictConfig = PoseConfig.from_any(model_config).to_dictconfig()
+        self.model_cfg: PoseConfig = PoseConfig.from_any(model_config)
 
-        def _infer_model_config_path(model_config: PoseConfig | DictConfig | Path | str) -> Path:
+        def _infer_model_config_path(model_config: PoseConfig | dict | Path | str) -> Path:
             """Resolve the pose config path. Either the input is a path, or it is specified in `metadata.pose_config_path` field."""
             provided_path = Path(model_config) if isinstance(model_config, (Path, str)) else None
-            specified_path = OmegaConf.select(self.model_cfg, "metadata.pose_config_path")
+            specified_path = self.model_cfg.select("metadata.pose_config_path")
             model_config_path = provided_path or specified_path
             if model_config_path is None:
                 raise ValueError("`model_config` must contain a `metadata.pose_config_path` field.")
@@ -144,16 +143,9 @@ class Loader(ABC):
         Args:
             updates: the items to update in the model configuration
         """
-        # TODO @deruyter92: updating the config after initialization is 
-        # not ideal. We should move away from this strategy and update all 
-        # override arguments during config creation.
-        updated_cfg: dict = config.update_config_by_dotpath(self.model_cfg, updates)
-
-        # Validate the updated config against the PoseConfig pydantic model
-        PoseConfig.validate_dict(updated_cfg)
-        self.model_cfg = PoseConfig.from_any(updated_cfg).to_dictconfig()
-
-        config_utils.write_config(self.model_config_path, self.model_cfg)
+        cfg_dict = config.update_config_by_dotpath(self.model_cfg.to_dict(), updates)
+        self.model_cfg = PoseConfig.from_dict(cfg_dict)
+        self.model_cfg.to_yaml(self.model_config_path)
 
     @abstractmethod
     def load_data(self, mode: str = "train") -> dict[str, list[dict]]:

--- a/deeplabcut/pose_estimation_pytorch/data/cocoloader.py
+++ b/deeplabcut/pose_estimation_pytorch/data/cocoloader.py
@@ -16,7 +16,6 @@ import warnings
 from pathlib import Path
 
 import numpy as np
-from omegaconf import OmegaConf, DictConfig
 
 from deeplabcut.pose_estimation_pytorch.data.base import Loader
 from deeplabcut.core.types import DEPRECATED_ARGUMENT
@@ -50,7 +49,7 @@ class COCOLoader(Loader):
     def __init__(
         self,
         project_root: str | Path,
-        model_config: PoseConfig | DictConfig | Path | str | None = None,
+        model_config: PoseConfig | dict | Path | str | None = None,
         train_json_filename: str = "train.json",
         test_json_filename: str = "test.json",
         model_config_path: str | Path | None = DEPRECATED_ARGUMENT,
@@ -86,7 +85,7 @@ class COCOLoader(Loader):
         if self._dataset_parameters is None:
             num_individuals, bodyparts = self.get_project_parameters(self.train_json)
 
-            crop_cfg = OmegaConf.select(self.model_cfg, "data.train.top_down_crop") or {}
+            crop_cfg = self.model_cfg.select("data.train.top_down_crop") or {}
             crop_w, crop_h = crop_cfg.get("width", 256), crop_cfg.get("height", 256)
             crop_margin = crop_cfg.get("margin", 0)
             crop_with_context = crop_cfg.get("crop_with_context", True)

--- a/deeplabcut/pose_estimation_pytorch/data/ctd.py
+++ b/deeplabcut/pose_estimation_pytorch/data/ctd.py
@@ -356,7 +356,7 @@ class CondFromFile(CondProvider):
         # Parse list and return
         if images is None:
             # TODO @deruyter92: decide on typed / plain list
-            if not isinstance(conditions, (list, ListConfig)):
+            if not isinstance(conditions, list):
                 raise ValueError(
                     f"Conditions are expected to be of type list when `images=None`, "
                     f"got {type(conditions)}."
@@ -371,7 +371,7 @@ class CondFromFile(CondProvider):
             return parsed
 
         # TODO @deruyter92: decide on typed / plain dict
-        if not isinstance(conditions, (dict, DictConfig)):
+        if not isinstance(conditions, dict):
             raise ValueError(
                 f"Conditions are expected to be of type dict, got {type(conditions)}. "
                 "They should be in the format 'labeled-data/video-0/img0000.png' -> "

--- a/deeplabcut/pose_estimation_pytorch/data/dlcloader.py
+++ b/deeplabcut/pose_estimation_pytorch/data/dlcloader.py
@@ -19,8 +19,6 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 import scipy.io as sio
-from omegaconf import OmegaConf, DictConfig
-
 from deeplabcut.core.config.project_config import ProjectConfig
 import deeplabcut.utils.auxiliaryfunctions as af
 from deeplabcut.core.engine import Engine
@@ -37,7 +35,7 @@ class DLCLoader(Loader):
 
     def __init__(
         self,
-        config: ProjectConfig | DictConfig | Path | str,
+        config: ProjectConfig | dict | Path | str,
         trainset_index: int = 0,
         shuffle: int = 0,
         modelprefix: str = "",
@@ -50,8 +48,8 @@ class DLCLoader(Loader):
             modelprefix: the modelprefix for the shuffle
         """
         provided_root_dir = Path(config).parent if isinstance(config, (str, Path)) else None
-        self._project_config: DictConfig = ProjectConfig.from_any(config).to_dictconfig()
-        self._project_root = provided_root_dir or OmegaConf.select(self._project_config, "project_path")
+        self._project_config: ProjectConfig = ProjectConfig.from_any(config)
+        self._project_root = provided_root_dir or self._project_config.project_path
         if self._project_root is None:
             raise ValueError(
                 "`config` must contain a `project_path` field."
@@ -88,7 +86,7 @@ class DLCLoader(Loader):
         self._resolutions = set()
 
     @property
-    def project_cfg(self) -> dict:
+    def project_cfg(self) -> ProjectConfig:
         """Returns: the configuration for the DeepLabCut project"""
         return self._project_config
 
@@ -168,7 +166,7 @@ class DLCLoader(Loader):
         Returns:
             An instance of the PoseDatasetParameters with the parameters set.
         """
-        crop_cfg = OmegaConf.select(self.model_cfg, "data.train.top_down_crop") or {}
+        crop_cfg = self.model_cfg.select("data.train.top_down_crop") or {}
         crop_w, crop_h = crop_cfg.get("width", 256), crop_cfg.get("height", 256)
         crop_margin = crop_cfg.get("margin", 0)
         crop_with_context = crop_cfg.get("crop_with_context", True)

--- a/deeplabcut/pose_estimation_pytorch/data/preprocessor.py
+++ b/deeplabcut/pose_estimation_pytorch/data/preprocessor.py
@@ -257,7 +257,7 @@ class AugmentImage(Preprocessor):
         scales = context.get("scales", (1, 1))
         if isinstance(offsets, tuple):
             # TODO @deruyter92: decide on typed / plain list
-            if isinstance(new_offsets, (list, ListConfig)):
+            if isinstance(new_offsets, list):
                 updated_offsets = [
                     AugmentImage.update_offset(offsets, scales, new_offset)
                     for new_offset in new_offsets
@@ -276,7 +276,7 @@ class AugmentImage(Preprocessor):
                 updated_scales = AugmentImage.update_scale(scales, new_scales)
         else:
             # TODO @deruyter92: decide on typed / plain list
-            if isinstance(new_offsets, (list, ListConfig)):
+            if isinstance(new_offsets, list):
                 if not len(offsets) == len(new_offsets):
                     raise ValueError("Cannot rescale lists when not same length")
 

--- a/deeplabcut/pose_estimation_pytorch/data/transforms.py
+++ b/deeplabcut/pose_estimation_pytorch/data/transforms.py
@@ -38,7 +38,7 @@ def build_transforms(augmentations: dict) -> A.BaseCompose:
         if isinstance(hflip_cfg, float):
             hflip_proba = hflip_cfg
         # TODO @deruyter92: decide on typed / plain dict
-        elif isinstance(hflip_cfg, (dict, DictConfig)):
+        elif isinstance(hflip_cfg, dict):
             if "p" in hflip_cfg:
                 hflip_proba = float(hflip_cfg["p"])
 

--- a/deeplabcut/pose_estimation_pytorch/models/detectors/base.py
+++ b/deeplabcut/pose_estimation_pytorch/models/detectors/base.py
@@ -37,8 +37,9 @@ def _build_detector(
     Returns:
         the built detector
     """
-    cfg["pretrained"] = pretrained
-    detector: BaseDetector = build_from_cfg(cfg, **kwargs)
+    detector: BaseDetector = build_from_cfg(
+        cfg, **kwargs, default_args={"pretrained": pretrained},
+    )
 
     if weight_init is not None and weight_init.detector_snapshot_path is not None:
         logging.info(

--- a/deeplabcut/pose_estimation_pytorch/models/heads/base.py
+++ b/deeplabcut/pose_estimation_pytorch/models/heads/base.py
@@ -83,7 +83,7 @@ class BaseHead(ABC, nn.Module):
             )
 
         # TODO @deruyter92: decide on typed / plain dict
-        if isinstance(criterion, (dict, DictConfig)):
+        if isinstance(criterion, dict):
             if aggregator is None:
                 raise ValueError(
                     f"When multiple criterions are defined, a loss aggregator must "

--- a/deeplabcut/pose_estimation_pytorch/models/model.py
+++ b/deeplabcut/pose_estimation_pytorch/models/model.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import copy
 import logging
 from pathlib import Path
-from omegaconf import DictConfig
 import torch
 import torch.nn as nn
 
@@ -41,7 +40,7 @@ class PoseModel(nn.Module):
 
     def __init__(
         self,
-        cfg: ModelConfig | DictConfig | dict | Path | str,
+        cfg: ModelConfig | dict | Path | str,
         backbone: BaseBackbone,
         heads: dict[str, BaseHead],
         neck: BaseNeck | None = None,
@@ -54,7 +53,7 @@ class PoseModel(nn.Module):
             neck: neck network architecture (default is None). Defaults to None.
         """
         super().__init__()
-        self.cfg: DictConfig = ModelConfig.from_any(cfg).to_dictconfig()
+        self.cfg: ModelConfig = ModelConfig.from_any(cfg)
         self.backbone = backbone
         self.heads = nn.ModuleDict(heads)
         self.neck = neck

--- a/deeplabcut/pose_estimation_pytorch/runners/schedulers.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/schedulers.py
@@ -82,6 +82,8 @@ def build_scheduler(
 
     parsed_params = {}
     for param_name, param in scheduler_cfg["params"].items():
+        # Ensure plain Python types for scheduler state_dict serialization
+
         # Convert omegaconf containers to plain Python types so that the
         # scheduler state_dict (saved via torch.save) does not contain
         # unpicklable omegaconf objects with _parent references.
@@ -102,8 +104,7 @@ def build_scheduler(
 
 def _parse_scheduler_param(param: Any, optimizer: torch.optim.Optimizer) -> Any:
     """Parses parameters so they're built as schedulers if they're configured as one"""
-    # TODO @deruyter92: decide on typed / plain dict
-    if isinstance(param, (dict, DictConfig)) and "type" in param:
+    if isinstance(param, dict) and "type" in param:
         param = build_scheduler(param, optimizer)
 
     return param

--- a/deeplabcut/pose_estimation_pytorch/runners/train.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/train.py
@@ -97,10 +97,10 @@ class TrainingRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
             model=model, device=device, gpus=gpus, snapshot_path=snapshot_path
         )
         # TODO @deruyter92: decide on typed / plain dict
-        if isinstance(optimizer, (dict, DictConfig)):
+        if isinstance(optimizer, dict):
             optimizer = build_optimizer(model, optimizer)
         # TODO @deruyter92: decide on typed / plain dict
-        if isinstance(scheduler, (dict, DictConfig)):
+        if isinstance(scheduler, dict):
             scheduler = schedulers.build_scheduler(scheduler, optimizer)
 
         self.eval_interval = eval_interval

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate.py
@@ -714,7 +714,7 @@ def evaluate_network(
         )
         # Make folder for evaluation
         auxiliaryfunctions.attempt_to_make_folder(
-            str(cfg["project_path"] + "/evaluation-results/")
+            str(Path(cfg["project_path"]) / "evaluation-results")
         )
         for shuffle in Shuffles:
             for trainFraction in TrainingFractions:

--- a/tests/core/config/test_change_tracking.py
+++ b/tests/core/config/test_change_tracking.py
@@ -1,0 +1,268 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Tests for ChangeTrackingMixin."""
+from __future__ import annotations
+
+import logging
+
+import pytest
+from pydantic import ConfigDict
+from pydantic.dataclasses import dataclass
+
+from pydantic import ValidationError
+
+from deeplabcut.core.config.change_tracking import ChangeTrackingMixin
+from deeplabcut.core.config.config_mixin import ConfigMixin
+from deeplabcut.core.config.versioning import MigrationMixin
+
+
+@dataclass(config=ConfigDict(validate_assignment=True))
+class TrackedConfig(ChangeTrackingMixin, ConfigMixin):
+    name: str = "default"
+    count: int = 0
+    flag: bool = False
+
+
+# ------------------------------------------------------------------
+# Dirty-state tracking
+# ------------------------------------------------------------------
+
+
+class TestDirtyState:
+    def test_clean_after_construction(self):
+        cfg = TrackedConfig()
+        assert not cfg.is_dirty
+        assert cfg.dirty_fields == frozenset()
+
+    def test_dirty_after_field_change(self):
+        cfg = TrackedConfig()
+        cfg.name = "changed"
+        assert cfg.is_dirty
+        assert "name" in cfg.dirty_fields
+
+    def test_not_dirty_when_set_to_same_value(self):
+        cfg = TrackedConfig(name="same")
+        cfg.name = "same"
+        assert not cfg.is_dirty
+
+    def test_multiple_fields_tracked(self):
+        cfg = TrackedConfig()
+        cfg.name = "new"
+        cfg.count = 5
+        assert cfg.dirty_fields == frozenset({"name", "count"})
+
+    def test_dirty_fields_is_frozen(self):
+        cfg = TrackedConfig()
+        cfg.name = "x"
+        fs = cfg.dirty_fields
+        assert isinstance(fs, frozenset)
+
+
+# ------------------------------------------------------------------
+# mark_clean
+# ------------------------------------------------------------------
+
+
+class TestMarkClean:
+    def test_mark_clean_resets_dirty_fields(self):
+        cfg = TrackedConfig()
+        cfg.name = "x"
+        cfg.mark_clean()
+        assert not cfg.is_dirty
+        assert cfg.dirty_fields == frozenset()
+
+    def test_mark_clean_resets_change_notes(self):
+        cfg = TrackedConfig()
+        cfg.name = "x"
+        cfg.record_change_note("name", "renamed")
+        cfg.mark_clean()
+        assert cfg.change_notes == []
+
+    def test_dirty_again_after_mark_clean(self):
+        cfg = TrackedConfig()
+        cfg.name = "x"
+        cfg.mark_clean()
+        cfg.count = 10
+        assert cfg.is_dirty
+        assert cfg.dirty_fields == frozenset({"count"})
+
+
+# ------------------------------------------------------------------
+# Change notes
+# ------------------------------------------------------------------
+
+
+class TestChangeNotes:
+    def test_no_notes_by_default(self):
+        cfg = TrackedConfig()
+        assert cfg.change_notes == []
+
+    def test_record_and_retrieve_note(self):
+        cfg = TrackedConfig()
+        cfg.name = "new"
+        cfg.record_change_note("name", "name was updated to 'new'")
+        assert cfg.change_notes == ["name was updated to 'new'"]
+
+    def test_note_overwrites_previous_for_same_field(self):
+        cfg = TrackedConfig()
+        cfg.name = "a"
+        cfg.record_change_note("name", "first")
+        cfg.record_change_note("name", "second")
+        assert cfg.change_notes == ["second"]
+
+    def test_multiple_notes_for_different_fields(self):
+        cfg = TrackedConfig()
+        cfg.name = "x"
+        cfg.count = 1
+        cfg.record_change_note("name", "note-name")
+        cfg.record_change_note("count", "note-count")
+        assert set(cfg.change_notes) == {"note-name", "note-count"}
+
+    def test_include_caller_appends_tag(self):
+        cfg = TrackedConfig()
+        cfg.name = "x"
+        cfg.record_change_note("name", "updated", include_caller=True)
+        notes = cfg.change_notes
+        assert len(notes) == 1
+        assert notes[0].startswith("updated [")
+        assert "test_change_tracking.py:" in notes[0]
+
+
+# ------------------------------------------------------------------
+# log_changes
+# ------------------------------------------------------------------
+
+
+class TestLogChanges:
+    def test_log_changes_no_output_when_clean(self, caplog):
+        cfg = TrackedConfig()
+        with caplog.at_level(logging.INFO):
+            cfg.log_changes()
+        assert caplog.text == ""
+
+    def test_log_changes_includes_note(self, caplog):
+        cfg = TrackedConfig()
+        cfg.name = "x"
+        cfg.record_change_note("name", "name was updated")
+        with caplog.at_level(logging.INFO):
+            cfg.log_changes()
+        assert "name was updated" in caplog.text
+
+    def test_log_changes_shows_field_without_note(self, caplog):
+        cfg = TrackedConfig()
+        cfg.count = 99
+        with caplog.at_level(logging.INFO):
+            cfg.log_changes()
+        assert "count was modified" in caplog.text
+
+    def test_log_changes_mixes_notes_and_bare_fields(self, caplog):
+        cfg = TrackedConfig()
+        cfg.name = "y"
+        cfg.count = 5
+        cfg.record_change_note("name", "renamed to y")
+        with caplog.at_level(logging.INFO):
+            cfg.log_changes()
+        assert "renamed to y" in caplog.text
+        assert "count was modified" in caplog.text
+
+    def test_log_changes_header_contains_class_name(self, caplog):
+        cfg = TrackedConfig()
+        cfg.flag = True
+        with caplog.at_level(logging.INFO):
+            cfg.log_changes()
+        assert "TrackedConfig" in caplog.text
+
+
+# ------------------------------------------------------------------
+# Integration with ConfigMixin.from_yaml
+# ------------------------------------------------------------------
+
+
+class TestFromYamlIntegration:
+    def test_clean_after_from_yaml(self, tmp_path):
+        path = tmp_path / "config.yaml"
+        path.write_text("name: loaded\ncount: 42\nflag: true\n")
+        cfg = TrackedConfig.from_yaml(path)
+        assert cfg.name == "loaded"
+        assert not cfg.is_dirty
+        assert cfg.change_notes == []
+
+    def test_roundtrip_stays_clean(self, tmp_path):
+        path = tmp_path / "config.yaml"
+        orig = TrackedConfig(name="rt", count=7)
+        orig.to_yaml(path)
+        loaded = TrackedConfig.from_yaml(path)
+        assert not loaded.is_dirty
+
+
+# ------------------------------------------------------------------
+# Interaction with pydantic validate_assignment
+# ------------------------------------------------------------------
+
+
+class TestValidateAssignment:
+    """Verify that change tracking wraps *around* pydantic's validator."""
+
+    def test_valid_assignment_is_tracked(self):
+        cfg = TrackedConfig()
+        cfg.count = 7
+        assert cfg.count == 7
+        assert "count" in cfg.dirty_fields
+
+    def test_invalid_assignment_rejected_and_not_tracked(self):
+        cfg = TrackedConfig()
+        with pytest.raises(Exception):
+            cfg.count = "not-an-int"
+        assert cfg.count == 0
+        assert not cfg.is_dirty
+
+    def test_coerced_value_stored(self):
+        """Pydantic coerces compatible types (e.g. bool -> int); the coerced
+        value should be stored and tracked."""
+        cfg = TrackedConfig()
+        cfg.count = True  # coerced to 1
+        assert cfg.count == 1
+        assert "count" in cfg.dirty_fields
+
+
+# ------------------------------------------------------------------
+# ChangeTrackingMixin + MigrationMixin combined
+# ------------------------------------------------------------------
+
+
+@dataclass(config=ConfigDict(validate_assignment=True))
+class TrackedMigratingConfig(ChangeTrackingMixin, MigrationMixin, ConfigMixin):
+    """Mirrors real usage (e.g. ProjectConfig) where both mixins are active."""
+
+    name: str = "default"
+    count: int = 0
+    flag: bool = False
+
+
+class TestChangeTrackingWithMigrationMixin:
+    """Verify that validate_assignment works correctly when
+    ChangeTrackingMixin and MigrationMixin are combined (regression tests)."""
+
+    def test_valid_assignment_still_works(self):
+        cfg = TrackedMigratingConfig()
+        cfg.count = 42
+        assert cfg.count == 42
+        assert "count" in cfg.dirty_fields
+
+    def test_invalid_assignment_raises_validation_error(self):
+        cfg = TrackedMigratingConfig()
+        with pytest.raises(ValidationError):
+            cfg.count = "not-an-int"
+        assert cfg.count == 0
+        assert not cfg.is_dirty
+
+    def test_coercion_still_applied(self):
+        cfg = TrackedMigratingConfig()
+        cfg.count = True  # should be coerced to 1
+        assert cfg.count == 1
+        assert "count" in cfg.dirty_fields

--- a/tests/core/config/test_config_mixin.py
+++ b/tests/core/config/test_config_mixin.py
@@ -9,8 +9,8 @@
 from pathlib import Path
 
 import pytest
-from omegaconf import OmegaConf
 from pydantic.dataclasses import dataclass
+from dataclasses import field
 
 from deeplabcut.core.config import ConfigMixin
 
@@ -22,10 +22,153 @@ class ToyConfig(ConfigMixin):
     project_path: str = "DefaultProjectPath"
 
 
-def test_validate_dict_returns_dictconfig():
-    cfg = ToyConfig.validate_dict({"Task": "task", "project_path": ""})
-    assert OmegaConf.is_config(cfg)
-    assert cfg.Task == "task"
+@dataclass
+class NestedInner(ConfigMixin):
+    lr: float = 0.001
+    momentum: float = 0.9
+
+
+@dataclass
+class NestedOuter(ConfigMixin):
+    name: str = "outer"
+    inner: NestedInner | None = field(default_factory=NestedInner)
+
+
+# ------------------------------------------------------------------
+# Dict-like access protocol
+# ------------------------------------------------------------------
+
+
+class TestGetitem:
+    def test_getitem_returns_field_value(self):
+        cfg = ToyConfig(Task="t", project_path="/p")
+        assert cfg["Task"] == "t"
+        assert cfg["project_path"] == "/p"
+
+    def test_getitem_missing_key_raises_key_error(self):
+        cfg = ToyConfig()
+        with pytest.raises(KeyError):
+            cfg["nonexistent"]
+
+
+class TestSetitem:
+    def test_setitem_updates_field(self):
+        cfg = ToyConfig()
+        cfg["Task"] = "new_task"
+        assert cfg.Task == "new_task"
+        assert cfg["Task"] == "new_task"
+
+    def test_setitem_unknown_field_raises_key_error(self):
+        cfg = ToyConfig()
+        with pytest.raises(KeyError, match="no field"):
+            cfg["nonexistent"] = 42
+
+
+class TestContains:
+    def test_contains_existing_field(self):
+        cfg = ToyConfig()
+        assert "Task" in cfg
+        assert "project_path" in cfg
+
+    def test_contains_missing_field(self):
+        cfg = ToyConfig()
+        assert "nonexistent" not in cfg
+
+    def test_contains_non_string_returns_false(self):
+        cfg = ToyConfig()
+        assert 42 not in cfg
+
+
+class TestGet:
+    def test_get_existing_key(self):
+        cfg = ToyConfig(Task="hello")
+        assert cfg.get("Task") == "hello"
+
+    def test_get_missing_key_returns_default(self):
+        cfg = ToyConfig()
+        assert cfg.get("nonexistent") is None
+        assert cfg.get("nonexistent", 42) == 42
+
+
+class TestKeysValuesItems:
+    def test_keys(self):
+        cfg = ToyConfig(Task="t", project_path="/p")
+        assert cfg.keys() == ["Task", "project_path"]
+
+    def test_values(self):
+        cfg = ToyConfig(Task="t", project_path="/p")
+        assert cfg.values() == ["t", "/p"]
+
+    def test_items(self):
+        cfg = ToyConfig(Task="t", project_path="/p")
+        assert cfg.items() == [("Task", "t"), ("project_path", "/p")]
+
+
+class TestIterAndLen:
+    def test_iter_yields_keys(self):
+        cfg = ToyConfig()
+        assert list(cfg) == ["Task", "project_path"]
+
+    def test_len(self):
+        cfg = ToyConfig()
+        assert len(cfg) == 2
+
+    def test_dict_constructor(self):
+        cfg = ToyConfig(Task="t", project_path="/p")
+        d = dict(cfg.items())
+        assert d == {"Task": "t", "project_path": "/p"}
+
+
+# ------------------------------------------------------------------
+# select() utility
+# ------------------------------------------------------------------
+
+
+class TestSelect:
+    def test_select_single_level(self):
+        cfg = ToyConfig(Task="t")
+        assert cfg.select("Task") == "t"
+
+    def test_select_nested_config(self):
+        cfg = NestedOuter(name="outer", inner=NestedInner(lr=0.01))
+        assert cfg.select("inner.lr") == 0.01
+        assert cfg.select("inner.momentum") == 0.9
+
+    def test_select_missing_returns_default(self):
+        cfg = ToyConfig()
+        assert cfg.select("nonexistent") is None
+        assert cfg.select("nonexistent", "fallback") == "fallback"
+
+    def test_select_deep_missing_returns_default(self):
+        cfg = NestedOuter()
+        assert cfg.select("inner.nonexistent") is None
+        assert cfg.select("nope.deep.path", 0) == 0
+
+    def test_select_none_intermediate(self):
+        cfg = NestedOuter(inner=None)
+        assert cfg.select("inner.lr") is None
+
+
+# ------------------------------------------------------------------
+# validate_dict
+# ------------------------------------------------------------------
+
+
+class TestValidateDict:
+    def test_validate_dict_returns_instance(self):
+        cfg = ToyConfig.validate_dict({"Task": "task", "project_path": ""})
+        assert isinstance(cfg, ToyConfig)
+        assert cfg.Task == "task"
+
+    def test_validate_dict_rejects_extra_keys(self):
+        """ToyConfig has no extra='forbid', so extra keys are just ignored."""
+        cfg = ToyConfig.validate_dict({"Task": "ok", "project_path": "", "extra": 1})
+        assert cfg.Task == "ok"
+
+
+# ------------------------------------------------------------------
+# from_dict / from_any / from_yaml / to_dict / to_yaml
+# ------------------------------------------------------------------
 
 
 def test_from_dict_returns_instance():
@@ -58,6 +201,16 @@ def test_from_any_with_dict_returns_instance():
     assert cfg.Task == "y"
 
 
+def test_from_any_with_dictconfig_emits_deprecation_warning():
+    from omegaconf import OmegaConf
+
+    dc = OmegaConf.create({"Task": "z", "project_path": "/dc"})
+    with pytest.warns(DeprecationWarning, match="DictConfig is deprecated"):
+        cfg = ToyConfig.from_any(dc)
+    assert isinstance(cfg, ToyConfig)
+    assert cfg.Task == "z"
+
+
 def test_from_any_with_invalid_type_raises():
     with pytest.raises(TypeError, match="Expected.*Got <class 'int'>"):
         ToyConfig.from_any(42)
@@ -78,9 +231,12 @@ def test_to_dict_returns_dict():
     assert d["Task"] == "t"
 
 
-def test_to_dictconfig_returns_dictconfig():
-    cfg = ToyConfig.from_dict({"Task": "t", "project_path": ""})
-    dc = cfg.to_dictconfig()
+def test_to_dictconfig_emits_deprecation_warning():
+    from omegaconf import OmegaConf
+
+    cfg = ToyConfig(Task="t", project_path="")
+    with pytest.warns(DeprecationWarning, match="to_dictconfig.*deprecated"):
+        dc = cfg.to_dictconfig()
     assert OmegaConf.is_config(dc)
     assert dc.Task == "t"
 


### PR DESCRIPTION
This PR is part of the WIP for migrating from dictionary configs to typed & validated configurations (see https://github.com/DeepLabCut/DeepLabCut/issues/3193 for an overview).


**Changes**
- `read_config`: returns pure ProjectConfig instead of validated DictConfig
- `make_pose_config`: returns pure PoseConfig instead of validated DictConfig
- `ConfigMixin`: added dict-like functionality: `get`, `__getitem__`, `keys`, `values` methods and `select` method for dot-path access into config, returning default value if None or non-existent.
- Extensive testing for ConfigMixin dict functionality
- Removed references to DictConfig in pipeline, such as type comparisons  `isinstance(obj, DictConfig)` and type hints for configs.