### PR TITLE
Fix redundant/incomplete installs in docs CI, replace with pyproject.toml optional deps

### DIFF
--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install .[docs]
-        pip install jupyter-book==1.0.4.post1 sphinxcontrib-mermaid
+        pip install jupyter-book==1.0.4.post1 sphinxcontrib-mermaid numpydoc
 
     - name: Build the book
       run: |

--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -20,7 +20,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install .[docs]
-        pip install jupyter-book==1.0.4.post1 sphinxcontrib-mermaid numpydoc
 
     - name: Build the book
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,9 +74,10 @@ gui = [
 openvino = [ "openvino-dev==2022.1" ]
 docs = [
   "jupyter-book==1.0.4.post1",
+  "numpydoc",
   "sphinxcontrib-mermaid",
 ]
-fmpose3d = ["fmpose3d"]	
+fmpose3d = [ "fmpose3d" ]
 tf = [
   # !!! TensorFlow is not supported on Windows with Python >= 3.11
   "tensorflow>=2,<=2.10; platform_system=='Windows' and python_version<'3.11'",
@@ -138,6 +139,19 @@ ignore = [
   "E501", # line-too-long
 ]
 
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_sort_within_sections = false
+lexicographical = true
+single_line_exclusions = [ "typing" ]
+order_by_type = false
+group_by_package = true
+line_length = 88
+skip = [
+  "__init__.py",
+]
+
 [tool.pyproject-fmt]
 max_supported_python = "3.12"
 generate_python_version_classifiers = true
@@ -149,18 +163,5 @@ markers = [ "require_models: mark test as requiring models to run" ]
 
 ## TEMPORARY - TODO - Remove after linting changes are made
 [tool.yapf]
- based_on_style = "google"
- indent_width = 4
-
- [tool.isort]
- multi_line_output = 3
- include_trailing_comma = true
- force_sort_within_sections = false
- lexicographical = true
- single_line_exclusions = ['typing']
- order_by_type = false
- group_by_package = true
- line_length = 88
- skip = [
-     "__init__.py",
- ] 
+based_on_style = "google"
+indent_width = 4


### PR DESCRIPTION
### Fix documentation dependencies

* Added missing `numpydoc` to the `docs` dependencies in `pyproject.toml` to support NumPy-style docstrings in documentation builds.
* Removed the redundant installation of `jupyter-book` and `sphinxcontrib-mermaid` from the GitHub Actions workflow, as these are now managed through `pyproject.toml` under `[docs]`.

---

### Miscellaneous changes

Ran pre-commit hooks on pyproject.toml.

**Code formatting and style configuration:**

* Moved and reformatted the `[tool.isort]` section in `pyproject.toml` for better clarity and maintainability, ensuring consistent import sorting across the codebase. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R142-R154) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L154-L166)