### PR TITLE
Refactor Analyze Videos tab

### DIFF
--- a/deeplabcut/gui/components.py
+++ b/deeplabcut/gui/components.py
@@ -250,9 +250,25 @@ class VideoSelectionWidget(QtWidgets.QWidget):
         """
         Update the dropdown/root videotype without triggering update_videotype(),
         because that method clears the current selection.
+
+        Only updates the underlying state if the videotype is supported by the
+        current QComboBox items. Otherwise, leaves the current state unchanged and
+        logs a warning.
         """
         normalized = (vtype or "").lower().lstrip(".")
         current = (self.videotype_widget.currentText() or "").lower().lstrip(".")
+
+        if not normalized:
+            self.root.logger.warning("Attempted to set an empty videotype silently; keeping current selection.")
+            return
+
+        # Validate against actual combo-box items
+        if self.videotype_widget.findText(normalized) == -1:
+            self.root.logger.warning(
+                f"Attempted to set unsupported videotype '{normalized}' silently; "
+                f"keeping current videotype '{current}'."
+            )
+            return
 
         if normalized != current:
             self.videotype_widget.blockSignals(True)

--- a/deeplabcut/gui/components.py
+++ b/deeplabcut/gui/components.py
@@ -177,7 +177,7 @@ class VideoSelectionWidget(QtWidgets.QWidget):
         self.videotype_widget = QtWidgets.QComboBox()
         self.videotype_widget.setMinimumWidth(100)
         self.videotype_widget.addItems(DLCParams.VIDEOTYPES)
-        self.videotype_widget.setCurrentText(self.root.video_type)
+        self.videotype_widget.setCurrentText(self._normalize_videotype(self.root.video_type))
         self.root.video_type_.connect(self.videotype_widget.setCurrentText)
         self.videotype_widget.currentTextChanged.connect(self.update_videotype)
 
@@ -206,8 +206,11 @@ class VideoSelectionWidget(QtWidgets.QWidget):
     def files(self):
         return self.root.video_files
 
+    def _normalize_videotype(self, vtype: str) -> str:
+        return (vtype or "").lower().lstrip(".")
+
     @property
-    def selected_suffixes(self):
+    def selected_suffixes(self) -> set[str]:
         """Return normalized suffixes (without leading dot) of currently selected files."""
         suffixes = set()
         for f in self.files:
@@ -216,7 +219,11 @@ class VideoSelectionWidget(QtWidgets.QWidget):
                 suffixes.add(suffix)
         return suffixes
 
-    def get_effective_videotype(self, prefer_selected_files: bool = False, with_dot: bool = True):
+    def get_effective_videotype(
+        self,
+        prefer_selected_files: bool = False,
+        with_dot: bool = True,
+    ) -> str:
         """
         Return the videotype to use.
 
@@ -224,21 +231,20 @@ class VideoSelectionWidget(QtWidgets.QWidget):
         If prefer_selected_files=True and the selected files all share one suffix,
         that suffix is used instead.
         """
-        videotype = self.videotype_widget.currentText()
+        videotype = self._normalize_videotype(self.videotype_widget.currentText())
 
         if prefer_selected_files:
             suffixes = self.selected_suffixes
             if len(suffixes) == 1:
                 videotype = next(iter(suffixes))
 
-        videotype = (videotype or "").lower().lstrip(".")
         if with_dot and videotype:
             return f".{videotype}"
         return videotype
 
     def get_files_grouped_by_suffix(self, keep_dot: bool = False) -> dict[str, list[str]]:
-        """Return a dict grouping selected files by their suffixes"""
-        groups = {}
+        """Return a dict grouping selected files by their suffixes."""
+        groups: dict[str, list[str]] = {}
         for f in self.files:
             suffix = Path(f).suffix.lower()
             if not keep_dot:
@@ -246,17 +252,49 @@ class VideoSelectionWidget(QtWidgets.QWidget):
             groups.setdefault(suffix, []).append(f)
         return groups
 
