### PR TITLE
Update conda env yaml: bump DeepLabCut and remove nb_conda

### DIFF
--- a/conda-environments/DEEPLABCUT.yaml
+++ b/conda-environments/DEEPLABCUT.yaml
@@ -28,9 +28,7 @@ dependencies:
   - pip
   - ipython
   - jupyter
-  - notebook<7.0.0
   - ffmpeg
-  - pytables==3.8.0
   - pip:
     - torch
     - torchvision

--- a/conda-environments/DEEPLABCUT.yaml
+++ b/conda-environments/DEEPLABCUT.yaml
@@ -28,11 +28,11 @@ dependencies:
   - pip
   - ipython
   - jupyter
-  - nb_conda
   - notebook<7.0.0
   - ffmpeg
   - pytables==3.8.0
   - pip:
     - torch
     - torchvision
-    - deeplabcut[gui,modelzoo,wandb]==3.0.0rc9
+    - --pre
+    - deeplabcut[gui,modelzoo,wandb]


### PR DESCRIPTION
**Motivation:** 
The conda env yaml is largely outdated and needs some updating. 

**Changes:**
- Remove `nb_conda`: it is an unmaintained Jupyter extension. This resolves #3203.
- Bump `deeplabcut` version (was rc9, now set to --pre so it always installs latest prerelease)
- Remove `notebook<7.0.0`: This was in the YAML to support nb_conda.
- Remove `pytables==3.8.0`: this should now be installed via pip instead of conda. Pinning to this version is actually harmful as it is largely outdated and may break pandas. tables is currently already installed via pip, so no need for the conda install. 
(The following PRs even make this more specific, by letting pandas handle tables dependency as extra #3184 , #3214)