### PR TITLE
[dev] C3-II Additional refactoring of configurations 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,11 +7,6 @@ sphinx:
   config:
     autodoc_mock_imports: ["wx", "matplotlib", "qtpy", "PySide6", "napari", "shiboken6"]
     mermaid_output_format: raw
-    exclude_patterns:
-      - ".venv/**"
-      - "venv/**"
-      - "**/site-packages/**"
-      - "**/_build/**"
   extra_extensions:
     - numpydoc
     - sphinxcontrib.mermaid

--- a/_toc.yml
+++ b/_toc.yml
@@ -1,12 +1,10 @@
 format: jb-book
 root: README
-
 parts:
 - caption: Getting Started
   chapters:
   - file: docs/UseOverviewGuide
   - file: docs/course
-
 - caption: Installation
   chapters:
   - file: docs/installation
@@ -19,52 +17,50 @@ parts:
   - file: docs/maDLC_UserGuide
   - file: docs/Overviewof3D
   - file: docs/HelperFunctions
-
+  
 - caption: Graphical User Interfaces (GUIs)
   chapters:
   - file: docs/gui/PROJECT_GUI
   - file: docs/gui/napari_GUI
-
 - caption: DLC3 PyTorch Specific Docs
   chapters:
   - file: docs/pytorch/user_guide.md
   - file: docs/pytorch/pytorch_config.md
   - file: docs/pytorch/architectures.md
-
 - caption: Quick Start Tutorials
   chapters:
   - file: docs/quick-start/single_animal_quick_guide
   - file: docs/quick-start/tutorial_maDLC
-
-- caption: "🚀 Beginner's Guide to DeepLabCut"
+- caption: 🚀 Beginner's Guide to DeepLabCut
   chapters:
   - file: docs/beginner-guides/beginners-guide
   - file: docs/beginner-guides/manage-project
   - file: docs/beginner-guides/labeling
   - file: docs/beginner-guides/Training-Evaluation
   - file: docs/beginner-guides/video-analysis
-
-- caption: "🚀 Main Demo Notebooks"
+- caption: 🚀 Main Demo Notebooks
   chapters:
   - file: examples/COLAB/COLAB_DEMO_SuperAnimal
   - file: examples/COLAB/COLAB_DEMO_mouse_openfield
   - file: examples/COLAB/COLAB_3miceDemo
   - file: examples/COLAB/COLAB_HumanPose_with_RTMPose
 
-- caption: "🚀 Notebooks For Your Data"
+
+  
+- caption: 🚀 Notebooks For Your Data
   chapters:
   - file: examples/COLAB/COLAB_YOURDATA_SuperAnimal
   - file: examples/COLAB/COLAB_YOURDATA_TrainNetwork_VideoAnalysis
   - file: examples/COLAB/COLAB_YOURDATA_maDLC_TrainNetwork_VideoAnalysis
 
-- caption: "🚀 Special Feature Demos"
+- caption: 🚀 Special Feature Demos
   chapters:
   - file: examples/COLAB/COLAB_transformer_reID
   - file: examples/COLAB/COLAB_BUCTD_and_CTD_tracking
   - file: examples/JUPYTER/Demo_3D_DeepLabCut
   - file: examples/COLAB/COLAB_DLC_ModelZoo
 
-- caption: "🧑‍🍳 Cookbook (detailed helper guides)"
+- caption: 🧑‍🍳 Cookbook (detailed helper guides)
   chapters:
   - file: docs/convert_maDLC
   - file: docs/recipes/OtherData
@@ -82,12 +78,10 @@ parts:
 - caption: Hardware Tips
   chapters:
   - file: docs/recipes/TechHardware
-
 - caption: DeepLabCut-Live!
   chapters:
   - file: docs/deeplabcutlive
-
-- caption: "🦄 DeepLabCut Model Zoo"
+- caption: 🦄 DeepLabCut Model Zoo
   chapters:
   - file: docs/ModelZoo
   - file: docs/recipes/UsingModelZooPupil
@@ -97,7 +91,7 @@ parts:
   - file: docs/benchmark
   - file: docs/pytorch/Benchmarking_shuffle_guide
 
-- caption: "Mission & Contribute"
+- caption: Mission & Contribute
   chapters:
   - file: docs/MISSION_AND_VALUES
   - file: docs/roadmap

--- a/deeplabcut/core/config/project_config.py
+++ b/deeplabcut/core/config/project_config.py
@@ -168,6 +168,9 @@ class ProjectConfig(ConfigMixin):
         metadata={"comment": "\nConversion tables to fine-tune SuperAnimal weights"},
     )
 