+    def _all_supported_video_patterns(self) -> list[str]:
+        """Return all supported video patterns in both lower and upper case."""
+        return [f"*.{ext.lower()}" for ext in DLCParams.VIDEOTYPES[1:]] + [
+            f"*.{ext.upper()}" for ext in DLCParams.VIDEOTYPES[1:]
+        ]
+
+    def _build_video_filter(self) -> str:
+        """
+        Build the file dialog filter.
+
+        By default, preserve current behavior: show all supported video types.
+        If strict_videotype_filter is enabled, restrict to the currently selected
+        videotype when it is non-empty. If the current dropdown value is empty
+        (the "all types" option), fall back to the full supported-extension filter.
+        """
+        all_video_types = self._all_supported_video_patterns()
+
+        if self.strict_videotype_filter:
+            current = self.get_effective_videotype(
+                prefer_selected_files=False,
+                with_dot=False,
+            )
+
+            if current:
+                video_types = [f"*.{current.lower()}", f"*.{current.upper()}"]
+            else:
+                # "All types" entry selected: keep the dialog usable
+                video_types = all_video_types
+        else:
+            video_types = all_video_types
+
+        return f"Videos ({' '.join(video_types)})"
+
     def _set_videotype_silently(self, vtype: str):
         """
         Update the dropdown/root videotype without triggering update_videotype(),
         because that method clears the current selection.
 
-        Only updates the underlying state if the videotype is supported by the
-        current QComboBox items. Otherwise, leaves the current state unchanged and
-        logs a warning.
+        Only updates state if the videotype is supported by the combo box.
+        Otherwise, leaves the current state unchanged.
         """
-        normalized = (vtype or "").lower().lstrip(".")
-        current = (self.videotype_widget.currentText() or "").lower().lstrip(".")
+        normalized = self._normalize_videotype(vtype)
+        current = self._normalize_videotype(self.videotype_widget.currentText())
 
         if not normalized:
             self.root.logger.warning("Attempted to set an empty videotype silently; keeping current selection.")
@@ -277,37 +315,33 @@ class VideoSelectionWidget(QtWidgets.QWidget):
 
         self.root.video_type = normalized
 
-    def update_videotype(self, vtype):
+    def update_videotype(self, vtype: str):
+        normalized = self._normalize_videotype(vtype)
         self.clear_selected_videos()
-        self.root.video_type = vtype
+        self.root.video_type = normalized
 
     def _update_video_selection(self, videopaths):
         n_videos = len(self.root.video_files)
         if n_videos:
-            self.selected_videos_text.setText(f"{n_videos} videos selected")
+            suffixes = self.selected_suffixes
+            if len(suffixes) == 1:
+                suffix = next(iter(suffixes))
+                self.selected_videos_text.setText(f"{n_videos} videos selected (.{suffix})")
+            elif len(suffixes) > 1:
+                counts = {
+                    suffix: len(files) for suffix, files in self.get_files_grouped_by_suffix(keep_dot=False).items()
+                }
+                summary = ", ".join(f"{count} .{suffix}" for suffix, count in sorted(counts.items()))
+                self.selected_videos_text.setText(
+                    f"{n_videos} videos selected ({summary}; will run in separate batches)"
+                )
+            else:
+                self.selected_videos_text.setText(f"{n_videos} videos selected")
+
             self.select_video_button.setText("Add more videos")
         else:
             self.selected_videos_text.setText("")
             self.select_video_button.setText("Select videos")
-
-    def _build_video_filter(self):
-        """
-        Build the file dialog filter.
-        By default, preserve current behavior: show all supported video types.
-        Optionally, restrict to the current dropdown videotype.
-        """
-        if self.strict_videotype_filter:
-            current = self.get_effective_videotype(prefer_selected_files=False, with_dot=False)
-            if current:
-                video_types = [f"*.{current.lower()}", f"*.{current.upper()}"]
-            else:
-                video_types = []
-        else:
-            video_types = [f"*.{ext.lower()}" for ext in DLCParams.VIDEOTYPES[1:]] + [
-                f"*.{ext.upper()}" for ext in DLCParams.VIDEOTYPES[1:]
-            ]
-
-        return f"Videos ({' '.join(video_types)})"
 
     def update_videos(self):
         directory_to_open = self.root.project_folder
