### PR TITLE
Handle tables via pip as pandas extra instead of separate conda install (and update installation instructions)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  python: circleci/python@0.2.1
+
 jobs:
   build-and-test:
     working_directory: ~/circleci-demo-python-django
@@ -10,14 +13,9 @@ jobs:
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - checkout
-      - run:
-          name: Upgrade pip tooling
-          command: |
-            python -m pip install --upgrade pip setuptools wheel
-      - run:
-          name: Install dependencies (no pip cache)
-          command: |
-            python -m pip install --no-cache-dir -r requirements.txt
+      - python/load-cache
+      - python/install-deps
+      - python/save-cache
       - run:
           command: python testscript_cli.py
           name: TestDLC

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-orbs:
-  python: circleci/python@0.2.1
-
 jobs:
   build-and-test:
     working_directory: ~/circleci-demo-python-django
@@ -13,9 +10,14 @@ jobs:
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - checkout
-      - python/load-cache
-      - python/install-deps
-      - python/save-cache
+      - run:
+          name: Upgrade pip tooling
+          command: |
+            python -m pip install --upgrade pip setuptools wheel
+      - run:
+          name: Install dependencies (no pip cache)
+          command: |
+            python -m pip install --no-cache-dir -r requirements.txt
       - run:
           command: python testscript_cli.py
           name: TestDLC

--- a/README.md
+++ b/README.md
@@ -72,11 +72,7 @@ Or as an example for GPU support (please check pytorch docs to get the perfect v
 ```bash
 conda install pytorch cudatoolkit=11.3 -c pytorch
 ```
-- [2] Then, [install `pytables`](https://www.pytables.org/usersguide/installation.html):
-```bash
-conda install -c conda-forge pytables==3.8.0
-```
-- [3] Finally, install `DeepLabCut` (with all functions + the GUI):
+- [2] Then, install `DeepLabCut` (with all functions + the GUI):
 
 ```bash
 pip install --pre  "deeplabcut[gui]"

--- a/docs/beginner-guides/beginners-guide.md
+++ b/docs/beginner-guides/beginners-guide.md
@@ -52,15 +52,16 @@ pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
 
 Alright! Next, we will install all the `deeplabcut` source code 🔥. Please decide which version you want (stable or alpha), then type:
 
-- **Alpha release:**
-```
-pip install "git+https://github.com/DeepLabCut/DeepLabCut.git@pytorch_dlc#egg=deeplabcut[gui,modelzoo,wandb]"
-```
-- OR run for the **Stable release:**
+- For the **Stable release:**
 ```
 pip install "deeplabcut[gui,modelzoo,wandb]"
 ```
 - This gives you DeepLabCut, the DLC GUI (gui), our latest neural networks (modelzoo) and a cool data logger (wandb) if you choose to use it later on!
+
+- OR for the **Alpha release (from GitHub bleeding edge of the code):**
+```
+pip install "git+https://github.com/DeepLabCut/DeepLabCut.git@pytorch_dlc#egg=deeplabcut[gui,modelzoo,wandb]"
+```
 
 ## Starting DeepLabCut
 

--- a/docs/beginner-guides/beginners-guide.md
+++ b/docs/beginner-guides/beginners-guide.md
@@ -50,11 +50,7 @@ pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
 
 **(2) Install DeepLabCut** 
 
-Alright! Next, we will install `Tables` (also called pytables), which is a package to read the HDF5 files that make up the backbone of data management in DeepLabCut, then we will install all the `deeplabcut` source code 🔥. Please decide which version you want (stable or alpha), then type: 
-
-```
-conda install -c conda-forge pytables==3.8.0
-```
+Alright! Next, we will install all the `deeplabcut` source code 🔥. Please decide which version you want (stable or alpha), then type:
 
 - **Alpha release:**
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,6 @@ need your GPU drivers installed.
 ```bash
 conda create -n DEEPLABCUT python=3.12
 conda activate DEEPLABCUT
-conda install -c conda-forge pytables==3.8.0
 
 # install PyTorch with your desired CUDA version (or for CPU only) - check [their
 ](https://pytorch.org/get-started/locally/) website:
@@ -36,10 +35,6 @@ pip install --pre deeplabcut[gui]
 # should print `True`
 python -c "import torch; print(torch.cuda.is_available())"
 ```
-
-- Why do we install [pytables](https://www.pytables.org/usersguide/installation.html) with
-`conda` and not `pip`? Because it requires some libraries that not all users will have
-installed, and conda will ensure that they are installed as well.
 
 - If you're familiar with the command line and want TensorFlow support, look [below](
 deeplabcut-with-tf-install) for a fresh installation that has worked for us (on Linux)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,14 +17,13 @@ numba>=0.54.0
 matplotlib>=3.3, <3.8.4
 networkx>=2.6
 numpy>=1.18.5,<2.0.0
-pandas>=1.0.1,!=1.5.0,<3.0
+pandas[hdf5,performance]>=1.0.1,!=1.5.0,<3.0
 Pillow>=7.1
 pyyaml
 scikit-image>=0.17
 scikit-learn>=1.0
 scipy>=1.9
 statsmodels>=0.11
-tables
 torch==2.7.1
 torchvision
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setuptools.setup(
         "matplotlib>=3.3,<3.9,!=3.7.0,!=3.7.1",
         "networkx>=2.6",
         "numpy>=1.18.5,<2.0.0",
-        "pandas>=1.0.1,!=1.5.0,<3.0",
+        "pandas[hdf5,performance]>=1.0.1,!=1.5.0,<3.0",
         "scikit-image>=0.17",
         "scikit-learn>=1.0",
         "scipy>=1.9",
@@ -80,7 +80,6 @@ setuptools.setup(
         "pycocotools",
         "pyyaml",
         "Pillow>=7.1",
-        "tables",
         "h5py>=3.15.1;sys_platform=='darwin'",
     ],
     extras_require={


### PR DESCRIPTION
**Motivation:** 
The separate conda installation of pytables, and it's potential mismatch with the pandas version has been causing some problems in the past (e.g. see recent issues and PRs #3111, #3162, #3163, #3171). Installing pytables from [PyPI](https://pypi.org/project/tables/) as dependency of pandas via the [hdf5] extra, would resolve these issues. 

PR #3184 already addresses this issue by updating the pyproject.toml to the newest PEP standards, but untill that PR is merged, this could PR provide a bridging alternative. Also, the installation instructions with respect to the tables requirement need to be adjusted anyway, so this is addressed in the current PR. 

**Changes:**
- Update requirements.txt and setup.py: add hdf5 extra (pandas -> pandas[hdf5,performance]). This automatically installs the required tables dependency.
- Update Readme, beginners guide, and installation: remove instructions to install tables separately.


**NOTE:** CircleCI is expected to fail on this PR, since the current workflow is set up to explicitly fail when the requirements.txt change with respect to the cached environment. I verified that the tests pass when I temporarily remove this caching restriction (succeeds👍). 

I am keeping the CI workflow in the original state now. @MMathisLab Let me know in case you prefer me to remove the caching restriction for the future (see example in commit [bc3ff85](https://github.com/DeepLabCut/DeepLabCut/pull/3214/commits/bc3ff85172e1d5198900b5d12c0ff07e2086af16)). 