### PR TITLE
Update CircleCI for pyproject.toml-based install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,35 @@ jobs:
   build-and-test:
     executor:
       name: python/default
-      tag: '3.10'
+      tag: '3.10' # or '3.12'
     steps:
       - checkout
+
+      # 1) Restore uv cache (prefer an exact lockfile match)
+      - restore_cache:
+          name: Restore uv cache
+          keys:
+            - v1-uv-{{ checksum "uv.lock" }}
+            - v1-uv-{{ checksum "pyproject.toml" }}
+            - v1-uv-
+
+      # 2) Install deps with uv via the Python orb (simple)
       - python/install-packages:
           pkg-manager: uv
+          # args: "--locked"   # enable this if you commit uv.lock for strict CI installs
+
+      # 3) (Optional) Trim the cache for CI so uploads stay small and fast
+      - run:
+          name: Prune uv cache for CI
+          command: uv cache prune --ci || true
+
+      # 4) Save the cache for next runs
+      - save_cache:
+          name: Save uv cache
+          key: v1-uv-{{ checksum "uv.lock" }}
+          paths:
+            - ~/.cache/uv
+
       - run:
           name: TestDLC
           # uv handles the installation of the dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,12 @@ jobs:
     steps:
       - checkout
 
-      # 1) Restore uv cache (prefer an exact lockfile match)
+      # 1) Restore uv cache
       - restore_cache:
           name: Restore uv cache
           keys:
-            - v1-uv-{{ checksum "uv.lock" }}
             - v1-uv-{{ checksum "pyproject.toml" }}
             - v1-uv-
-
       # 2) Install deps with uv via the Python orb (simple)
       - python/install-packages:
           pkg-manager: uv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,21 @@
 version: 2.1
 
 orbs:
-  python: circleci/python@0.2.1
+  python: circleci/python@4.0.0
 
 jobs:
   build-and-test:
-    working_directory: ~/circleci-demo-python-django
-    docker:
-      - image: circleci/python:3.10  # primary container for the build job
-        auth:
-          username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+    executor:
+      name: python/default
+      tag: '3.10'
     steps:
       - checkout
-      - python/load-cache
-      - python/install-deps
-      - python/save-cache
+      - python/install-packages:
+          pkg-manager: uv
       - run:
-          command: python testscript_cli.py
           name: TestDLC
+          # uv handles the installation of the dependencies
+          command: uv run python testscript_cli.py
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       # 4) Save the cache for next runs
       - save_cache:
           name: Save uv cache
-          key: v1-uv-{{ checksum "uv.lock" }}
+          key: v1-uv-{{ checksum "pyproject.toml" }}
           paths:
             - ~/.cache/uv
 


### PR DESCRIPTION
### Motivation

Following #3184, the removal of requirements.txt will affect CircleCI jobs, as they currently run an old python Orb version that can only use requirements.txt.

### Intended Procedure

- [x] ⚠️Merge #3184 first
- [x] Requires napari-deeplabcut release for install to succeed
- [x] CircleCI  job successfully completes

### Changes

The following introduces :

- A minimal uv-based update of the CircleCI job
  - Switch CircleCI to circleci/python@4.0.0 and use python/default executor. 
  - With caching
  - Relies on pyproject.toml for caching
- Python versions and test scripts stay the same
- Optionally the cache step can be skipped for a more concise job config (not recommended)   