### PR TITLE
Update CI formatting workflow: fix checkout for forked pull requests

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -60,7 +60,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   detect_changes:
     runs-on: ubuntu-latest
@@ -16,6 +19,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Detect changed files
         id: changed_files


### PR DESCRIPTION
**Motivation:**
This PR fixes CI checkout failures for forked pull requests by relying on the default GitHub ref behavior instead of forcing the PR head branch. See https://github.com/DeepLabCut/DeepLabCut/pull/3220 for an example


**Details:**
Updated `format.yml` (pre-commit workflow): changed the “Checkout PR branch” step to stop forcing `ref: ${{ github.head_ref }}`, so pre-commit runs against the PR merge ref that always exists on the CI runner’s repository.