@@ -327,6 +361,7 @@ class VideoSelectionWidget(QtWidgets.QWidget):
             # Optional safety: sync dropdown to selected file suffix
             if self.sync_videotype_with_selection:
                 suffixes = {Path(v).suffix.lower().lstrip(".") for v in abs_files if Path(v).suffix}
+
                 if len(suffixes) == 1:
                     inferred = next(iter(suffixes))
                     self._set_videotype_silently(inferred)

--- a/deeplabcut/gui/components.py
+++ b/deeplabcut/gui/components.py
@@ -154,12 +154,19 @@ class VideoSelectionWidget(QtWidgets.QWidget):
         self,
         root: QtWidgets.QMainWindow,
         parent: QtWidgets.QWidget,
+        *,
         hide_videotype: bool = False,
+        sync_videotype_with_selection: bool = False,
+        strict_videotype_filter: bool = False,
     ):
         super().__init__(parent)
 
         self.root = root
         self.parent = parent
+
+        # Optional safeties; defaults preserve current behavior
+        self.sync_videotype_with_selection = sync_videotype_with_selection
+        self.strict_videotype_filter = strict_videotype_filter
 
         self._init_layout(hide_videotype)
 
@@ -181,7 +188,7 @@ class VideoSelectionWidget(QtWidgets.QWidget):
         self.root.video_files_.connect(self._update_video_selection)
 
         # Number of selected videos text
-        self.selected_videos_text = QtWidgets.QLabel("")  # updated when videos are selected
+        self.selected_videos_text = QtWidgets.QLabel("")
 
         # Clear video selection
         self.clear_videos = QtWidgets.QPushButton("Clear selection")
@@ -199,6 +206,61 @@ class VideoSelectionWidget(QtWidgets.QWidget):
     def files(self):
         return self.root.video_files
 
+    @property
+    def selected_suffixes(self):
+        """Return normalized suffixes (without leading dot) of currently selected files."""
+        suffixes = set()
+        for f in self.files:
+            suffix = Path(f).suffix.lower().lstrip(".")
+            if suffix:
+                suffixes.add(suffix)
+        return suffixes
+
+    def get_effective_videotype(self, prefer_selected_files: bool = False, with_dot: bool = True):
+        """
+        Return the videotype to use.
+
+        By default, preserves current behavior and uses the dropdown.
+        If prefer_selected_files=True and the selected files all share one suffix,
+        that suffix is used instead.
+        """
+        videotype = self.videotype_widget.currentText()
+
+        if prefer_selected_files:
+            suffixes = self.selected_suffixes
+            if len(suffixes) == 1:
+                videotype = next(iter(suffixes))
+
+        videotype = (videotype or "").lower().lstrip(".")
+        if with_dot and videotype:
+            return f".{videotype}"
+        return videotype
+
+    def get_files_grouped_by_suffix(self, keep_dot: bool = False) -> dict[str, list[str]]:
+        """Return a dict grouping selected files by their suffixes"""
+        groups = {}
+        for f in self.files:
+            suffix = Path(f).suffix.lower()
+            if not keep_dot:
+                suffix = suffix.lstrip(".")
+            groups.setdefault(suffix, []).append(f)
+        return groups
+
+    def _set_videotype_silently(self, vtype: str):
+        """
+        Update the dropdown/root videotype without triggering update_videotype(),
+        because that method clears the current selection.
+        """
+        normalized = (vtype or "").lower().lstrip(".")
+        current = (self.videotype_widget.currentText() or "").lower().lstrip(".")
+
+        if normalized != current:
+            self.videotype_widget.blockSignals(True)
+            self.videotype_widget.setCurrentText(normalized)
+            self.videotype_widget.blockSignals(False)
+
+        self.root.video_type = normalized
+
     def update_videotype(self, vtype):
         self.clear_selected_videos()
         self.root.video_type = vtype
