### PR TITLE
Consolidate test workflow infrastructure in CI

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   detect_changes:
     runs-on: ubuntu-latest
@@ -16,6 +19,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Detect changed files
         id: changed_files
@@ -60,7 +64,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/intelligent-testing.yml
+++ b/.github/workflows/intelligent-testing.yml
@@ -88,58 +88,37 @@ jobs:
 
 
   fast-tests:
-    name: Fast lane (targeted pytest + selected functional)
-    needs: intelligent-test-selection
-    if: needs.intelligent-test-selection.outputs.run_fast == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install test deps
-        run: |
-          python -m pip install --upgrade pip
-          pip install pytest
-          pip install -e ".[tf]" --group dev
-
-      - name: Run targeted pytest (paths selected by selector)
-        env:
-          PYTEST_PATHS: ${{ needs.intelligent-test-selection.outputs.pytest_paths }}
-        run: |
-          python - << 'PY'
-          import json, os, subprocess, sys
-          paths = json.loads(os.environ.get("PYTEST_PATHS", "[]"))
-          if not paths:
-            print("No pytest paths selected; skipping targeted pytest.")
-            sys.exit(0)
-          cmd = ["python", "-m", "pytest"] + paths
-          print("Running:", " ".join(cmd))
-          sys.exit(subprocess.call(cmd))
-          PY
-
-      - name: Run selected functional scripts
-        env:
-          FUN_SCRIPTS: ${{ needs.intelligent-test-selection.outputs.functional_scripts }}
-        run: |
-          python - << 'PY'
-          import json, os, subprocess, sys
-          scripts = json.loads(os.environ.get("FUN_SCRIPTS", "[]"))
-          for s in scripts:
-              print("Running:", s)
-              rc = subprocess.call(["python", s])
-              if rc != 0:
-                  sys.exit(rc)
-          PY
+      name: Fast lane (targeted pytest + selected functional)
+      needs: intelligent-test-selection
+      if: needs.intelligent-test-selection.outputs.run_fast == 'true'
+      uses: ./.github/workflows/python-package.yml
+      with:
+        concurrency_key: ${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || '' }}
+        matrix_json: >-
+          {"include":[{"os":"ubuntu-latest","python-version":"3.12"}]}
+        pytest_paths_json: ${{ needs.intelligent-test-selection.outputs.pytest_paths }}
+        functional_scripts_json: ${{ needs.intelligent-test-selection.outputs.functional_scripts }}
+        full_suite: false
 
   full-tests:
-    name: Full matrix tests
-    needs: intelligent-test-selection
-    if: needs.intelligent-test-selection.outputs.run_full == 'true'
-    uses: ./.github/workflows/python-package.yml
-    with:
-      concurrency_key: ${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || '' }}
+      name: Full matrix tests
+      needs: intelligent-test-selection
+      if: needs.intelligent-test-selection.outputs.run_full == 'true'
+      uses: ./.github/workflows/python-package.yml
+      with:
+        concurrency_key: ${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || '' }}
+        matrix_json: >-
+          {
+            "include": [
+              {"os":"ubuntu-latest","python-version":"3.10"},
+              {"os":"ubuntu-latest","python-version":"3.11"},
+              {"os":"ubuntu-latest","python-version":"3.12"},
+              {"os":"macos-latest","python-version":"3.10"},
+              {"os":"macos-latest","python-version":"3.11"},
+              {"os":"macos-latest","python-version":"3.12"},
+              {"os":"windows-latest","python-version":"3.10"},
+              {"os":"windows-latest","python-version":"3.11"},
+              {"os":"windows-latest","python-version":"3.12"}
+            ]
+          }
+        full_suite: true

--- a/.github/workflows/intelligent-testing.yml
+++ b/.github/workflows/intelligent-testing.yml
@@ -88,37 +88,37 @@ jobs:
 
 
   fast-tests:
-      name: Fast lane (targeted pytest + selected functional)
-      needs: intelligent-test-selection
-      if: needs.intelligent-test-selection.outputs.run_fast == 'true'
-      uses: ./.github/workflows/python-package.yml
-      with:
-        concurrency_key: ${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || '' }}
-        matrix_json: >-
-          {"include":[{"os":"ubuntu-latest","python-version":"3.12"}]}
-        pytest_paths_json: ${{ needs.intelligent-test-selection.outputs.pytest_paths }}
-        functional_scripts_json: ${{ needs.intelligent-test-selection.outputs.functional_scripts }}
-        full_suite: false
+    name: Fast lane (targeted pytest + selected functional)
+    needs: intelligent-test-selection
+    if: needs.intelligent-test-selection.outputs.run_fast == 'true'
+    uses: ./.github/workflows/python-package.yml
+    with:
+      concurrency_key: ${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || '' }}
+      matrix_json: >-
+        {"include":[{"os":"ubuntu-latest","python-version":"3.12"}]}
+      pytest_paths_json: ${{ needs.intelligent-test-selection.outputs.pytest_paths }}
+      functional_scripts_json: ${{ needs.intelligent-test-selection.outputs.functional_scripts }}
+      full_suite: false
 
   full-tests:
