### PR TITLE
Optimize CI runner time use on multiple pushes to same PR

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  tests:
     runs-on: ${{ matrix.os }}
 
     # Cancel outdated jobs for the same PR + same matrix combo

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,10 +12,7 @@ jobs:
 
     # Cancel outdated jobs for the same PR + same matrix combo
     concurrency:
-      group: >-
-        tests-${{ github.workflow }}-
-        ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('run-{0}', github.run_id) }}-
-        ${{ matrix.os }}-${{ matrix.python-version }}
+      group: tests-${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('run-{0}', github.run_id) }}-${{ matrix.os }}-${{ matrix.python-version }}
       cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
     strategy:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,6 +10,14 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
 
+    # Cancel outdated jobs for the same PR + same matrix combo
+    concurrency:
+      group: >-
+        tests-${{ github.workflow }}-
+        ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('run-{0}', github.run_id) }}-
+        ${{ matrix.os }}-${{ matrix.python-version }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Introduce a concurrency block to the build job in .github/workflows/python-package.yml to cancel outdated matrix runs for the same PR and matrix combo. The concurrency group combines workflow name, PR number (or run id for non-PR runs), OS and python-version; cancel-in-progress is enabled for pull_request events to reduce wasted CI runs when new commits are pushed.