### PR TITLE
update conda yaml: add pyside6 as conda dependency

### DIFF
--- a/conda-environments/DEEPLABCUT.yaml
+++ b/conda-environments/DEEPLABCUT.yaml
@@ -29,6 +29,7 @@ dependencies:
   - ipython
   - jupyter
   - ffmpeg
+  - pyside6
   - pip:
     - torch
     - torchvision


### PR DESCRIPTION
solves #3252

**Summary**
The installation using our conda yaml can cause a dll shadowing problem on some machines if ffmpeg is installed via conda and pyside6 via pip (the conda-installed ffmpeg dll's are resolved first, but can have a mismatching version for pyside6). This issue of mixing conda and pip installations (for ffmpeg and pyside6) can be addressed by either installing both via pip or both via conda. This PR includes pyside6 as a conda dependency for users of the conda yaml file.

**Notes:**
1. We might want to stop supporting mixed conda + pip installations and delete this yaml file altogether, or at least clearly communicate that installation via uv or pip is preferred over mixed installations via conda + pip (this is not required anymore and still a big cause of installation problems). 
2. An alternative to the current solution in this PR is to remove ffmpeg as a conda requirement, which also solves the problem. It seemed safer for me to add them both as conda requirement for now as I don't know the original motivation for putting ffmpeg as conda requirement in the yaml. If this is not necessary, we might prefer adding both as pip rather than conda requirements.