-      name: Full matrix tests
-      needs: intelligent-test-selection
-      if: needs.intelligent-test-selection.outputs.run_full == 'true'
-      uses: ./.github/workflows/python-package.yml
-      with:
-        concurrency_key: ${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || '' }}
-        matrix_json: >-
-          {
-            "include": [
-              {"os":"ubuntu-latest","python-version":"3.10"},
-              {"os":"ubuntu-latest","python-version":"3.11"},
-              {"os":"ubuntu-latest","python-version":"3.12"},
-              {"os":"macos-latest","python-version":"3.10"},
-              {"os":"macos-latest","python-version":"3.11"},
-              {"os":"macos-latest","python-version":"3.12"},
-              {"os":"windows-latest","python-version":"3.10"},
-              {"os":"windows-latest","python-version":"3.11"},
-              {"os":"windows-latest","python-version":"3.12"}
-            ]
-          }
-        full_suite: true
+    name: Full matrix tests
+    needs: intelligent-test-selection
+    if: needs.intelligent-test-selection.outputs.run_full == 'true'
+    uses: ./.github/workflows/python-package.yml
+    with:
+      concurrency_key: ${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || '' }}
+      matrix_json: >-
+        {
+          "include": [
+            {"os":"ubuntu-latest","python-version":"3.10"},
+            {"os":"ubuntu-latest","python-version":"3.11"},
+            {"os":"ubuntu-latest","python-version":"3.12"},
+            {"os":"macos-latest","python-version":"3.10"},
+            {"os":"macos-latest","python-version":"3.11"},
+            {"os":"macos-latest","python-version":"3.12"},
+            {"os":"windows-latest","python-version":"3.10"},
+            {"os":"windows-latest","python-version":"3.11"},
+            {"os":"windows-latest","python-version":"3.12"}
+          ]
+        }
+      full_suite: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,13 +7,48 @@ on:
       concurrency_key:
         required: false
         type: string
+      matrix_json:
+        required: true
+        type: string
+      pytest_paths_json:
+        required: false
+        type: string
+        default: "[]"
+      functional_scripts_json:
+        required: false
+        type: string
+        default: "[]"
+      full_suite:
+        required: false
+        type: boolean
+        default: false
+
   workflow_dispatch:
     inputs:
       concurrency_key:
         description: "Optional stable key to dedupe manual runs (for example: pr-123)"
         required: false
         type: string
-
+      matrix_json:
+        description: "JSON matrix definition"
+        required: true
+        type: string
+        default: '{"include":[{"os":"ubuntu-latest","python-version":"3.12"}]}'
+      pytest_paths_json:
+        description: "JSON array of pytest paths"
+        required: false
+        type: string
+        default: "[]"
+      functional_scripts_json:
+        description: "JSON array of functional scripts"
+        required: false
+        type: string
+        default: "[]"
+      full_suite:
+        description: "Run full pytest and default functional suite"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -32,19 +67,9 @@ jobs:
         ${{ matrix.os }}-${{ matrix.python-version }}
       cancel-in-progress: true
 
-
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
-        include:
-          - os: ubuntu-latest
-            path: ~/.cache/pip
-          - os: macos-latest
-            path: ~/Library/Caches/pip
-          - os: windows-latest
-            path: ~\AppData\Local\pip\Cache
+      matrix: ${{ fromJson(inputs.matrix_json) }}
 
     steps:
       - name: Checkout code
@@ -72,48 +97,112 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install TensorFlow
-        shell: bash -el {0}  # Important: activates the conda environment
         if: runner.os != 'macOS'
+        shell: bash -el {0} # Important to enable conda env
         run: |
           pip install --no-cache-dir tensorflow tensorpack==0.11 tf_slim==1.1.0 tf-keras
 
       - name: Install TensorFlow on macOS
-        shell: bash -el {0}  # Important: activates the conda environment
         if: runner.os == 'macOS'
+        shell: bash -el {0}
         run: |
           pip install --no-cache-dir tensorflow-macos tensorpack==0.11 tf_slim==1.1.0 tf-keras
 
       - name: Install dependencies
-        shell: bash -el {0}  # Important: activates the conda environment
+        shell: bash -el {0}
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install --no-cache-dir -e . --group dev
 
       - name: Install ffmpeg
+        shell: bash
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
             sudo apt-get update