@@ -212,15 +274,28 @@ class VideoSelectionWidget(QtWidgets.QWidget):
             self.selected_videos_text.setText("")
             self.select_video_button.setText("Select videos")
 
+    def _build_video_filter(self):
+        """
+        Build the file dialog filter.
+        By default, preserve current behavior: show all supported video types.
+        Optionally, restrict to the current dropdown videotype.
+        """
+        if self.strict_videotype_filter:
+            current = self.get_effective_videotype(prefer_selected_files=False, with_dot=False)
+            if current:
+                video_types = [f"*.{current.lower()}", f"*.{current.upper()}"]
+            else:
+                video_types = []
+        else:
+            video_types = [f"*.{ext.lower()}" for ext in DLCParams.VIDEOTYPES[1:]] + [
+                f"*.{ext.upper()}" for ext in DLCParams.VIDEOTYPES[1:]
+            ]
+
+        return f"Videos ({' '.join(video_types)})"
+
     def update_videos(self):
         directory_to_open = self.root.project_folder
-
-        # Create a filter string with both lowercase and uppercase extensions
-
-        video_types = [f"*.{ext.lower()}" for ext in DLCParams.VIDEOTYPES[1:]] + [
-            f"*.{ext.upper()}" for ext in DLCParams.VIDEOTYPES[1:]
-        ]
-        video_filter = f"Videos ({' '.join(video_types)})"
+        video_filter = self._build_video_filter()
 
         filenames = QtWidgets.QFileDialog.getOpenFileNames(
             parent=self,
@@ -230,8 +305,21 @@ class VideoSelectionWidget(QtWidgets.QWidget):
         )
 
         if filenames[0]:
-            # Qt returns a tuple (list of files, filetype)
-            self.root.add_video_files([os.path.abspath(vid) for vid in filenames[0]])
+            abs_files = [os.path.abspath(vid) for vid in filenames[0]]
+            self.root.add_video_files(abs_files)
+
+            # Optional safety: sync dropdown to selected file suffix
+            if self.sync_videotype_with_selection:
+                suffixes = {Path(v).suffix.lower().lstrip(".") for v in abs_files if Path(v).suffix}
+                if len(suffixes) == 1:
+                    inferred = next(iter(suffixes))
+                    self._set_videotype_silently(inferred)
+                    self.root.logger.info(f"Inferred videotype '{inferred}' from selected file(s)")
+                elif len(suffixes) > 1:
+                    self.root.logger.warning(
+                        f"Selected videos have mixed suffixes {sorted(suffixes)}; "
+                        "keeping current videotype dropdown unchanged."
+                    )
 
     def clear_selected_videos(self):
         self.root.clear_video_files()

--- a/deeplabcut/gui/tabs/analyze_videos.py
+++ b/deeplabcut/gui/tabs/analyze_videos.py
@@ -38,14 +38,14 @@ class AnalyzeVideosOptions:
     filter_data: bool
     plot_trajectories: bool
     show_trajectory_plots: bool
-    displayed_bodyparts: list[str]
+    displayed_bodyparts: tuple[str, ...]
     create_video_all_detections: bool
     auto_track: bool
     calibrate_assembly: bool
     assemble_with_ID_only: bool
     num_animals_in_videos: int | None
-    cropping: tuple | None
-    dynamic_cropping_params: tuple
+    cropping: tuple[int, int, int, int] | None
+    dynamic_cropping_params: tuple[bool, float, int]
     track_method: str | None
 
 

--- a/deeplabcut/gui/tabs/analyze_videos.py
+++ b/deeplabcut/gui/tabs/analyze_videos.py
@@ -8,6 +8,7 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
+from dataclasses import dataclass
 from functools import partial
 
 from PySide6 import QtWidgets
@@ -26,8 +27,26 @@ from deeplabcut.gui.components import (
 )
 from deeplabcut.gui.utils import move_to_separate_thread
 from deeplabcut.gui.widgets import ConfigEditor