+    # @TODO @deruyter92 2026-02-13: These aliases are used in parallel. One of them should be removed.
+    with_identity: bool | None = field(default=False, metadata={"comment": "Alias for 'identity'. Kept for backwards compatibility."})
+
     # TODO @deruyter92 2026-02-06: These parameters are no longer used in the new pipeline.
     resnet: int | None = field(
         default=None,

--- a/deeplabcut/core/config/project_config.py
+++ b/deeplabcut/core/config/project_config.py
@@ -170,6 +170,7 @@ class ProjectConfig(ConfigMixin):
 
     # @TODO @deruyter92 2026-02-13: These aliases are used in parallel. One of them should be removed.
     with_identity: bool | None = field(default=False, metadata={"comment": "Alias for 'identity'. Kept for backwards compatibility."})
+    unique_bodyparts: list[str] = field(default_factory=list, metadata={"comment": "Alias for 'uniquebodyparts'. Kept for backwards compatibility."})
 
     # TODO @deruyter92 2026-02-06: These parameters are no longer used in the new pipeline.
     resnet: int | None = field(

--- a/deeplabcut/core/config/project_config.py
+++ b/deeplabcut/core/config/project_config.py
@@ -97,7 +97,10 @@ class ProjectConfig(ConfigMixin):
     # VV TODO @deruyter92 2026-01-30: following the old original config.yaml template for now. VV
     # VV We should change this to a list[str] in the future. VV
     bodyparts: list[str] | str = 'MULTI!' 
-    individuals: list[str] = field(default_factory=list)
+
+    # TODO @deruyter92 2026-02-06: The current pipeline requires at least one individual defined in the 
+    # default configuration. This will be removed in the future.
+    individuals: list[str] = field(default_factory=lambda: ['individual_1']) 
     uniquebodyparts: list[str] = field(default_factory=list)  # multi-animal project key
     multianimalbodyparts: list[str] = field(
         default_factory=list
@@ -164,6 +167,16 @@ class ProjectConfig(ConfigMixin):
         default=None,
         metadata={"comment": "\nConversion tables to fine-tune SuperAnimal weights"},
     )
+
+    # TODO @deruyter92 2026-02-06: These parameters are no longer used in the new pipeline.
+    resnet: int | None = field(
+        default=None,
+        metadata={
+        "comment": "\nThese are very old parameters that are no longer used "
+        "in most cases. They are kept for backwards compatibility."
+        },
+    )
+    croppedtraining: bool | None = None
 
     @classmethod
     def from_yaml(cls, yaml_path: str | Path, *args, **kwargs) -> Self:

--- a/deeplabcut/core/config/project_config.py
+++ b/deeplabcut/core/config/project_config.py
@@ -12,6 +12,8 @@
 
 from typing import Any
 from pathlib import Path
+from typing_extensions import Self
+import warnings
 
 from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass
@@ -162,3 +164,23 @@ class ProjectConfig(ConfigMixin):
         default=None,
         metadata={"comment": "\nConversion tables to fine-tune SuperAnimal weights"},
     )
+
+    @classmethod
+    def from_yaml(cls, yaml_path: str | Path, *args, **kwargs) -> Self:
+        """
+            Overrides the from_yaml method to update the project path if the yaml file
+            is not in the same directory as the project path.
+        """
+        # NOTE @deruyter92 2026-02-06: This replicates prior behaviour of adjusting the project path
+        # when reading the config file. Note that we do not write the config file back to the file system.
+        cfg = super().from_yaml(yaml_path, *args, **kwargs)
+        project_path = Path(yaml_path).parent
+        if project_path.resolve() != cfg.project_path.resolve():
+            warnings.warn(
+                f"Project path {yaml_path} is not the in the same directory as the project_path defined "
+                "in the yaml file {cfg.project_path}. This may cause issues with loading the project. "
+                "Updating the project path internally to the parent directory of the yaml file. The file "
+                "itself will not be updated."
+            )
+            cfg.project_path = project_path
+        return cfg

--- a/deeplabcut/core/config/project_config.py
+++ b/deeplabcut/core/config/project_config.py
@@ -13,13 +13,14 @@
 from typing import Any
 from pathlib import Path
 
+from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass
 from dataclasses import field
 
 from deeplabcut.core.config.config_mixin import ConfigMixin
 
 
-@dataclass
+@dataclass(config=ConfigDict(extra="forbid"))
 class ProjectConfig(ConfigMixin):
     """Complete project configuration.
 

--- a/deeplabcut/core/config/utils.py
+++ b/deeplabcut/core/config/utils.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 import yaml
 import ruamel.yaml.representer
 from ruamel.yaml import YAML
-from omegaconf import DictConfig
+from omegaconf import DictConfig, ListConfig
 from pydantic import ValidationError
 
 from deeplabcut.core.engine import Engine
@@ -46,6 +46,15 @@ def get_yaml_dumper() -> YAML:
     yaml.representer.add_multi_representer(
         Enum,
         lambda r, e: r.represent_str(e.value)
+    )
+    # OmegaConf containers -> plain dict/list so ruamel can serialize them
+    yaml.representer.add_representer(
+        DictConfig,
+        lambda r, d: r.represent_dict(dict(d))
+    )
+    yaml.representer.add_representer(
+        ListConfig,
+        lambda r, l: r.represent_list(list(l))
     )
     return yaml
 

--- a/deeplabcut/core/config/utils.py
+++ b/deeplabcut/core/config/utils.py
@@ -17,6 +17,8 @@ from typing import TYPE_CHECKING, Callable
 from pathlib import PurePath
 from enum import Enum
 
+from omegaconf import DictConfig
+
 if TYPE_CHECKING:
     from deeplabcut.core.config.project_config import ProjectConfig, ProjectConfig3D
 
@@ -124,7 +126,7 @@ def pretty_print(
         print_fn = print
 
     for k, v in config.items():
-        if isinstance(v, dict):
+        if isinstance(v, (dict, DictConfig)):
             print_fn(f"{indent * ' '}{k}:")
             pretty_print(v, indent + 2, print_fn=print_fn)
         else:

--- a/deeplabcut/core/config/utils.py
+++ b/deeplabcut/core/config/utils.py
@@ -38,6 +38,14 @@ def get_yaml_loader() -> YAML:
 def get_yaml_dumper() -> YAML:
     """Get a ruamel.yaml YAML handler with representers for Enum and Path objects."""
     yaml = YAML(typ="rt", pure=True)
+
+    # Use a very large width so long strings (e.g., file paths or keys with spaces)
+    # are kept on a single line instead of being wrapped, which can otherwise cause
+    # them to be emitted as complex keys. See also:
+    # https://stackoverflow.com/questions/31197268/pyyaml-yaml-dump-produces-complex-key-for-string-key-122-chars/31199123#31199123
+    # See PR https://github.com/DeepLabCut/DeepLabCut/pull/3140 for more details.
+    yaml.width = 1_000_000
+
     # Auto-serialize Path objects as strings
     yaml.representer.add_multi_representer(
         PurePath,

--- a/deeplabcut/core/weight_init.py
+++ b/deeplabcut/core/weight_init.py
@@ -107,6 +107,10 @@ class WeightInitialization(ConfigMixin):
         if "snapshot_path" not in data:
             return WeightInitialization.from_dict_legacy(data)
 
+        snapshot_path = data['snapshot_path']
+        if data['snapshot_path'] is not None:
+            snapshot_path = Path(snapshot_path)
+
         detector_snapshot_path = data.get("detector_snapshot_path")
         if detector_snapshot_path is not None:
             detector_snapshot_path = Path(detector_snapshot_path)
@@ -116,7 +120,7 @@ class WeightInitialization(ConfigMixin):
             conversion_array = np.array(conversion_array, dtype=int)
 
         return WeightInitialization(
-            snapshot_path=Path(data["snapshot_path"]),
+            snapshot_path=snapshot_path,
             detector_snapshot_path=detector_snapshot_path,
             dataset=data.get("dataset"),
             with_decoder=data["with_decoder"],

--- a/deeplabcut/generate_training_dataset/metadata.py
+++ b/deeplabcut/generate_training_dataset/metadata.py
@@ -18,8 +18,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
-from ruamel.yaml import YAML
 
+from deeplabcut.core.config.utils import get_yaml_loader, get_yaml_dumper
 from deeplabcut.core.engine import Engine
 from deeplabcut.utils import auxiliaryfunctions
 
@@ -231,7 +231,7 @@ class TrainingDatasetMetadata:
 
         with open(self.path(self.project_config), "w") as file:
             file.write("\n".join(self.file_header) + "\n")
-            YAML().dump(metadata, file)
+            get_yaml_dumper().dump(metadata, file)
 
     @staticmethod
     def load(
@@ -251,7 +251,7 @@ class TrainingDatasetMetadata:
 
         metadata_path = TrainingDatasetMetadata.path(cfg)
         with open(metadata_path, "r") as file:
-            metadata = YAML(typ="safe", pure=True).load(file)
+            metadata = get_yaml_loader().load(file)
 
         shuffles = []
         for shuffle_name, shuffle_metadata in metadata["shuffles"].items():

--- a/deeplabcut/gui/tabs/create_training_dataset.py
+++ b/deeplabcut/gui/tabs/create_training_dataset.py
@@ -81,8 +81,10 @@ class CreateTrainingDataset(DefaultTab):
         self.main_layout.addWidget(self.help_button, alignment=Qt.AlignLeft)
 
     def set_edit_table_visibility(self) -> None:
+        # TODO @deruyter92: This pattern should be refactored throughout the codebase
+        # it is reading a config value that is supposed to be missing / None.
         has_conversion_tables = bool(
-            self.root.cfg.get("SuperAnimalConversionTables", {})
+            self.root.cfg.get("SuperAnimalConversionTables") or {}
         )
         is_pytorch_engine = self.root.engine == Engine.PYTORCH
         is_finetuning = self.weight_init_selector.with_decoder

--- a/deeplabcut/modelzoo/utils.py
+++ b/deeplabcut/modelzoo/utils.py
@@ -161,8 +161,10 @@ def get_conversion_table(cfg: dict | str | Path, super_animal: str) -> Conversio
     if isinstance(cfg, (str, Path)):
         cfg = read_config(str(cfg))
 
-    conversion_tables = cfg.get("SuperAnimalConversionTables", {})
-    if conversion_tables is None or super_animal not in conversion_tables:
+    # TODO @deruyter92: This pattern should be refactored throughout the codebase
+    # it is reading a config value that is supposed to be missing / None.
+    conversion_tables = cfg.get("SuperAnimalConversionTables") or {}
+    if not conversion_tables or super_animal not in conversion_tables:
         raise ValueError(
             f"No conversion table defined in the project config for {super_animal}."
             "Call deeplabcut.modelzoo.create_conversion_table to create one."

--- a/deeplabcut/modelzoo/video_inference.py
+++ b/deeplabcut/modelzoo/video_inference.py
@@ -396,6 +396,8 @@ def video_inference_superanimal(
             superanimal_name, pose_model_path, detector_path, torchvision_detector_name
         )
 
+        # TODO @deruyter92: This is currently not validated against the PoseConfig schema.
+        # We should create the validated config (with override arguments) in an early stage.
         config = update_config(config, max_individuals, device)
 
         output_suffix = "_before_adapt"

--- a/deeplabcut/modelzoo/webapp/inference.py
+++ b/deeplabcut/modelzoo/webapp/inference.py
@@ -80,6 +80,8 @@ class SuperanimalPyTorchInference:
             model_name=pose_model_type,
             detector_name=detector_model_type,
         )
+        # TODO @deruyter92: super animal configs are currently not 
+        # validated against the pydantic schema. We should add this functionality.
         config = update_config(config, max_individuals, device)
         self._config = config
 

--- a/deeplabcut/pose_estimation_pytorch/apis/analyze_images.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/analyze_images.py
@@ -195,6 +195,8 @@ def superanimal_analyze_images(
     else:
         config = copy.deepcopy(customized_model_config)
 
+    # TODO @deruyter92: This is currently not validated against the pydantic schema.
+    # We should add this functionality (and do updates in an early stage).
     config = update_config(config, max_individuals, device)
     config["metadata"]["individuals"] = [f"animal{i}" for i in range(max_individuals)]
     if config.get("detector") is not None:

--- a/deeplabcut/pose_estimation_pytorch/apis/analyze_images.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/analyze_images.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
+from omegaconf import DictConfig
 from tqdm import tqdm
 
 import deeplabcut.core.config as config_utils
@@ -333,7 +334,8 @@ def analyze_images(
                 condition_cfg=model_cfg["inference"]["conditions"],
                 config=config,
             )
-        elif isinstance(ctd_conditions, dict):
+        # TODO @deruyter92: decide on typed / plain dict
+        elif isinstance(ctd_conditions, (dict, DictConfig)):
             cond_provider = get_condition_provider(
                 condition_cfg=ctd_conditions,
                 config=config,
@@ -469,7 +471,8 @@ def analyze_image_folder(
     Raises:
         ValueError: if the pose model is a top-down model but no detector path is given
     """
-    if not isinstance(model_cfg, dict):
+    # TODO @deruyter92: decide on typed / plain dict
+    if not isinstance(model_cfg, (dict, DictConfig)):
         model_cfg = config_utils.read_config_as_dict(model_cfg)
 
     pose_task = Task(model_cfg["method"])

--- a/deeplabcut/pose_estimation_pytorch/apis/ctd.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/ctd.py
@@ -12,6 +12,7 @@
 from pathlib import Path
 
 import numpy as np
+from omegaconf import DictConfig
 
 import deeplabcut.pose_estimation_pytorch.data as data
 from deeplabcut.pose_estimation_pytorch.data.ctd import (
@@ -48,7 +49,8 @@ def get_condition_provider(
             "want to use to generate conditions.\n"
         ) + error_message
         raise ValueError(error_message)
-    elif not isinstance(condition_cfg, dict):
+    # TODO @deruyter92: decide on typed / plain dict
+    elif not isinstance(condition_cfg, (dict, DictConfig)):
         raise ValueError(error_message)
 
     if config is not None:
@@ -117,7 +119,8 @@ def load_conditions_for_evaluation(
     if isinstance(condition_cfg, (str, Path)):
         condition_filepath = Path(condition_cfg)
         cond_provider = CondFromFile(filepath=condition_filepath)
-    elif isinstance(condition_cfg, dict):
+    # TODO @deruyter92: decide on typed / plain dict
+    elif isinstance(condition_cfg, (dict, DictConfig)):
         if isinstance(loader, data.DLCLoader) and "config" not in condition_cfg:
             condition_cfg["config"] = loader.project_root / "config.yaml"
 

--- a/deeplabcut/pose_estimation_pytorch/apis/evaluation.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/evaluation.py
@@ -653,11 +653,12 @@ def evaluate_snapshot(
 
         df_ground_truth = ensure_multianimal_df_format(loader.df)
 
+        # TODO @deruyter92: This pattern should be refactored throughout the codebase
+        # it is reading a config value that is supposed to be missing / None.
         bboxes_cutoff = (
-            loader.model_cfg.get("detector", {})
-            .get("model", {})
-            .get("box_score_thresh", 0.6)
-        )
+            (loader.model_cfg.get("detector") or {})
+            .get("model") or {}
+        ).get("box_score_thresh", 0.6)
 
         for mode in ["train", "test"]:
             df_combined = predictions[mode].merge(

--- a/deeplabcut/pose_estimation_pytorch/apis/evaluation.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/evaluation.py
@@ -18,6 +18,7 @@ import albumentations as A
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from omegaconf import DictConfig, ListConfig
 from tqdm import tqdm
 
 import deeplabcut.core.metrics as metrics
@@ -556,7 +557,8 @@ def evaluate_snapshot(
 
     if pcutoff is None:
         pcutoff = cfg.get("pcutoff", 0.6)
-    elif isinstance(pcutoff, dict):
+    # TODO @deruyter92: decide on typed / plain dict
+    elif isinstance(pcutoff, (dict, DictConfig)):
         pcutoff = [
             pcutoff.get(bpt, 0.6)
             for bpt in eval_parameters.bodyparts + eval_parameters.unique_bpts
@@ -575,7 +577,8 @@ def evaluate_snapshot(
         ),
         "pcutoff": (
             ", ".join([str(v) for v in pcutoff])
-            if isinstance(pcutoff, list)
+            # TODO @deruyter92: decide on typed / plain list
+            if isinstance(pcutoff, (list, ListConfig))
             else pcutoff
         ),
     }

--- a/deeplabcut/pose_estimation_pytorch/apis/export.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/export.py
@@ -196,5 +196,7 @@ def wipe_paths_from_model_config(model_cfg: dict) -> None:
         model_cfg["train_settings"]["weight_init"] = None
     if "resume_training_from" in model_cfg:
         model_cfg["resume_training_from"] = None
-    if "resume_training_from" in model_cfg.get("detector", {}):
+    # TODO @deruyter92: This pattern should be refactored throughout the codebase
+    # it is reading a config value that is supposed to be missing / None.
+    if "resume_training_from" in (model_cfg.get("detector") or {}):
         model_cfg["detector"]["resume_training_from"] = None

--- a/deeplabcut/pose_estimation_pytorch/apis/export.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/export.py
@@ -13,6 +13,7 @@ import copy
 from pathlib import Path
 
 import torch
+from omegaconf import DictConfig, OmegaConf
 
 import deeplabcut.pose_estimation_pytorch.apis.utils as utils
 import deeplabcut.pose_estimation_pytorch.data as dlc3_data
@@ -133,6 +134,11 @@ def export_model(
             model_cfg = copy.deepcopy(loader.model_cfg)
             if wipe_paths:
                 wipe_paths_from_model_config(model_cfg)
+
+            # Convert DictConfig to plain dict so torch.save doesn't pickle
+            # omegaconf types (which require weights_only=False to load)
+            if isinstance(model_cfg, DictConfig):
+                model_cfg = OmegaConf.to_container(model_cfg, resolve=True)
 
             pose_weights = torch.load(snapshot.path, **load_kwargs)["model"]
             export_dict = dict(config=model_cfg, pose=pose_weights)

--- a/deeplabcut/pose_estimation_pytorch/apis/prune_paf_graph.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/prune_paf_graph.py
@@ -146,6 +146,9 @@ def benchmark_paf_graphs(
             print(f"|   edges: {best_edges}")
             print()
 
+        # TODO @deruyter92: Mid-way updates of the config are not ideal.
+        # We should validate this against the pydantic schema.
+        
         # update the edges to keep in the PyTorch configuration file
         loader.update_model_cfg(
             {"model.heads.bodypart.predictor.edges_to_keep": best_edges}

--- a/deeplabcut/pose_estimation_pytorch/apis/prune_paf_graph.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/prune_paf_graph.py
@@ -291,7 +291,7 @@ def get_n_best_paf_graphs(
     order = order[np.isin(order, root_edges, invert=True)]
     best_edges = [root_edges]
     for length in lengths:
-        best_edges.append(root_edges + list(order[:length]))
+        best_edges.append(root_edges + order[:length].tolist())
 
     model.heads.bodypart.predictor.return_preds = return_preds
     return best_edges, dict(zip(existing_edges, scores))

--- a/deeplabcut/pose_estimation_pytorch/apis/tracking_dataset.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/tracking_dataset.py
@@ -49,7 +49,9 @@ def build_feature_extraction_runner(
     if top_down:
         rescale_mode = postprocessing.RescaleAndOffset.Mode.KEYPOINT_TD
         data_cfg = loader.model_cfg["data"]["inference"]
-        crop_cfg = data_cfg.get("top_down_crop", {})
+        # TODO @deruyter92: This pattern should be refactored throughout the codebase
+        # it is reading a config value that is supposed to be missing / None.
+        crop_cfg = data_cfg.get("top_down_crop") or {}
         width, height = crop_cfg.get("width", 256), crop_cfg.get("height", 256)
         preprocessor = data.build_top_down_preprocessor(
             color_mode=loader.model_cfg["data"]["colormode"],

--- a/deeplabcut/pose_estimation_pytorch/apis/training.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/training.py
@@ -167,9 +167,11 @@ def train(
     )
     valid_dataloader = DataLoader(valid_dataset, batch_size=1, shuffle=False)
 
+    # TODO @deruyter92: This pattern should be refactored throughout the codebase
+    # it is reading a config value that is supposed to be missing / None.
     if (
         loader.model_cfg["model"].get("freeze_bn_stats", False)
-        or loader.model_cfg["model"].get("backbone", {}).get("freeze_bn_stats", False)
+        or (loader.model_cfg["model"].get("backbone") or {}).get("freeze_bn_stats", False)
         or batch_size == 1
     ):
         logging.info(

--- a/deeplabcut/pose_estimation_pytorch/apis/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/utils.py
@@ -566,7 +566,9 @@ def get_inference_runners(
             with_identity=with_identity,
         )
     else:
-        crop_cfg = model_config["data"]["inference"].get("top_down_crop", {})
+        # TODO @deruyter92: This pattern should be refactored throughout the codebase
+        # it is reading a config value that is supposed to be missing / None.
+        crop_cfg = model_config["data"]["inference"].get("top_down_crop") or {}
         width, height = crop_cfg.get("width", 256), crop_cfg.get("height", 256)
         margin = crop_cfg.get("margin", 0)
         if pose_task == Task.COND_TOP_DOWN:
@@ -914,7 +916,9 @@ def get_pose_inference_runner(
             with_identity=with_identity,
         )
     else:
-        crop_cfg = model_config["data"]["inference"].get("top_down_crop", {})
+        # TODO @deruyter92: This pattern should be refactored throughout the codebase
+        # it is reading a config value that is supposed to be missing / None.
+        crop_cfg = model_config["data"]["inference"].get("top_down_crop") or {}
         width, height = crop_cfg.get("width", 256), crop_cfg.get("height", 256)
         margin = crop_cfg.get("margin", 0)
 

--- a/deeplabcut/pose_estimation_pytorch/apis/videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/videos.py
@@ -21,6 +21,7 @@ import albumentations as A
 import numpy as np
 import pandas as pd
 import torch
+from omegaconf import DictConfig
 from tqdm import tqdm
 
 import deeplabcut.pose_estimation_pytorch.apis.utils as utils
@@ -494,7 +495,8 @@ def analyze_videos(
                 condition_cfg=loader.model_cfg["inference"]["conditions"],
                 config=config,
             )
-        elif isinstance(ctd_conditions, dict):
+        # TODO @deruyter92: decide on typed / plain dict
+        elif isinstance(ctd_conditions, (dict, DictConfig)):
             cond_provider = get_condition_provider(
                 condition_cfg=ctd_conditions,
                 config=config,
@@ -502,7 +504,8 @@ def analyze_videos(
         else:
             cond_provider = ctd_conditions
 
-    if isinstance(ctd_tracking, dict):
+    # TODO @deruyter92: decide on typed / plain dict
+    if isinstance(ctd_tracking, (dict, DictConfig)):
         # FIXME(niels) - add video FPS setting
         ctd_tracking = CTDTrackingConfig.build(ctd_tracking)
 

--- a/deeplabcut/pose_estimation_pytorch/apis/visualization.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/visualization.py
@@ -324,9 +324,11 @@ def extract_maps(
         bpt_names = metadata["bodyparts"] + metadata["unique_bodyparts"]
         paf_graph = []
         bpt_head_cfg = loader.model_cfg["model"]["heads"]["bodypart"]
+        # TODO @deruyter92: This pattern should be refactored throughout the codebase
+        # it is reading a config value that is supposed to be missing / None.
         if bpt_head_cfg["type"] == "DLCRNetHead":
-            paf_graph = bpt_head_cfg.get("predictor", {}).get("graph")
-            paf_indices = bpt_head_cfg.get("predictor", {}).get("edges_to_keep")
+            paf_graph = (bpt_head_cfg.get("predictor") or {}).get("graph")
+            paf_indices = (bpt_head_cfg.get("predictor") or {}).get("edges_to_keep")
             if paf_indices is not None:
                 paf_graph = [paf_graph[i] for i in paf_indices]
 

--- a/deeplabcut/pose_estimation_pytorch/config/data.py
+++ b/deeplabcut/pose_estimation_pytorch/config/data.py
@@ -123,7 +123,6 @@ class GenSamplingConfig(ConfigMixin):
     """Configuration for CTD models.
 
     Args:
-        bbox_margin: The margin added around conditional keypoints
         keypoint_sigmas: The sigma for each keypoint.
         keypoints_symmetry: Indices of symmetric keypoints (e.g. left/right eye)
         jitter_prob: The probability of applying jitter. Jitter error is defined as
@@ -138,7 +137,6 @@ class GenSamplingConfig(ConfigMixin):
             large displacement from the GT keypoint position.
     """
 
-    bbox_margin: int
     keypoint_sigmas: float | list[float] = 0.1
     keypoints_symmetry: list[tuple[int, int]] | None = None
     jitter_prob: float = 0.16

--- a/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
+++ b/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
@@ -16,18 +16,17 @@ from pathlib import Path
 
 from omegaconf import DictConfig
 
-from deeplabcut.core.config import read_config_as_dict, write_config
+from deeplabcut.core.config import read_config_as_dict
 from deeplabcut.core.weight_init import WeightInitialization
 from deeplabcut.pose_estimation_pytorch.config.utils import (
     get_config_folder_path,
     load_backbones,
-    load_base_config,
     replace_default_values,
     update_config,
 )
 from deeplabcut.core.config.project_config import ProjectConfig
 from deeplabcut.pose_estimation_pytorch.config.inference import InferenceConfig
-from deeplabcut.pose_estimation_pytorch.config.pose import PoseConfig, NetType
+from deeplabcut.pose_estimation_pytorch.config.pose import PoseConfig, TestConfig, NetType
 from deeplabcut.pose_estimation_pytorch.task import Task
 from deeplabcut.utils import auxiliaryfunctions, auxfun_multianimal
 
@@ -319,7 +318,7 @@ def make_pytorch_test_config(
     unique_bodyparts = model_config["metadata"]["unique_bodyparts"]
     all_joint_names = bodyparts + unique_bodyparts
 
-    test_config = dict(
+    test_config = TestConfig(
         dataset=model_config["metadata"]["project_path"],
         dataset_type="multi-animal-imgaug",  # required for downstream tracking
         num_joints=len(all_joint_names),
@@ -330,9 +329,9 @@ def make_pytorch_test_config(
         scoremap_dir="test",
     )
     if save:
-        write_config(test_config_path, test_config)
+        test_config.to_yaml(test_config_path, overwrite=True)
 
-    return test_config
+    return test_config.to_dict()
 
 
 def make_basic_project_config(

--- a/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
+++ b/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
@@ -218,6 +218,10 @@ def make_pytorch_pose_config(
     # Initialize ProjectConfig (convert to DictConfig if needed)
     project_config: DictConfig = ProjectConfig.from_any(project_config).to_dictconfig()
     project_config.pose_config_path = pose_config_path
+
+    # @TODO @deruyter92 2026-02-13: This is a temporary fix to allow backwards compatibility. 
+    # This should be resolved by migrating to V1 project config.
+    project_config.with_identity = project_config.identity
     
     # Initialize PoseConfig as DictConfig
     pose_config = PoseConfig().to_dictconfig()

--- a/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
+++ b/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
@@ -21,11 +21,14 @@ from deeplabcut.core.weight_init import WeightInitialization
 from deeplabcut.pose_estimation_pytorch.config.utils import (
     get_config_folder_path,
     load_backbones,
+    load_base_config,
     replace_default_values,
     update_config,
 )
 from deeplabcut.core.config.project_config import ProjectConfig
 from deeplabcut.pose_estimation_pytorch.config.inference import InferenceConfig
+from deeplabcut.pose_estimation_pytorch.config.training import TrainSettingsConfig
+from deeplabcut.pose_estimation_pytorch.config.runner import RunnerConfig
 from deeplabcut.pose_estimation_pytorch.config.pose import PoseConfig, TestConfig, NetType
 from deeplabcut.pose_estimation_pytorch.task import Task
 from deeplabcut.utils import auxiliaryfunctions, auxfun_multianimal
@@ -91,7 +94,7 @@ def _load_pose_config_defaults(
         net_type = project_config.get("default_net_type", "resnet_50")
 
     configs_dir = get_config_folder_path()
-
+    base_cfg = load_base_config(configs_dir)
     backbones = load_backbones(configs_dir)
     if net_type in backbones:
         if not top_down and multianimal_project:
@@ -139,6 +142,7 @@ def _load_pose_config_defaults(
     aug_cfg = {"data": read_config_as_dict(configs_dir / "base" / aug_filename)}
 
     model_cfg = update_config(model_cfg, aug_cfg)
+    model_cfg = update_config(base_cfg, model_cfg)
 
     # add a unique bodypart head if needed
     if len(unique_bpts) > 0:
@@ -216,7 +220,7 @@ def make_pytorch_pose_config(
         the PyTorch pose configuration file
     """
     # Initialize ProjectConfig (convert to DictConfig if needed)
-    project_config: DictConfig = ProjectConfig.from_any(project_config).to_dictconfig()
+    project_config = ProjectConfig.from_any(project_config)
     project_config.pose_config_path = pose_config_path
 
     # @TODO @deruyter92 2026-02-13: This is a temporary fix to allow backwards compatibility. 
@@ -227,21 +231,21 @@ def make_pytorch_pose_config(
     project_config.unique_bodyparts = project_config.uniquebodyparts
     
     # Initialize PoseConfig as DictConfig
-    pose_config = PoseConfig().to_dictconfig()
-    pose_config.metadata = project_config
-    pose_config.net_type = NetType(net_type) if net_type is not None else None
-
-    # Add inference config and weight init configs
-    pose_config.inference = InferenceConfig().to_dictconfig()
     if weight_init is not None:
-        weight_init = WeightInitialization.from_any(weight_init).to_dictconfig()
-        pose_config.train_settings.weight_init = weight_init
+        weight_init = WeightInitialization.from_any(weight_init)
+
+    pose_config = PoseConfig(
+        net_type=NetType(net_type) if net_type is not None else None,
+        metadata=project_config,
+        train_settings=TrainSettingsConfig(weight_init=weight_init),
+        # runner=RunnerConfig(),
+    ).to_dictconfig()
 
     # Update default values for the specific model architecture and project config.
     # TODO @deruyter92 2026-02-04: using legacy v0 config (dict) for the defaults,
     # we should move to typed model defaults and use omegaconf merge to update
     defaults: dict = _load_pose_config_defaults(
-        project_config,
+        project_config.to_dict(),
         net_type,
         top_down,
         detector_type,

--- a/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
+++ b/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
@@ -222,6 +222,9 @@ def make_pytorch_pose_config(
     # @TODO @deruyter92 2026-02-13: This is a temporary fix to allow backwards compatibility. 
     # This should be resolved by migrating to V1 project config.
     project_config.with_identity = project_config.identity
+    if project_config.bodyparts == "MULTI!":
+        project_config.bodyparts = project_config.multianimalbodyparts
+    project_config.unique_bodyparts = project_config.uniquebodyparts
     
     # Initialize PoseConfig as DictConfig
     pose_config = PoseConfig().to_dictconfig()

--- a/deeplabcut/pose_estimation_pytorch/config/pose.py
+++ b/deeplabcut/pose_estimation_pytorch/config/pose.py
@@ -61,6 +61,16 @@ class NetType(str, Enum):
     TOP_DOWN_HRNET_W32 = "top_down_hrnet_w32"
     TOP_DOWN_HRNET_W48 = "top_down_hrnet_w48"
 
+    # CSPNeXt variants (bottom-up)
+    CSPNEXT_S = "cspnext_s"
+    CSPNEXT_M = "cspnext_m"
+    CSPNEXT_X = "cspnext_x"
+
+    # CSPNeXt variants (top-down)
+    TOP_DOWN_CSPNEXT_S = "top_down_cspnext_s"
+    TOP_DOWN_CSPNEXT_M = "top_down_cspnext_m"
+    TOP_DOWN_CSPNEXT_X = "top_down_cspnext_x"
+
     # DEKR variants (bottom-up with HRNet backbone)
     DEKR_W18 = "dekr_w18"
     DEKR_W32 = "dekr_w32"

--- a/deeplabcut/pose_estimation_pytorch/config/pose.py
+++ b/deeplabcut/pose_estimation_pytorch/config/pose.py
@@ -12,7 +12,7 @@
 
 from pydantic.dataclasses import dataclass
 from dataclasses import field
-from pydantic import Field
+from pydantic import Field, ConfigDict
 from enum import Enum
 
 from deeplabcut.core.config.config_mixin import ConfigMixin
@@ -99,7 +99,7 @@ class DetectorConfig(ConfigMixin):
     inference: InferenceConfig = field(default_factory=InferenceConfig)
 
 
-@dataclass
+@dataclass(config=ConfigDict(extra="forbid"))
 class PoseConfig(ConfigMixin):
     """Main configuration class for DeepLabCut pose estimation models.
 

--- a/deeplabcut/pose_estimation_pytorch/config/pose.py
+++ b/deeplabcut/pose_estimation_pytorch/config/pose.py
@@ -14,6 +14,7 @@ from pydantic.dataclasses import dataclass
 from dataclasses import field
 from pydantic import Field, ConfigDict
 from enum import Enum
+from pathlib import Path
 
 from deeplabcut.core.config.config_mixin import ConfigMixin
 from deeplabcut.core.config.project_config import ProjectConfig
@@ -89,6 +90,12 @@ class NetType(str, Enum):
     ANIMALTOKENPOSE_BASE = "animaltokenpose_base"
 
 
+class DatasetType(str, Enum):
+    """Enumeration of dataset types."""
+    # TODO @deruyter92 2026-02-05: Add other dataset types as needed.
+    MULTIANIMAL_IMGAUG = "multi-animal-imgaug"
+
+
 @dataclass
 class DetectorConfig(ConfigMixin):
     model: DetectorModelConfig
@@ -135,3 +142,32 @@ class PoseConfig(ConfigMixin):
     runner: RunnerConfig | None = None
     train_settings: TrainSettingsConfig | None = None
     detector: DetectorConfig | None = None
+
+
+@dataclass(config=ConfigDict(extra="forbid"))
+class TestConfig(ConfigMixin):
+    """Configuration class for DeepLabCut test/inference settings.
+
+    This configuration is used for downstream tracking and evaluation, containing
+    the essential metadata about joints and network architecture.
+
+    Attributes:
+        dataset: Path to the project/dataset.
+        dataset_type: Type of dataset (required for downstream tracking).
+        num_joints: Total number of joints (bodyparts + unique bodyparts).
+        all_joints: List of joint indices, each as a single-element list.
+        all_joints_names: List of joint names.
+        net_type: Network architecture type.
+        global_scale: Global scale factor for inference.
+        scoremap_dir: Directory for score maps.
+    """
+    # TODO @deruyter92 2026-02-05: Is this additional configuration really needed?
+    # We could aim for using the PoseConfig class or InferenceConfig class instead.
+    dataset: Path = Path()
+    num_joints: int = 0 
+    all_joints: list[list[int]] = field(default_factory=list)
+    all_joints_names: list[str] = field(default_factory=list)
+    net_type: NetType = NetType.RESNET_50
+    dataset_type: DatasetType = DatasetType.MULTIANIMAL_IMGAUG
+    global_scale: int = 1
+    scoremap_dir: Path = Path()

--- a/deeplabcut/pose_estimation_pytorch/config/runner.py
+++ b/deeplabcut/pose_estimation_pytorch/config/runner.py
@@ -76,7 +76,11 @@ class RunnerConfig(ConfigMixin):
     """
 
     type: str = "PoseTrainingRunner"
+    # TODO @deruyter92: Currently different configs for device are used in 
+    # parallel. We should probably move to only 'PoseConfig.device'. This is 
+    # kept here for backwards compatibility.
     gpus: Any | None = None
+    device: str = "auto" # <- unused, but present in test scripts. 
     key_metric: str = "test.mAP"
     key_metric_asc: bool = True
     eval_interval: int = 10

--- a/deeplabcut/pose_estimation_pytorch/config/training.py
+++ b/deeplabcut/pose_estimation_pytorch/config/training.py
@@ -36,4 +36,6 @@ class TrainSettingsConfig(ConfigMixin):
     display_iters: int = 500
     epochs: int = 200
     seed: int = 42
-    weight_init: WeightInitialization = field(default_factory=WeightInitialization)
+    # @TODO @deruyter92 2026-02-13: V0 pipeline uses None for default initialization 
+    # (with ImageNet weights). We should update this to explicit WeightInitialization.
+    weight_init: WeightInitialization | None = None 

--- a/deeplabcut/pose_estimation_pytorch/config/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/config/utils.py
@@ -14,10 +14,12 @@ from __future__ import annotations
 import copy
 from pathlib import Path
 
+from deeplabcut.core.config.config_mixin import ensure_plain_config
 from deeplabcut.core.config import read_config_as_dict
 from deeplabcut.utils import auxiliaryfunctions
 
 
+@ensure_plain_config
 def replace_default_values(
     config: dict | list,
     num_bodyparts: int | None = None,
@@ -121,6 +123,7 @@ def replace_default_values(
     return config
 
 
+@ensure_plain_config
 def update_config(config: dict, updates: dict, copy_original: bool = True) -> dict:
     """Updates items in the configuration file
 
@@ -151,6 +154,11 @@ def update_config(config: dict, updates: dict, copy_original: bool = True) -> di
     return config
 
 
+# TODO @deruyter92 2026-02-17: This function is currently still used to update 
+# the config in a late stage (after the config is initially created and validated).
+# We should move away from this strategy and update all override arguments during 
+# config creation.   
+@ensure_plain_config
 def update_config_by_dotpath(
     config: dict, updates: dict, copy_original: bool = True
 ) -> dict:

--- a/deeplabcut/pose_estimation_pytorch/data/base.py
+++ b/deeplabcut/pose_estimation_pytorch/data/base.py
@@ -299,10 +299,8 @@ class Loader(ABC):
         data["annotations"] = self.filter_annotations(data["annotations"], task)
         ctd_config = None
         if self.pose_task == Task.COND_TOP_DOWN:
-            ctd_config = GenSamplingConfig(
-                bbox_margin=self.model_cfg["data"].get("bbox_margin", 20),
-                **self.model_cfg["data"].get("gen_sampling", {}),
-            )
+            # TODO @deruyter92: when moving to typed configs, this conversion becomes unnecessary
+            ctd_config = GenSamplingConfig.from_any(self.model_cfg.data.gen_sampling)
 
         dataset = PoseDataset(
             images=data["images"],

--- a/deeplabcut/pose_estimation_pytorch/data/base.py
+++ b/deeplabcut/pose_estimation_pytorch/data/base.py
@@ -144,7 +144,15 @@ class Loader(ABC):
         Args:
             updates: the items to update in the model configuration
         """
-        self.model_cfg = config.update_config_by_dotpath(self.model_cfg, updates)
+        # TODO @deruyter92: updating the config after initialization is 
+        # not ideal. We should move away from this strategy and update all 
+        # override arguments during config creation.
+        updated_cfg: dict = config.update_config_by_dotpath(self.model_cfg, updates)
+
+        # Validate the updated config against the PoseConfig pydantic model
+        PoseConfig.validate_dict(updated_cfg)
+        self.model_cfg = PoseConfig.from_any(updated_cfg).to_dictconfig()
+
         config_utils.write_config(self.model_config_path, self.model_cfg)
 
     @abstractmethod

--- a/deeplabcut/pose_estimation_pytorch/data/base.py
+++ b/deeplabcut/pose_estimation_pytorch/data/base.py
@@ -208,7 +208,7 @@ class Loader(ABC):
             individuals = parameters.individuals
             num_bodyparts = parameters.num_joints
 
-        if "weight_init" in self.model_cfg["train_settings"]:
+        if self.model_cfg["train_settings"].get("weight_init") is not None:
             weight_init_cfg = self.model_cfg["train_settings"]["weight_init"]
             if weight_init_cfg["memory_replay"]:
                 conversion_array = weight_init_cfg["conversion_array"]

--- a/deeplabcut/pose_estimation_pytorch/data/cocoloader.py
+++ b/deeplabcut/pose_estimation_pytorch/data/cocoloader.py
@@ -86,11 +86,7 @@ class COCOLoader(Loader):
         if self._dataset_parameters is None:
             num_individuals, bodyparts = self.get_project_parameters(self.train_json)
 
-            crop_cfg = OmegaConf.select(
-                self.model_cfg,
-                "data.train.top_down_crop",
-                default={},
-            )
+            crop_cfg = OmegaConf.select(self.model_cfg, "data.train.top_down_crop") or {}
             crop_w, crop_h = crop_cfg.get("width", 256), crop_cfg.get("height", 256)
             crop_margin = crop_cfg.get("margin", 0)
             crop_with_context = crop_cfg.get("crop_with_context", True)

--- a/deeplabcut/pose_estimation_pytorch/data/cocoloader.py
+++ b/deeplabcut/pose_estimation_pytorch/data/cocoloader.py
@@ -25,7 +25,7 @@ from deeplabcut.pose_estimation_pytorch.data.utils import (
     map_id_to_annotations,
     map_image_path_to_id,
 )
-from deeplabcut.pose_estimation_pytorch.config.pose import PoseConfig
+from deeplabcut.pose_estimation_pytorch.config.pose import MethodType, PoseConfig
 
 
 class COCOLoader(Loader):
@@ -95,6 +95,10 @@ class COCOLoader(Loader):
             crop_margin = crop_cfg.get("margin", 0)
             crop_with_context = crop_cfg.get("crop_with_context", True)
 
+            ctd_bbox_margin = None
+            if self.model_cfg["method"] == MethodType.CONDITIONAL_TOP_DOWN:
+                ctd_bbox_margin = self.model_cfg["data"].get("bbox_margin", 20)
+
             self._dataset_parameters = PoseDatasetParameters(
                 bodyparts=bodyparts,
                 unique_bpts=[],
@@ -103,6 +107,7 @@ class COCOLoader(Loader):
                     "with_center_keypoints", False
                 ),
                 color_mode=self.model_cfg.get("color_mode", "RGB"),
+                ctd_bbox_margin=ctd_bbox_margin,
                 top_down_crop_size=(crop_w, crop_h),
                 top_down_crop_margin=crop_margin,
                 top_down_crop_with_context=crop_with_context,

--- a/deeplabcut/pose_estimation_pytorch/data/ctd.py
+++ b/deeplabcut/pose_estimation_pytorch/data/ctd.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+from omegaconf import DictConfig, ListConfig
 
 from deeplabcut.pose_estimation_pytorch.data.dlcloader import DLCLoader
 from deeplabcut.pose_estimation_pytorch.data.snapshots import Snapshot
@@ -354,7 +355,8 @@ class CondFromFile(CondProvider):
 
         # Parse list and return
         if images is None:
-            if not isinstance(conditions, list):
+            # TODO @deruyter92: decide on typed / plain list
+            if not isinstance(conditions, (list, ListConfig)):
                 raise ValueError(
                     f"Conditions are expected to be of type list when `images=None`, "
                     f"got {type(conditions)}."
@@ -368,7 +370,8 @@ class CondFromFile(CondProvider):
                     parsed.append(np.asarray(cond))
             return parsed
 
-        if not isinstance(conditions, dict):
+        # TODO @deruyter92: decide on typed / plain dict
+        if not isinstance(conditions, (dict, DictConfig)):
             raise ValueError(
                 f"Conditions are expected to be of type dict, got {type(conditions)}. "
                 "They should be in the format 'labeled-data/video-0/img0000.png' -> "

--- a/deeplabcut/pose_estimation_pytorch/data/dataset.py
+++ b/deeplabcut/pose_estimation_pytorch/data/dataset.py
@@ -44,7 +44,8 @@ class PoseDatasetParameters:
         individuals: the names of individuals
         with_center_keypoints: whether to compute center keypoints for individuals
         color_mode: {"RGB", "BGR"} the mode to load images in
-        ctd_config: for CTD models, the configuration for bbox calculation and error sampling
+        ctd_bbox_margin: the margin (in pixels) to add around keypoints when generating
+            bounding boxes from pose
         top_down_crop_size: for top-down models, the (width, height) to crop bboxes to
         top_down_crop_margin: for top-down models, the margin to add around bboxes
     """
@@ -54,7 +55,7 @@ class PoseDatasetParameters:
     individuals: list[str]
     with_center_keypoints: bool = False
     color_mode: str = "RGB"
-    ctd_config: GenSamplingConfig | None = None
+    ctd_bbox_margin: int | None = None
     top_down_crop_size: tuple[int, int] | None = None
     top_down_crop_margin: int | None = None
     top_down_crop_with_context: bool = True
@@ -236,7 +237,7 @@ class PoseDataset(Dataset):
                         synthesized_keypoints,
                         original_size[0],
                         original_size[1],
-                        self.ctd_config.bbox_margin,
+                        self.parameters.ctd_bbox_margin,
                     )
 
             if bboxes[0, 2] == 0 or bboxes[0, 3] == 0:

--- a/deeplabcut/pose_estimation_pytorch/data/dlcloader.py
+++ b/deeplabcut/pose_estimation_pytorch/data/dlcloader.py
@@ -635,7 +635,10 @@ def _load_pickle_dataset(
         keypoints = np.zeros((params.max_num_animals, params.num_joints, 2))
         keypoints.fill(np.nan)
         keypoints_unique = None
-        for idv_idx, idv_bodyparts in image_data.get("joints", {}).items():
+
+        # TODO @deruyter92: This pattern should be refactored throughout the codebase
+        # it is reading a config value that is supposed to be missing / None.
+        for idv_idx, idv_bodyparts in (image_data.get("joints") or {}).items():
             if idv_idx < params.max_num_animals:
                 for joint_id, x, y in idv_bodyparts:
                     bodypart = int(joint_id)

--- a/deeplabcut/pose_estimation_pytorch/data/dlcloader.py
+++ b/deeplabcut/pose_estimation_pytorch/data/dlcloader.py
@@ -168,11 +168,7 @@ class DLCLoader(Loader):
         Returns:
             An instance of the PoseDatasetParameters with the parameters set.
         """
-        crop_cfg = OmegaConf.select(
-            self.model_cfg,
-            "data.train.top_down_crop",
-            default={},
-        )
+        crop_cfg = OmegaConf.select(self.model_cfg, "data.train.top_down_crop") or {}
         crop_w, crop_h = crop_cfg.get("width", 256), crop_cfg.get("height", 256)
         crop_margin = crop_cfg.get("margin", 0)
         crop_with_context = crop_cfg.get("crop_with_context", True)

--- a/deeplabcut/pose_estimation_pytorch/data/dlcloader.py
+++ b/deeplabcut/pose_estimation_pytorch/data/dlcloader.py
@@ -24,6 +24,7 @@ from omegaconf import OmegaConf, DictConfig
 from deeplabcut.core.config.project_config import ProjectConfig
 import deeplabcut.utils.auxiliaryfunctions as af
 from deeplabcut.core.engine import Engine
+from deeplabcut.pose_estimation_pytorch.config.pose import MethodType
 from deeplabcut.pose_estimation_pytorch.data.base import Loader
 from deeplabcut.pose_estimation_pytorch.data.dataset import PoseDatasetParameters
 from deeplabcut.pose_estimation_pytorch.data.snapshots import Snapshot
@@ -175,13 +176,16 @@ class DLCLoader(Loader):
         crop_w, crop_h = crop_cfg.get("width", 256), crop_cfg.get("height", 256)
         crop_margin = crop_cfg.get("margin", 0)
         crop_with_context = crop_cfg.get("crop_with_context", True)
-
+        ctd_bbox_margin = None
+        if self.model_cfg["method"] == MethodType.CONDITIONAL_TOP_DOWN:
+            ctd_bbox_margin = self.model_cfg["data"].get("bbox_margin", 20)
         return PoseDatasetParameters(
             bodyparts=self.model_cfg["metadata"]["bodyparts"],
             unique_bpts=self.model_cfg["metadata"]["unique_bodyparts"],
             individuals=self.model_cfg["metadata"]["individuals"],
             with_center_keypoints=self.model_cfg.get("with_center_keypoints", False),
             color_mode=self.model_cfg.get("color_mode", "RGB"),
+            ctd_bbox_margin=ctd_bbox_margin,
             top_down_crop_size=(crop_w, crop_h),
             top_down_crop_margin=crop_margin,
             top_down_crop_with_context=crop_with_context,

--- a/deeplabcut/pose_estimation_pytorch/data/helper.py
+++ b/deeplabcut/pose_estimation_pytorch/data/helper.py
@@ -70,7 +70,9 @@ class PropertyMeta(type):
     def __new__(cls, name, bases, attrs):
         if "properties" not in attrs:
             raise AttributeError(f"{name} must define a 'properties' dictionary.")
-        properties = attrs.get("properties", {})
+        # TODO @deruyter92: This pattern should be refactored throughout the codebase
+        # it is reading a config value that is supposed to be missing / None.
+        properties = attrs.get("properties") or {}
         for prop_name, (func, arg_func) in properties.items():
             attrs[prop_name] = class_property(func, arg_func)(lambda self: None)
         return super().__new__(cls, name, bases, attrs)

--- a/deeplabcut/pose_estimation_pytorch/data/image.py
+++ b/deeplabcut/pose_estimation_pytorch/data/image.py
@@ -169,8 +169,10 @@ def resize_and_random_crop(
     targets["scales"] = sx * scale_x, sy * scale_y
 
     # update annotations and context
-    anns = targets.get("annotations", {})
-    context = targets.get("context", {})
+    # TODO @deruyter92: This pattern should be refactored throughout the codebase
+    # it is reading a config value that is supposed to be missing / None.
+    anns = targets.get("annotations") or {}
+    context = targets.get("context") or {}
 
     kpt_scale = np.array([scale_x, scale_y])
     kpt_offset = np.array([offset_x, offset_y])

--- a/deeplabcut/pose_estimation_pytorch/data/preprocessor.py
+++ b/deeplabcut/pose_estimation_pytorch/data/preprocessor.py
@@ -18,6 +18,7 @@ from typing import Any, TypeVar, Callable
 import albumentations as A
 import numpy as np
 import torch
+from omegaconf import ListConfig
 
 from deeplabcut.pose_estimation_pytorch.data.image import load_image, top_down_crop
 from deeplabcut.pose_estimation_pytorch.data.utils import bbox_from_keypoints
@@ -255,7 +256,8 @@ class AugmentImage(Preprocessor):
         offsets = context.get("offsets", (0, 0))
         scales = context.get("scales", (1, 1))
         if isinstance(offsets, tuple):
-            if isinstance(new_offsets, list):
+            # TODO @deruyter92: decide on typed / plain list
+            if isinstance(new_offsets, (list, ListConfig)):
                 updated_offsets = [
                     AugmentImage.update_offset(offsets, scales, new_offset)
                     for new_offset in new_offsets
@@ -273,7 +275,8 @@ class AugmentImage(Preprocessor):
                 )
                 updated_scales = AugmentImage.update_scale(scales, new_scales)
         else:
-            if isinstance(new_offsets, list):
+            # TODO @deruyter92: decide on typed / plain list
+            if isinstance(new_offsets, (list, ListConfig)):
                 if not len(offsets) == len(new_offsets):
                     raise ValueError("Cannot rescale lists when not same length")
 

--- a/deeplabcut/pose_estimation_pytorch/data/transforms.py
+++ b/deeplabcut/pose_estimation_pytorch/data/transforms.py
@@ -14,6 +14,7 @@ import warnings
 from typing import Any, Iterable, Sequence
 
 import albumentations as A
+from omegaconf import DictConfig
 import cv2
 import numpy as np
 from albumentations.augmentations.geometric import functional as F
@@ -36,7 +37,8 @@ def build_transforms(augmentations: dict) -> A.BaseCompose:
         symmetries = None
         if isinstance(hflip_cfg, float):
             hflip_proba = hflip_cfg
-        elif isinstance(hflip_cfg, dict):
+        # TODO @deruyter92: decide on typed / plain dict
+        elif isinstance(hflip_cfg, (dict, DictConfig)):
             if "p" in hflip_cfg:
                 hflip_proba = float(hflip_cfg["p"])
 

--- a/deeplabcut/pose_estimation_pytorch/models/heads/base.py
+++ b/deeplabcut/pose_estimation_pytorch/models/heads/base.py
@@ -14,6 +14,7 @@ from abc import ABC, abstractmethod
 
 import torch
 import torch.nn as nn
+from omegaconf import DictConfig
 
 from deeplabcut.pose_estimation_pytorch.models.criterions import (
     BaseCriterion,
@@ -81,7 +82,8 @@ class BaseHead(ABC, nn.Module):
                 f"Could not parse ``weight_init`` parameter: {weight_init}."
             )
 
-        if isinstance(criterion, dict):
+        # TODO @deruyter92: decide on typed / plain dict
+        if isinstance(criterion, (dict, DictConfig)):
             if aggregator is None:
                 raise ValueError(
                     f"When multiple criterions are defined, a loss aggregator must "

--- a/deeplabcut/pose_estimation_pytorch/models/predictors/paf_predictor.py
+++ b/deeplabcut/pose_estimation_pytorch/models/predictors/paf_predictor.py
@@ -411,8 +411,8 @@ class PartAffinityFieldPredictor(BasePredictor):
         # Build an index dict of slices for group lookup by (batch, limb)
         batch_groups = defaultdict(list)  # (batch)->list of (limb, start, end)
         for st, en in zip(group_starts, group_ends):
-            b = batch_inds[st]
-            k = edge_idx[st]
+            b = batch_inds[st].item()
+            k = edge_idx[st].item()
             batch_groups[b].append((k, st, en))
 
         paf_limb_inds = set(paf_limb_inds.tolist())

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/config.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/config.py
@@ -14,8 +14,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from ruamel.yaml import YAML
-
+from deeplabcut.core.config.utils import get_yaml_loader
 import deeplabcut.pose_estimation_pytorch.config.utils as config_utils
 import deeplabcut.utils.auxiliaryfunctions as af
 from deeplabcut.core.config import (
@@ -187,5 +186,5 @@ def write_pytorch_config_for_memory_replay(config_path, shuffle, pytorch_config)
     os.makedirs(model_folder / "train", exist_ok=True)
     out_path = model_folder / "train" / "pytorch_config.yaml"
     with open(str(out_path), "w") as f:
-        yaml = YAML()
+        yaml = get_yaml_loader()
         yaml.dump(pytorch_config, f)

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/train_from_coco.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/train_from_coco.py
@@ -70,6 +70,8 @@ def adaptation_train(
     if eval_interval is not None:
         updates["runner.eval_interval"] = eval_interval
 
+    # TODO @deruyter92: midway config updates are not ideal. 
+    # We should validate this against the pydantic schema.
     loader.update_model_cfg(updates)
 
     pose_task = Task(loader.model_cfg["method"])

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/utils.py
@@ -107,6 +107,8 @@ def load_super_animal_config(
     project_cfg_path = get_super_animal_project_config_path(super_animal=super_animal)
     project_config = read_config_as_dict(project_cfg_path)
 
+    # TODO @deruyter92: This is currently not validated against the PoseConfig pydantic model.
+    # We should add this functionality for super animal configs.
     model_cfg_path = get_super_animal_model_config_path(model_name=model_name)
     model_config = read_config_as_dict(model_cfg_path)
     model_config = add_metadata(project_config, model_config, model_cfg_path)
@@ -184,7 +186,8 @@ def raise_warning_if_called_directly():
             UserWarning,
         )
 
-
+# TODO @deruyter92: This logic is currently completely separated from 
+# the PoseConfig logic elsewhere. We should put this in line with the rest of the codebase.
 def update_config(config: dict, max_individuals: int, device: str):
     """Loads the model configuration file for a model, detector and SuperAnimal
 

--- a/deeplabcut/pose_estimation_pytorch/registry.py
+++ b/deeplabcut/pose_estimation_pytorch/registry.py
@@ -11,8 +11,13 @@
 import inspect
 from functools import partial
 from typing import Any, Dict, Optional
+from deeplabcut.core.config.config_mixin import ensure_plain_config
 
 
+# NOTE @deruyter92 2026-02-17: The configuration is currently converted to a 
+# plain dictionary, using this decorator, since fully typed configs are not
+# supported for all modules in the registry.
+@ensure_plain_config
 def build_from_cfg(
     cfg: Dict, registry: "Registry", default_args: Optional[Dict] = None
 ) -> Any:

--- a/deeplabcut/pose_estimation_pytorch/runners/base.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/base.py
@@ -202,7 +202,10 @@ def fix_snapshot_metadata(path: str | Path) -> None:
         path: The path of the snapshot to fix.
     """
     snapshot = torch.load(path, map_location="cpu", weights_only=False)
-    metrics = snapshot.get("metadata", {}).get("metrics")
+
+    # TODO @deruyter92: This pattern should be refactored throughout the codebase
+    # it is reading a config value that is supposed to be missing / None.
+    metrics = (snapshot.get("metadata") or {}).get("metrics")
     if metrics is not None:
         snapshot["metadata"]["metrics"] = {k: float(v) for k, v in metrics.items()}
 

--- a/deeplabcut/pose_estimation_pytorch/runners/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/inference.py
@@ -20,6 +20,7 @@ from queue import Queue, Empty, Full
 import numpy as np
 import torch
 import torch.nn as nn
+from omegaconf import DictConfig
 
 import deeplabcut.pose_estimation_pytorch.post_processing.nms as nms
 import deeplabcut.pose_estimation_pytorch.runners.ctd as ctd

--- a/deeplabcut/pose_estimation_pytorch/runners/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/inference.py
@@ -80,12 +80,14 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
         self.preprocessor = preprocessor
         self.postprocessor = postprocessor
 
-        if isinstance(inference_cfg, InferenceConfig):
+        if isinstance(inference_cfg, (InferenceConfig, DictConfig)):
             self.inference_cfg = inference_cfg
         elif isinstance(inference_cfg, dict):
             self.inference_cfg = InferenceConfig.from_dict(inference_cfg)
         elif inference_cfg is None:
             self.inference_cfg = InferenceConfig()
+        else: 
+            raise ValueError(f"Invalid inference config: {inference_cfg}")
 
         if self.snapshot_path is not None and self.snapshot_path != "":
             self.load_snapshot(

--- a/deeplabcut/pose_estimation_pytorch/runners/logger.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/logger.py
@@ -229,7 +229,10 @@ class ImageLoggerMixin(ABC):
         images_to_log = [(i, p) for i, p in enumerate(paths) if p in self._logged]
         for idx, path in images_to_log:
             base = self._logged[path]["name"]
-            keypoints = inputs.get("annotations", {}).get("keypoints")
+
+            # TODO @deruyter92: This pattern should be refactored throughout the codebase
+            # it is reading a config value that is supposed to be missing / None.
+            keypoints = (inputs.get("annotations") or {}).get("keypoints")
             if keypoints is not None:
                 keypoints = keypoints[idx]
             image_logs[f"{base}.input"] = self._prepare_image(

--- a/deeplabcut/pose_estimation_pytorch/runners/schedulers.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/schedulers.py
@@ -102,7 +102,8 @@ def build_scheduler(
 
 def _parse_scheduler_param(param: Any, optimizer: torch.optim.Optimizer) -> Any:
     """Parses parameters so they're built as schedulers if they're configured as one"""
-    if isinstance(param, dict) and "type" in param:
+    # TODO @deruyter92: decide on typed / plain dict
+    if isinstance(param, (dict, DictConfig)) and "type" in param:
         param = build_scheduler(param, optimizer)
 
     return param

--- a/deeplabcut/pose_estimation_pytorch/runners/schedulers.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/schedulers.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from typing import Any
 
 import torch
+from omegaconf import DictConfig, ListConfig, OmegaConf
 from torch.optim.lr_scheduler import _LRScheduler
 
 
@@ -81,6 +82,14 @@ def build_scheduler(
 
     parsed_params = {}
     for param_name, param in scheduler_cfg["params"].items():
+        # Convert omegaconf containers to plain Python types so that the
+        # scheduler state_dict (saved via torch.save) does not contain
+        # unpicklable omegaconf objects with _parent references.
+        # TODO @deruyter92: decide on typed / plain list / dict in upstream code
+        # Then this check can be removed.
+        if isinstance(param, (ListConfig, DictConfig)):
+            param = OmegaConf.to_container(param, resolve=True)
+
         if isinstance(param, list):
             param = [_parse_scheduler_param(p, optimizer) for p in param]
         else:

--- a/deeplabcut/pose_estimation_pytorch/runners/train.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/train.py
@@ -19,6 +19,7 @@ from typing import Any, Generic
 import numpy as np
 import torch
 import torch.nn as nn
+from omegaconf import DictConfig
 from torch.nn.parallel import DataParallel
 from torch.utils.data import DataLoader
 
@@ -95,9 +96,11 @@ class TrainingRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
         super().__init__(
             model=model, device=device, gpus=gpus, snapshot_path=snapshot_path
         )
-        if isinstance(optimizer, dict):
+        # TODO @deruyter92: decide on typed / plain dict
+        if isinstance(optimizer, (dict, DictConfig)):
             optimizer = build_optimizer(model, optimizer)
-        if isinstance(scheduler, dict):
+        # TODO @deruyter92: decide on typed / plain dict
+        if isinstance(scheduler, (dict, DictConfig)):
             scheduler = schedulers.build_scheduler(scheduler, optimizer)
 
         self.eval_interval = eval_interval

--- a/deeplabcut/pose_estimation_pytorch/runners/train.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/train.py
@@ -126,7 +126,9 @@ class TrainingRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
                 self.model,
                 weights_only=load_weights_only,
             )
-            self.starting_epoch = snapshot.get("metadata", {}).get("epoch", 0)
+            # TODO @deruyter92: This pattern should be refactored throughout the codebase
+            # it is reading a config value that is supposed to be missing / None.
+            self.starting_epoch = (snapshot.get("metadata") or {}).get("epoch", 0)
 
             if "optimizer" in snapshot:
                 self.optimizer.load_state_dict(snapshot["optimizer"])
@@ -519,8 +521,10 @@ class PoseTrainingRunner(TrainingRunner[PoseModel]):
         offsets: torch.Tensor,
     ) -> None:
         """Updates the stored predictions with a new batch"""
-        epoch_gt_metric = self._epoch_ground_truth.get(name, {})
-        epoch_metric = self._epoch_predictions.get(name, {})
+        # TODO @deruyter92: This pattern should be refactored throughout the codebase
+        # it is reading a config value that is supposed to be missing / None.
+        epoch_gt_metric = self._epoch_ground_truth.get(name) or {}
+        epoch_metric = self._epoch_predictions.get(name) or {}
         assert len(gt_keypoints) == len(pred_keypoints)
         assert len(offsets) == len(scales)
         scales = scales.detach().cpu().numpy()

--- a/deeplabcut/pose_estimation_tensorflow/backbones/mobilenet.py
+++ b/deeplabcut/pose_estimation_tensorflow/backbones/mobilenet.py
@@ -172,8 +172,10 @@ def mobilenet_base(  # pylint: disable=invalid-name
         raise ValueError("multiplier is not greater than zero.")
 
     # Set conv defs defaults and overrides.
-    conv_defs_defaults = conv_defs.get("defaults", {})
-    conv_defs_overrides = conv_defs.get("overrides", {})
+    # TODO @deruyter92: This pattern should be refactored throughout the codebase
+    # it is reading a config value that is supposed to be missing / None.
+    conv_defs_defaults = conv_defs.get("defaults") or {}
+    conv_defs_overrides = conv_defs.get("overrides") or {}
     if use_explicit_padding:
         conv_defs_overrides = copy.deepcopy(conv_defs_overrides)
         conv_defs_overrides[(slim.conv2d, slim.separable_conv2d)] = {"padding": "VALID"}

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -151,7 +151,7 @@ def evaluate_multianimal_full(
         )
     )
     all_bpts = np.asarray(
-        len(cfg["individuals"]) * cfg["multianimalbodyparts"] + cfg["uniquebodyparts"]
+        len(cfg["individuals"]) * list(cfg["multianimalbodyparts"]) + list(cfg["uniquebodyparts"])
     )
     colors = visualization.get_cmap(len(comparisonbodyparts), name=cfg["colormap"])
     # Make folder for evaluation

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
@@ -216,8 +216,10 @@ class ImgaugPoseDataset(BasePoseDataset):
                 opt = {}
             return opt
 
-        cfg_cnt = cfg.get("contrast", {})
-        cfg_cnv = cfg.get("convolution", {})
+        # TODO @deruyter92: This pattern should be refactored throughout the codebase
+        # it is reading a config value that is supposed to be missing / None.
+        cfg_cnt = cfg.get("contrast") or {}
+        cfg_cnv = cfg.get("convolution") or {}
 
         contrast_aug = ["histeq", "clahe", "gamma", "sigmoid", "log", "linear"]
         for aug in contrast_aug:

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_multianimal_imgaug.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_multianimal_imgaug.py
@@ -284,8 +284,10 @@ class MAImgaugPoseDataset(BasePoseDataset):
                 opt = {}
             return opt
 
-        cfg_cnt = cfg.get("contrast", {})
-        cfg_cnv = cfg.get("convolution", {})
+        # TODO @deruyter92: This pattern should be refactored throughout the codebase
+        # it is reading a config value that is supposed to be missing / None.
+        cfg_cnt = cfg.get("contrast") or {}
+        cfg_cnv = cfg.get("convolution") or {}
 
         contrast_aug = ["histeq", "clahe", "gamma", "sigmoid", "log", "linear"]
         for aug in contrast_aug:

--- a/deeplabcut/pose_estimation_tensorflow/export.py
+++ b/deeplabcut/pose_estimation_tensorflow/export.py
@@ -16,9 +16,9 @@ import tarfile
 from pathlib import Path
 
 import numpy as np
-import ruamel.yaml
 import tensorflow as tf
 
+from deeplabcut.core.config.utils import get_yaml_loader
 from deeplabcut.utils import auxiliaryfunctions
 from deeplabcut.pose_estimation_tensorflow.config import load_config
 from deeplabcut.pose_estimation_tensorflow.core import predict
@@ -52,7 +52,7 @@ def create_deploy_config_template():
     \n
     """
 
-    ruamelFile = ruamel.yaml.YAML()
+    ruamelFile = get_yaml_loader()
     cfg_file = ruamelFile.load(yaml_str)
     return cfg_file, ruamelFile
 
@@ -66,7 +66,7 @@ def write_deploy_config(configname, cfg):
     """
 
     with open(configname, "w") as cf:
-        ruamelFile = ruamel.yaml.YAML()
+        ruamelFile = get_yaml_loader()
         cfg_file, ruamelFile = create_deploy_config_template()
         for key in cfg.keys():
             cfg_file[key] = cfg[key]
@@ -334,7 +334,7 @@ def export_model(
             sorted_cfg[key] = value
 
     pose_cfg_file = os.path.normpath(full_export_dir + "/pose_cfg.yaml")
-    ruamel_file = ruamel.yaml.YAML()
+    ruamel_file = get_yaml_loader()
     ruamel_file.dump(sorted_cfg, open(pose_cfg_file, "w"))
 
     ### copy checkpoint to export directory

--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -436,7 +436,9 @@ def extract_outlier_frames(
             # offset if the data was cropped
             # note: When output video is also cropped, the keypoints should be shifted back.
             out_x1, out_y1 = _read_video_specific_cropping_margins(config, video)
-            if metadata.get("data", {}).get("cropping"):
+            # TODO @deruyter92: This pattern should be refactored throughout the codebase
+            # it is reading a config value that is supposed to be missing / None.
+            if (metadata.get("data") or {}).get("cropping"):
                 x1, _, y1, _ = metadata["data"]["cropping_parameters"]
                 df.iloc[:, df.columns.get_level_values(level="coords") == "x"] += x1 - out_x1
                 df.iloc[:, df.columns.get_level_values(level="coords") == "y"] += y1 - out_y1
@@ -771,7 +773,7 @@ def ExtractFramesbasedonPreselection(
         duration = clip.duration
 
     if cfg["cropping"]:  # one might want to adjust
-        coords = cfg["video_sets"].get(video, {}).get("crop")
+        coords = (cfg["video_sets"].get(video) or {}).get("crop")
         if coords is not None:
             coords = list(map(int, coords.split(", ")))
     else:

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -692,18 +692,20 @@ def create_labeled_video(
         )
         if model_config_path.exists():
             model_config = auxiliaryfunctions.read_plainconfig(str(model_config_path))
+            # TODO @deruyter92: This pattern should be refactored throughout the codebase
+            # it is reading a config value that is supposed to be missing / None.
             if (
-                model_config["train_settings"]
-                .get("weight_init", {})
+                (model_config["train_settings"].get("weight_init") or {})
                 .get("memory_replay", False)
             ):
                 superanimal_name = model_config["train_settings"]["weight_init"][
                     "dataset"
                 ]
             if bboxes_pcutoff is None:
+                # TODO @deruyter92: This pattern should be refactored throughout the codebase
+                # it is reading a config value that is supposed to be missing / None.
                 bboxes_pcutoff = (
-                    model_config.get("detector", {})
-                    .get("model", {})
+                    ((model_config.get("detector") or {}).get("model") or {})
                     .get("box_score_thresh", 0.6)
                 )
         else:
@@ -1314,7 +1316,9 @@ def create_video_with_all_detections(
             x1, y1 = 0, 0
             if cropping is not None:
                 x1, _, y1, _ = cropping
-            elif metadata.get("data", {}).get("cropping"):
+            # TODO @deruyter92: This pattern should be refactored throughout the codebase
+            # it is reading a config value that is supposed to be missing / None.
+            elif (metadata.get("data") or {}).get("cropping"):
                 x1, _, y1, _ = metadata["data"]["cropping_parameters"]
 
             header = data.pop("metadata")
@@ -1340,12 +1344,15 @@ def create_video_with_all_detections(
             clip = vp(fname=video, sname=outputname, codec="mp4v")
             ny, nx = clip.height(), clip.width()
 
+            # TODO @deruyter92: This pattern should be refactored throughout the codebase
+            # it is reading a config value that is supposed to be missing / None.
             bboxes_pcutoff = (
-                metadata.get("data", {})
-                .get("pytorch-config", {})
-                .get("detector", {})
-                .get("model", {})
-                .get("box_score_thresh", 0.6)
+                (
+                    (
+                        ((metadata.get("data") or {}).get("pytorch-config") or {})
+                        .get("detector") or {}
+                    ).get("model") or {}
+                ).get("box_score_thresh", 0.6)
             )
             bboxes_color = (255, 0, 0)
 

--- a/deeplabcut/utils/pseudo_label.py
+++ b/deeplabcut/utils/pseudo_label.py
@@ -206,6 +206,8 @@ def keypoint_matching(
         dataset=superanimal_name, model_name=detector_name,
     )
 
+    # TODO @deruyter92: midway config updates are not ideal. 
+    # We should validate this against the pydantic schema.
     config = update_config(config, max_individuals, device)
     individuals = [f"animal{i}" for i in range(max_individuals)]
     config["metadata"]["individuals"] = individuals

--- a/examples/testscript_pytorch_multi_animal.py
+++ b/examples/testscript_pytorch_multi_animal.py
@@ -67,17 +67,25 @@ def main(
                     "runner.device": device,
                     "runner.snapshots.save_epochs": save_epochs,
                     "runner.snapshots.max_snapshots": max_snapshots_to_keep,
-                    "detector.train_settings.display_iters": 1,
-                    "detector.train_settings.epochs": detector_epochs,
-                    "detector.train_settings.batch_size": detector_batch_size,
-                    "detector.train_settings.dataloader_workers": 0,
-                    "detector.runner.snapshots.save_epochs": save_epochs,
-                    "detector.runner.snapshots.max_snapshots": max_snapshots_to_keep,
                     "logger": logger,
                 }
+
+                # Only add detector config updates for top-down models
+                if is_model_top_down(net_type):
+                    pytorch_cfg_updates.update({
+                        "detector.train_settings.display_iters": 1,
+                        "detector.train_settings.epochs": detector_epochs,
+                        "detector.train_settings.batch_size": detector_batch_size,
+                        "detector.train_settings.dataloader_workers": 0,
+                        "detector.runner.snapshots.save_epochs": save_epochs,
+                        "detector.runner.snapshots.max_snapshots": max_snapshots_to_keep,
+                    })
+                
+                # Only add conditional top-down config updates for conditional top-down models
                 if is_model_cond_top_down(net_type):
                     pytorch_cfg_updates["inference.conditions.shuffle"] = conditions_shuffle
                     pytorch_cfg_updates["inference.conditions.snapshot_index"] = -1
+
                 run(
                     config_path=config_path,
                     train_fraction=train_frac,

--- a/tests/create_project/test_video_set_configuration.py
+++ b/tests/create_project/test_video_set_configuration.py
@@ -14,6 +14,7 @@ import warnings
 from pathlib import Path
 from unittest.mock import Mock, patch
 import pytest
+from collections.abc import Mapping
 
 import deeplabcut.create_project.new as new_module
 from deeplabcut.utils.auxfun_videos import VideoReader
@@ -244,10 +245,10 @@ def test_config_file_video_sets_format(
     cfg = auxiliaryfunctions.read_config(config_path)
     
     assert "video_sets" in cfg
-    assert isinstance(cfg["video_sets"], dict)
+    assert isinstance(cfg["video_sets"], Mapping)
     
     # Check format of video_sets entries
     for video_path, video_info in cfg["video_sets"].items():
-        assert isinstance(video_info, dict)
+        assert isinstance(video_info, Mapping)
         assert "crop" in video_info
         assert isinstance(video_info["crop"], str)

--- a/tests/generate_training_dataset/test_trainset_metadata.py
+++ b/tests/generate_training_dataset/test_trainset_metadata.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 import pickle
 
 import pytest
-from ruamel.yaml import YAML
 
+from deeplabcut.core.config.utils import get_yaml_loader, get_yaml_dumper
 import deeplabcut.generate_training_dataset.metadata as metadata
 from deeplabcut.core.engine import Engine
 from deeplabcut.utils import auxiliaryfunctions
@@ -68,7 +68,7 @@ def test_load_metadata(tmpdir, data: dict, load_splits: bool):
     # write data to tmp file
     cfg, cfg_path, trainset_dir, meta_path = _create_project_with_config(tmpdir)
     with open(meta_path, "w") as f:
-        YAML().dump(data, f)
+        get_yaml_dumper().dump(data, f)
 
     print(cfg_path)
     print(meta_path)
@@ -181,7 +181,7 @@ def test_save_metadata_simple(tmpdir, data):
 
     trainset_meta.save()
     with open(meta_path, "r") as f:
-        meta = YAML().load(f)
+        meta = get_yaml_loader().load(f)
     print(data)
     print(meta)
     assert data["expected"] == meta
@@ -383,7 +383,7 @@ def _create_project_with_config(
 
     cfg_path = project_dir.join("config.yaml")
     with open(cfg_path, "w") as file:
-        YAML().dump(cfg, file)
+        get_yaml_dumper().dump(cfg, file)
 
     it = f"iteration-{iteration}"
     dir_name = "UnaugmentedDataSet_" + task + date


### PR DESCRIPTION
This PR is part of the WIP for migrating from dictionary configs to typed & validated configurations, and follows PR https://github.com/DeepLabCut/DeepLabCut/pull/3191. (see issue https://github.com/DeepLabCut/DeepLabCut/issues/3193 for an overview). It is a follow-up of #3194, with additional refactors that are required to make the change to DictConfig working. 



**Summary**
1. **Improve YAML I/O** :  A pair of central factory functions `get_yaml_loader()` and `get_yaml_dumper()` were added to deeplabcut/core/config/utils.py, instead of having downstream functions creating YAML handlers themselves. The dumper registers custom representers for Path, Enum, DictConfig, and ListConfig so these types are transparently serialized as plain YAML scalars/mappings. All call-sites across the codebase (metadata.py, export.py, modelzoo/config.py, test_trainset_metadata.py, etc.) now use these centralized factories instead of constructing YAML() / YAML(typ="safe", pure=True) ad hoc.

2. **Updates to the core configuration types**
   - PoseConfig and ProjectConfig now use ConfigDict(extra="forbid"), making them reject unknown fields - this was the intended behaviour in earlier PRs. 
   - The `make_pytorch_pose_config` flow is restructured (and corrected): 
Constructs a fully-typed PoseConfig object (with TrainSettingsConfig, WeightInitialization, etc.) before merging architecture defaults. Similarly, make_pytorch_test_config now constructs and validates a TestConfig instance. The Loader.update_model_cfg method now re-validates the config through PoseConfig after applying dot-path updates. **This will be again further simplified at the end of the PR series (e.g. after moving to fully-typed configs**
   - A new TestConfig dataclass was added to formalize the previously untyped test/inference config dict.
   - Many (sometimes ambiguous) fields that were used in the old configuration system are added when missing:  
      - NetType enum was extended with CSPNeXt variants (these were missing).
      - TrainSettingsConfig.weight_init now allows None (coding for default weight initialization, as before).
      - RunnerConfig gained a device field for backward compatibility with test scripts.
      - ProjectConfig gained legacy/alias fields (resnet, croppedtraining, with_identity, unique_bodyparts) 
      - **a from_yaml override is added** to ProjecConfig that adjusts project_path when the YAML file lives in a different directory. This matches prior behaviour. 
      -   GenSamplingConfig removed its bbox_margin field; Nearly the entire codebase uses the data.bbox_margin field in pose_config directly (for the only exception, PoseDatasetParameters it is now sourced from the data config as well).
 

3. **Improved handling/conversion of config Types**:  While in the central pipeline, we aim to move to typed configs, some places (e.g. before initial construction of the PoseConfig, or when serializing state dicts) may benefit from using plain dictionaries with native python types. 
    - This is made more explicit by using a `@ensure_plain_config` decorator that converts the config back to a plain dictionary. It is applied to key functions that must operate on plain dicts: `update_config`, `update_config_by_dotpath`, `replace_default_values`, `_load_pose_config_defaults`, `_add_ctd_conditions`, `add_metadata`, and the central registry's `build_from_cfg`.
   - In some places a conversion from non-native to native python types is put in place (e.g. `paf_predictor.py` now uses int instead of numpy.int64, which was equivalent but non-serializable)
   - Throughout the codebase (~25 locations), isinstance checks were broadened from dict to (dict, DictConfig) and from list to (list, ListConfig) to handle cases where OmegaConf containers leak into code expecting plain Python types. Each of these is marked with a TODO to eventually standardize on one representation. 
   - Numerous TODO comments flagging areas where config updates happen after validation, unvalidated super-animal configs, and typed-vs-plain dict decisions that still need resolution. 

4. **None-safe .get() pattern fix**
A widespread pattern cfg.get("key", {}) was replaced with cfg.get("key") or {}. When a key exists but is explicitly set to None in the config, the old pattern returns None (ignoring the default), leading to AttributeError on the chained .get(). The new pattern handles both missing keys and None values. These are marked with TODOs for future refactoring.

5. **Fix invalid test configuration:** in one of the test scripts, detector conditions are added to all of the training, even when bottom-up or ctd models are used. When these models are missing other required detector specifications, the new PoseConfig system throws an (accurate) validation error. The script is adjusted such that no partially detector-configs are added. 