-            sudo apt-get install ffmpeg
+            sudo apt-get install -y ffmpeg
           elif [ "$RUNNER_OS" == "macOS" ]; then
             brew install ffmpeg || true
           else
             choco install ffmpeg
           fi
-        shell: bash
 
-      - name: Run pytest tests
-        shell: bash -el {0}  # Important: activates the conda environment
+      - name: Run pytest
+        shell: bash -el {0}
+        env:
+          FULL_SUITE: ${{ inputs.full_suite }}
+          PYTEST_PATHS_JSON: ${{ inputs.pytest_paths_json }}
         run: |
-          pip install --no-cache-dir -e . --group dev
-          python -m pytest
+          python - << 'PY'
+          import json
+          import os
+          import subprocess
+          import sys
 
-      - name: Run functional tests
-        shell: bash -el {0}  # Important: activates the conda environment
+          full_suite = os.environ["FULL_SUITE"].lower() == "true"
+
+          if full_suite:
+              cmd = [sys.executable, "-m", "pytest"]
+              print("Running full pytest suite")
+          else:
+              paths = json.loads(os.environ.get("PYTEST_PATHS_JSON", "[]"))
+              if not paths:
+                  print("No pytest paths selected; skipping pytest.")
+                  raise SystemExit(0)
+              cmd = [sys.executable, "-m", "pytest", *paths]
+              print("Running targeted pytest:", " ".join(paths))
+
+          raise SystemExit(subprocess.call(cmd))
+          PY
+
+      - name: Run functional scripts
+        shell: bash -el {0}
+        env:
+          FULL_SUITE: ${{ inputs.full_suite }}
+          FUNCTIONAL_SCRIPTS_JSON: ${{ inputs.functional_scripts_json }}
+          RUNNER_OS: ${{ runner.os }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
-          pip install -c "$GITHUB_WORKSPACE/.github/versioning/tf-ci-constraints.txt" \
-          tensorflow tensorpack==0.11 tf_slim==1.1.0 tf-keras
-          pip install --no-cache-dir -c "$GITHUB_WORKSPACE/.github/versioning/tf-ci-constraints.txt" -e .
-          python examples/testscript_tensorflow_single_animal.py
-          python examples/testscript_tensorflow_multi_animal.py
-          python examples/testscript_pytorch_single_animal.py
-          python examples/testscript_pytorch_multi_animal.py
+          python - << 'PY'
+          import json
+          import os
+          import subprocess
+          import sys
+
+          full_suite = os.environ["FULL_SUITE"].lower() == "true"
+          runner_os = os.environ["RUNNER_OS"]
+          python_version = os.environ["PYTHON_VERSION"]
+
+          if full_suite:
+              scripts = [
+                  "examples/testscript_tensorflow_single_animal.py",
+                  "examples/testscript_tensorflow_multi_animal.py",
+                  "examples/testscript_pytorch_single_animal.py",
+                  "examples/testscript_pytorch_multi_animal.py",
+              ]
+          else:
+              scripts = json.loads(os.environ.get("FUNCTIONAL_SCRIPTS_JSON", "[]"))
+              if not scripts:
+                  print("No functional scripts selected; skipping functional tests.")
+                  raise SystemExit(0)
+
+          # Respect current TensorFlow support expectations on Windows
+          tf_allowed = not (runner_os == "Windows" and python_version in {"3.11", "3.12"})
+
+          filtered = []
+          for script in scripts:
+              is_tf = "tensorflow" in script
+              if is_tf and not tf_allowed:
+                  print(f"Skipping unsupported TensorFlow script on {runner_os} Python {python_version}: {script}")
+                  continue
+              filtered.append(script)
+
+          if not filtered:
+              print("No functional scripts remain after platform filtering; skipping.")
+              raise SystemExit(0)
+
+          for script in filtered:
+              print("Running:", script)
+              rc = subprocess.call([sys.executable, script])
+              if rc != 0:
+                  raise SystemExit(rc)
+          PY

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -123,7 +123,7 @@ jobs:
           elif [ "$RUNNER_OS" == "macOS" ]; then
             brew install ffmpeg || true
           else
-            choco install ffmpeg
+            choco install ffmpeg -y --no-progress
           fi
 
       - name: Run pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -114,7 +114,8 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           pip install --no-cache-dir -e . --group dev
 
-      - name: Install ffmpeg
+      - name: Install ffmpeg (Linux/macOS)
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
@@ -122,9 +123,40 @@ jobs:
             sudo apt-get install -y ffmpeg
           elif [ "$RUNNER_OS" == "macOS" ]; then
             brew install ffmpeg || true
-          else
-            choco install ffmpeg -y --no-progress
           fi
+
+      - name: Install ffmpeg (Windows, BtbN build)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          FFMPEG_TAG: autobuild-2026-03-31-13-11
+          FFMPEG_ASSET: ffmpeg-master-latest-win64-gpl-shared.zip
+          FFMPEG_SHA256: 084537f4fc8f4a6c6509fc7d25b74df715994107e635a7aee94cdeee054dcac4
+        run: |
+          $ErrorActionPreference = "Stop"
+          $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/$env:FFMPEG_TAG/$env:FFMPEG_ASSET"
+          $zip = Join-Path $env:RUNNER_TEMP $env:FFMPEG_ASSET
+          $dest = Join-Path $env:RUNNER_TEMP "ffmpeg"
+
+          Invoke-WebRequest -Uri $url -OutFile $zip
+
+          $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash.ToLowerInvariant()
+          $expected = $env:FFMPEG_SHA256.ToLowerInvariant()
+
+          if ($actual -ne $expected) {
+            throw "FFmpeg checksum mismatch. Expected $expected but got $actual"
+          }
+          if (Test-Path $dest) { Remove-Item -Recurse -Force $dest }
+          Expand-Archive -Path $zip -DestinationPath $dest -Force
+          $ffdir = Get-ChildItem $dest -Directory | Select-Object -First 1
+          "$($ffdir.FullName)\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Verify ffmpeg/ffprobe available
+        shell: bash -el {0}
+        run: |
+          set -e
+          ffmpeg -version
+          ffprobe -version
 
       - name: Run pytest
         shell: bash -el {0}

--- a/tools/test_selector.py
+++ b/tools/test_selector.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Deterministic, strictly validated test selector for DeepLabCut.
 
-Outputs orthogonal workflow lane selections plus structured test selections:
+Outputs orthogonal workflow mode selections plus structured test selections:
 
   - lanes: which workflow lanes should run (skip, docs, fast, full)
   - pytest_paths: JSON list of pytest path arguments
@@ -26,10 +26,10 @@ Intended usage in GitHub Actions
     python tools/test_selector.py --write-github-output --json
 
 This will write the following keys to $GITHUB_OUTPUT:
-    - run_skip (bool): whether to run the skip lane
-    - run_docs (bool): whether to run the docs lane
-    - run_fast (bool): whether to run the fast lane
-    - run_full (bool): whether to run the full lane
+    - run_skip (bool): whether to run the skip mode
+    - run_docs (bool): whether to run the docs workflow
+    - run_fast (bool): whether to run targeted test execution
+    - run_full (bool): whether to run the full matrix/full suite workflow
     - selected_workflows (list): list of selected workflow lanes
     - lane_reasons (dict): reasons for selecting each workflow lane
     - diff_mode (str): how the diff was determined
@@ -112,7 +112,7 @@ class LaneSelection(BaseModel):
 
     skip: bool = False  # Skip all tests (e.g. lint-only changes only)
     docs: bool = False  # Run docs build checks
-    fast: bool = False  # Run targeted pytest + optional functional scripts (single-lane)
+    fast: bool = False  # Run targeted pytest + optional functional scripts in test workflow
     full: bool = False  # Delegate to full test workflow/matrix
 
 


### PR DESCRIPTION
## Summary

This PR consolidates CI test execution so that dependency installation and test/script execution live in a single reusable workflow, instead of being split across multiple jobs with partially duplicated setup logic and different dependencies.
The main goal is to reduce drift between the fast/targeted lane and the full matrix lane, while preserving the current intelligent test-selection behavior.

## Requires

- [x] Requires #3216 to be merged
- [x] ⚠️ Branch target should be updated to `main` if #3216 has been merged

## Motivation

Before this change, CI test execution was spread across two workflows/jobs:
- the fast lane installed and ran tests/scripts one way
- the full matrix installed and ran them another way

This made it easy for the two paths to drift over time, especially around:
- Python/package dependency installation
- TensorFlow-related setup
- system dependencies such as ffmpeg
- how pytest and functional scripts were invoked

In practice, this meant the fast lane could fail for environment reasons that were unrelated to the code under test, simply because its runtime setup no longer matched the full test workflow.
This PR addresses that by making the reusable Python test workflow the single place where CI test environments are setup and where pytest / functional scripts are executed.

## What changed
### CI architecture

Refactored the reusable Python test workflow so it can serve both:
- full matrix execution
- targeted/fast execution

Updated the intelligent test-selection workflow so it acts primarily as a planner/router:

- it still determines whether to run skip, docs, fast, or full
- but it now delegates actual test execution to the shared reusable workflow

### Dependency/setup consolidation

- Centralized dependency installation in one location (ffmpeg installation notably)

This PR does not change the high-level test selection policy itself.
In particular:
- the selector still decides between skip, docs, fast, and full
- full-suite triggers remain unchanged
- category-based routing remains unchanged