### PR TITLE
Use pinned ffmpeg version in CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -124,16 +124,19 @@ jobs:
           elif [ "$RUNNER_OS" == "macOS" ]; then
             brew install ffmpeg || true
           fi
-      - name: Install ffmpeg (Windows, BtbN latest)
+      - name: Install ffmpeg (Windows, pinned monthly BtbN build)
         if: runner.os == 'Windows'
         shell: pwsh
         env:
+          FFMPEG_TAG: autobuild-2026-03-31-13-11
           FFMPEG_ASSET: ffmpeg-master-latest-win64-gpl-shared.zip
         run: |
           $ErrorActionPreference = "Stop"
 
+          $tag = $env:FFMPEG_TAG
           $asset = $env:FFMPEG_ASSET
-          $baseUrl = "https://github.com/BtbN/FFmpeg-Builds/releases/latest/download"
+
+          $baseUrl = "https://github.com/BtbN/FFmpeg-Builds/releases/download/$tag"
           $url = "$baseUrl/$asset"
           $checksumsUrl = "$baseUrl/checksums.sha256"
 
@@ -142,13 +145,15 @@ jobs:
           $checksums = Join-Path $tmpRoot "checksums.sha256"
           $dest = Join-Path $tmpRoot "ffmpeg"
 
-          if (Test-Path $tmpRoot) { Remove-Item -Recurse -Force $tmpRoot }
+          if (Test-Path -LiteralPath $tmpRoot) {
+            Remove-Item -LiteralPath $tmpRoot -Recurse -Force
+          }
           New-Item -ItemType Directory -Path $tmpRoot | Out-Null
 
           Invoke-WebRequest -Uri $url -OutFile $zip
           Invoke-WebRequest -Uri $checksumsUrl -OutFile $checksums
 
-          $expected = Get-Content -Path $checksums |
+          $expected = Get-Content -LiteralPath $checksums |
             ForEach-Object {
               if ($_ -match '^(?<sha>[0-9A-Fa-f]{64})\s+\*?(?<name>.+)$' -and $matches.name.Trim() -eq $asset) {
                 $matches.sha.ToLowerInvariant()
@@ -160,14 +165,16 @@ jobs:
             throw "Could not find checksum for $asset in $checksums"
           }
 
-          $actual = (Get-FileHash -Path $zip -Algorithm SHA256).Hash.ToLowerInvariant()
+          $actual = (Get-FileHash -LiteralPath $zip -Algorithm SHA256).Hash.ToLowerInvariant()
           if ($actual -ne $expected) {
             throw "FFmpeg checksum mismatch. Expected $expected but got $actual"
           }
 
-          Expand-Archive -Path $zip -DestinationPath $dest -Force
-          $ffdir = Get-ChildItem -Path $dest -Directory | Select-Object -First 1
-          if (-not $ffdir) { throw "Could not find extracted FFmpeg directory." }
+          Expand-Archive -LiteralPath $zip -DestinationPath $dest -Force
+          $ffdir = Get-ChildItem -LiteralPath $dest -Directory | Select-Object -First 1
+          if (-not $ffdir) {
+            throw "Could not find extracted FFmpeg directory."
+          }
 
           $binDir = Join-Path $ffdir.FullName "bin"
           $binDir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -125,6 +125,8 @@ jobs:
             brew install ffmpeg || true
           fi
       - name: Install ffmpeg (Windows, pinned monthly BtbN build)
+      # NOTE: The pinned version should be retained for ~2 years. This WILL fail if the BtbN release is removed,
+      # so if you are two years in the future and this step fails, please check the builds. Thanks.
         if: runner.os == 'Windows'
         shell: pwsh
         env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -131,7 +131,7 @@ jobs:
         shell: pwsh
         env:
           FFMPEG_TAG: autobuild-2026-03-31-13-11
-          FFMPEG_ASSET: ffmpeg-master-latest-win64-gpl-shared.zip
+          FFMPEG_ASSET: ffmpeg-N-123777-g53537f6cf5-win64-gpl-shared.zip
         run: |
           $ErrorActionPreference = "Stop"
 


### PR DESCRIPTION
### Problem description

Due to the way the BtBn ffmpeg build CI is written, there is a ~2-3 hours gap in the day, starting around 1 PM CEST, where the latest release URL points to the previous build rather than the latest, a drift that causes the download to fail in our CI, as the files in the "latest" release do not have the correct name.

### Proposed solution

To alleviate this, the PR installs a pinned version of ffmpeg from BtBn which should be valid for roughly 2 years, limiting the impact for build downloads. (Includes a note to update in two years.)

### Alternatives

We could revert to Chocolatey or Winget, but with some retry logic to account for sporadic download failures.