-from deeplabcut.utils import auxfun_multianimal
 from deeplabcut.utils.auxiliaryfunctions import edit_config
+
+
+@dataclass(frozen=True)
+class AnalyzeVideosOptions:
+    config: str
+    shuffle: int
+    save_as_csv: bool
+    filter_data: bool
+    plot_trajectories: bool
+    show_trajectory_plots: bool
+    displayed_bodyparts: list[str]
+    create_video_all_detections: bool
+    auto_track: bool
+    calibrate_assembly: bool
+    assemble_with_ID_only: bool
+    num_animals_in_videos: int | None
+    cropping: tuple | None
+    dynamic_cropping_params: tuple
+    track_method: str | None
 
 
 class AnalyzeVideos(DefaultTab):
@@ -42,7 +61,9 @@ class AnalyzeVideos(DefaultTab):
 
     def _set_page(self):
         self.main_layout.addWidget(_create_label_widget("Video Selection", "font:bold"))
-        self.video_selection_widget = VideoSelectionWidget(self.root, self)
+        self.video_selection_widget = VideoSelectionWidget(
+            self.root, self, hide_videotype=True, sync_videotype_with_selection=True
+        )
         self.main_layout.addWidget(self.video_selection_widget)
 
         tmp_layout = _create_horizontal_layout()
@@ -246,28 +267,31 @@ class AnalyzeVideos(DefaultTab):
         editor = ConfigEditor(self.root.config)
         editor.show()
 
-    def analyze_videos(self):
+    def _collect_options(self) -> AnalyzeVideosOptions:
         config = self.root.config
         shuffle = self.root.shuffle_value
-
-        videos = list(self.files)
         save_as_csv = self.save_as_csv.isChecked()
-        videotype = self.video_selection_widget.videotype_widget.currentText()
+        filter_data = self.filter_predictions.isChecked()
+        plot_trajectories = self.plot_trajectories.isChecked()
+        show_trajectory_plots = self.show_trajectory_plots.isChecked()
+        displayed_bodyparts = self.bodyparts_list_widget.selected_bodyparts if plot_trajectories else []
 
         if self.root.is_multianimal:
             calibrate_assembly = self.calibrate_assembly_checkbox.isChecked()
             assemble_with_ID_only = self.assemble_with_ID_only_checkbox.isChecked()
             track_method = self.tracker_type_widget.currentText()
-            edit_config(self.root.config, {"default_track_method": track_method})
             num_animals_in_videos = self.num_animals_in_videos.value()
+            create_video_all_detections = self.create_detections_video_checkbox.isChecked()
         else:
             calibrate_assembly = False
-            num_animals_in_videos = None
             assemble_with_ID_only = False
+            track_method = None
+            num_animals_in_videos = None
+            create_video_all_detections = False
 
         cropping = None
-
-        if self.root.cfg["cropping"] == "True":
+        crop_flag = self.root.cfg.get("cropping", False)
+        if str(crop_flag).lower() == "true":
             cropping = (
                 self.root.cfg["x1"],
                 self.root.cfg["x2"],
@@ -276,84 +300,120 @@ class AnalyzeVideos(DefaultTab):
             )
 
         dynamic_cropping_params = (False, 0.5, 10)
-        try:
-            if self.dynamic_cropping:
-                dynamic_cropping_params = (True, 0.5, 10)
-        except AttributeError:
-            pass
+        if getattr(self, "dynamic_cropping", False):
+            dynamic_cropping_params = (True, 0.5, 10)
 
-        func = partial(
-            deeplabcut.analyze_videos,
-            config,
-            videos=videos,
-            videotype=videotype,
+        return AnalyzeVideosOptions(
+            config=config,
             shuffle=shuffle,
             save_as_csv=save_as_csv,
-            cropping=cropping,
-            dynamic=dynamic_cropping_params,
+            filter_data=filter_data,
+            plot_trajectories=plot_trajectories,
+            show_trajectory_plots=show_trajectory_plots,
+            displayed_bodyparts=displayed_bodyparts,
+            create_video_all_detections=create_video_all_detections,
             auto_track=self.root.is_multianimal,
-            n_tracks=num_animals_in_videos,
-            calibrate=calibrate_assembly,
-            identity_only=assemble_with_ID_only,
+            calibrate_assembly=calibrate_assembly,
+            assemble_with_ID_only=assemble_with_ID_only,
+            num_animals_in_videos=num_animals_in_videos,
+            cropping=cropping,
+            dynamic_cropping_params=dynamic_cropping_params,
+            track_method=track_method,
         )
 
-        self.worker, self.thread = move_to_separate_thread(func)
-        self.worker.finished.connect(lambda: self.analyze_videos_btn.setEnabled(True))
-        self.worker.finished.connect(lambda: self.root._progress_bar.hide())
-        self.worker.finished.connect(lambda: self.run_enabled())
-        self.thread.start()
-        self.analyze_videos_btn.setEnabled(False)
-        self.root._progress_bar.show()
+    def _get_video_batches(self):
+        """
+        Returns a list of (videotype, videos) pairs.
+        videotype should include the leading dot, e.g. '.avi'.
+        """
+        groups = self.video_selection_widget.get_files_grouped_by_suffix(keep_dot=True)
+        batches = [(suffix, videos) for suffix, videos in sorted(groups.items()) if suffix]
+        return batches
 
-    def run_enabled(self):
-        config = self.root.config
-        shuffle = self.root.shuffle_value
+    def _run_pipeline(self, options: AnalyzeVideosOptions, batches: list[tuple[str, list[str]]]):
+        for videotype, videos in batches:
+            try:
+                self.root.logger.info(f"Analyzing {len(videos)} video(s) with extension {videotype}")
 
-        videos = list(self.files)
-        save_as_csv = self.save_as_csv.isChecked()
-        filter_data = self.filter_predictions.isChecked()
-        videotype = self.video_selection_widget.videotype_widget.currentText()
-        try:
-            create_video_all_detections = self.create_detections_video_checkbox.isChecked()
-        except AttributeError:
-            create_video_all_detections = False
-        if create_video_all_detections:
+                deeplabcut.analyze_videos(
+                    options.config,
+                    videos=videos,
+                    videotype=videotype,
+                    shuffle=options.shuffle,
+                    save_as_csv=options.save_as_csv,
+                    cropping=options.cropping,
+                    dynamic=options.dynamic_cropping_params,
+                    auto_track=options.auto_track,
+                    n_tracks=options.num_animals_in_videos,
+                    calibrate=options.calibrate_assembly,
+                    identity_only=options.assemble_with_ID_only,
+                )
+
+                self._run_postprocessing_for_group(options, videotype, videos)
+            except Exception as e:
+                self.root.logger.error(f"Error analyzing videos {videos} with extension {videotype}: {e}")
+
+    def _run_postprocessing_for_group(
+        self,
+        options: AnalyzeVideosOptions,
+        videotype: str,
+        videos: list[str],
+    ):
+        if options.create_video_all_detections:
             deeplabcut.create_video_with_all_detections(
-                config,
+                options.config,
                 videos=videos,
                 videotype=videotype,
-                shuffle=shuffle,
+                shuffle=options.shuffle,
             )
 
-        track_method = auxfun_multianimal.get_track_method(self.root.cfg)
-        if filter_data:
+        if options.filter_data:
             deeplabcut.filterpredictions(
-                config,
+                options.config,
                 video=videos,
                 videotype=videotype,
-                shuffle=shuffle,
+                shuffle=options.shuffle,
                 filtertype="median",
                 windowlength=5,
-                save_as_csv=save_as_csv,
-                track_method=track_method,
+                save_as_csv=options.save_as_csv,
+                track_method=options.track_method,
             )
 
-        if self.plot_trajectories.isChecked():
-            bdpts = self.bodyparts_list_widget.selected_bodyparts
-            self.root.logger.debug(f"Selected body parts for plot_trajectories: {bdpts}")
+        if options.plot_trajectories:
             deeplabcut.plot_trajectories(
-                config,
+                options.config,
                 videos=videos,
-                displayedbodyparts=bdpts,
+                displayedbodyparts=options.displayed_bodyparts,
                 videotype=videotype,
-                shuffle=shuffle,
-                filtered=filter_data,
-                showfigures=self.show_trajectory_plots.isChecked(),
-                track_method=track_method,
+                shuffle=options.shuffle,
+                filtered=options.filter_data,
+                showfigures=options.show_trajectory_plots,
+                track_method=options.track_method,
             )
 
-        if self.root.is_multianimal and save_as_csv:
+        if options.auto_track and options.save_as_csv:
             deeplabcut.analyze_videos_converth5_to_csv(
                 videos,
                 listofvideos=True,
             )
+
+    def analyze_videos(self):
+        options = self._collect_options()
+        batches = self._get_video_batches()
+
+        if not batches:
+            self.root.logger.warning("No videos selected.")
+            return
+
+        # Keep config in sync with GUI choice before launching worker
+        if self.root.is_multianimal and options.track_method is not None:
+            edit_config(self.root.config, {"default_track_method": options.track_method})
+
+        func = partial(self._run_pipeline, options, batches)
+
+        self.worker, self.thread = move_to_separate_thread(func)
+        self.worker.finished.connect(lambda: self.analyze_videos_btn.setEnabled(True))
+        self.worker.finished.connect(lambda: self.root._progress_bar.hide())
+        self.thread.start()
+        self.analyze_videos_btn.setEnabled(False)
+        self.root._progress_bar.show()

--- a/deeplabcut/gui/tabs/analyze_videos.py
+++ b/deeplabcut/gui/tabs/analyze_videos.py
@@ -351,7 +351,9 @@ class AnalyzeVideos(DefaultTab):
 
                 self._run_postprocessing_for_group(options, videotype, videos)
             except Exception as e:
-                self.root.logger.error(f"Error analyzing videos {videos} with extension {videotype}: {e}")
+                self.root.logger.error(
+                    f"Error analyzing videos {videos} with extension {videotype}: {e}", exc_info=True
+                )
 
     def _run_postprocessing_for_group(
         self,

--- a/deeplabcut/gui/tabs/analyze_videos.py
+++ b/deeplabcut/gui/tabs/analyze_videos.py
@@ -10,6 +10,7 @@
 #
 from dataclasses import dataclass
 from functools import partial
+from pathlib import Path
 
 from PySide6 import QtWidgets
 from PySide6.QtCore import Qt
@@ -330,6 +331,19 @@ class AnalyzeVideos(DefaultTab):
         batches = [(suffix, videos) for suffix, videos in sorted(groups.items()) if suffix]
         return batches
 
+    def _get_unique_video_parent_folders(self, batches: list[tuple[str, list[str]]]) -> list[str]:
+        folders = []
+        seen = set()
+
+        for _, videos in batches:
+            for video in videos:
+                parent = str(Path(video).parent.resolve())
+                if parent not in seen:
+                    seen.add(parent)
+                    folders.append(parent)
+
+        return folders
+
     def _run_pipeline(self, options: AnalyzeVideosOptions, batches: list[tuple[str, list[str]]]):
         for videotype, videos in batches:
             try:
@@ -354,6 +368,10 @@ class AnalyzeVideos(DefaultTab):
                 exc = f"Error analyzing videos {videos} with extension {videotype}: {e}"
                 self.root.logger.error(exc, exc_info=True)
                 raise RuntimeError(exc) from e
+
+        # Run CSV conversion once per unique folder, after all batches
+        if options.auto_track and options.save_as_csv:
+            self._convert_outputs_to_csv_once_per_folder(batches)
 
     def _run_postprocessing_for_group(
         self,
@@ -393,10 +411,14 @@ class AnalyzeVideos(DefaultTab):
                 track_method=options.track_method,
             )
 
-        if options.auto_track and options.save_as_csv:
+    def _convert_outputs_to_csv_once_per_folder(self, batches: list[tuple[str, list[str]]]):
+        folders = self._get_unique_video_parent_folders(batches)
+
+        for folder in folders:
+            self.root.logger.info(f"Converting H5 outputs to CSV in folder: {folder}")
             deeplabcut.analyze_videos_converth5_to_csv(
-                videos,
-                listofvideos=True,
+                folder,
+                listofvideos=False,
             )
 
     def analyze_videos(self):

--- a/deeplabcut/gui/tabs/analyze_videos.py
+++ b/deeplabcut/gui/tabs/analyze_videos.py
@@ -274,7 +274,7 @@ class AnalyzeVideos(DefaultTab):
         filter_data = self.filter_predictions.isChecked()
         plot_trajectories = self.plot_trajectories.isChecked()
         show_trajectory_plots = self.show_trajectory_plots.isChecked()
-        displayed_bodyparts = self.bodyparts_list_widget.selected_bodyparts if plot_trajectories else []
+        displayed_bodyparts = tuple(self.bodyparts_list_widget.selected_bodyparts) if plot_trajectories else ()
 
         if self.root.is_multianimal:
             calibrate_assembly = self.calibrate_assembly_checkbox.isChecked()
@@ -351,9 +351,9 @@ class AnalyzeVideos(DefaultTab):
 
                 self._run_postprocessing_for_group(options, videotype, videos)
             except Exception as e:
-                self.root.logger.error(
-                    f"Error analyzing videos {videos} with extension {videotype}: {e}", exc_info=True
-                )
+                exc = f"Error analyzing videos {videos} with extension {videotype}: {e}"
+                self.root.logger.error(exc, exc_info=True)
+                raise RuntimeError(exc) from e
 
     def _run_postprocessing_for_group(
         self,


### PR DESCRIPTION
### Scope

- Adds optional, backward-compatible options to the VideoSelectionWidget to automatically synchronize the file extension dropdown with selected video's filetype
- Reworks the GUI's workflow to be more robust, fail early on mismatches, make it clearer which options are being used and be robust to multiple video types being selected at once

This helps in setting up a robust foundation for future changes related to video selection and type inference.

Tested successfully on a mix of mp4/avi videos, analysis runs as expected and results are correct.

### Goals

Streamline UX for analyzing videos, making it simpler to run on mixed videos.
Intended to help close #3260, further fixes may be made accordingly

### Backward compatibility note

- VideoSelectionWidget is fully backwards compatible
- The Analyze videos tab no longer has a filetype dropdown, and its under-the-hood logic has been significantly reworked.
  - Usage is the same, video selection is simplified
  -  Actual underlying function calls have not changed, nor has the threading infrastructure

---

### Automated summary

This pull request introduces significant improvements to the video analysis workflow in the DeepLabCut GUI, focusing on more robust handling of video file types, improved batch processing, and cleaner separation of options and logic. Key changes include enhanced video type inference and filtering, a new options dataclass, and a refactored analysis pipeline that processes videos in groups by file extension.

**Video selection and file type handling:**
- The `VideoSelectionWidget` now supports optional behaviors for syncing the videotype dropdown with selected files and for stricter filtering of selectable video types. It also provides utilities to infer video types from selected files and to group files by their suffixes.
- The video file dialog can now be restricted to show only files matching the currently selected videotype, improving user safety and reducing accidental selection of unsupported files.

**Analysis workflow refactor:**
- Video analysis is now performed in batches grouped by file extension, with each group processed separately. This allows for more accurate handling of different video types and simplifies downstream processing.
- The logic for collecting analysis options has been moved into a new `_collect_options` method, which returns an immutable `AnalyzeVideosOptions` dataclass.

**Post-processing improvements:**
- Post-processing steps such as creating detection videos, filtering predictions, and plotting trajectories are now handled per group of videos, ensuring correct application of options and reducing the risk of errors.