### PR TITLE
Docs versioning: Add glob support, better validation and reporting

### DIFF
--- a/tests/tools/docs_and_notebooks_checks/test_check_contracts.py
+++ b/tests/tools/docs_and_notebooks_checks/test_check_contracts.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import os
 import subprocess
+from collections.abc import Callable
 from datetime import date, datetime, timezone
 from pathlib import Path
 from types import ModuleType
@@ -79,6 +80,34 @@ def _write(repo: Path, rel: str, content: str) -> None:
 
 
 # -----------------------------
+# Shared fixtures
+# -----------------------------
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_init(repo)
+    return repo
+
+
+@pytest.fixture
+def cfg(tool) -> Callable[..., object]:
+    def _make_cfg(
+        include: list[str],
+        exclude: list[str] | None = None,
+        **policy_overrides,
+    ):
+        policy = tool.PolicyConfig(**policy_overrides)
+        return tool.ToolConfig(
+            version=1,
+            scan=tool.ScanConfig(include=include, exclude=exclude or []),
+            policy=policy,
+        )
+
+    return _make_cfg
+
+
+# -----------------------------
 # Contract tests
 # -----------------------------
 def test_marker_constants_exist(tool):
@@ -97,14 +126,10 @@ def test_schema_contract_fields(tool):
     assert not hasattr(meta, "last_git_updated")
 
 
-def test_git_content_date_skips_meta_commits(tool, tmp_path: Path):
+def test_git_content_date_skips_meta_commits(tool, repo: Path):
     """
     Contract: last_content_updated is computed from git history excluding metadata commits.
     """
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git_init(repo)
-
     rel = "docs/page.md"
     _write(repo, rel, "# hello\n")
     _git_commit(repo, "docs: initial content", "2020-01-01T12:00:00+00:00")
@@ -131,15 +156,11 @@ def test_git_content_date_skips_meta_commits(tool, tmp_path: Path):
     assert used_fallback is False
 
 
-def test_git_content_date_fallback_when_only_meta_commits(tool, tmp_path: Path):
+def test_git_content_date_fallback_when_only_meta_commits(tool, repo: Path):
     """
     If all commits touching the file are meta-marker commits, we fall back to git_last_touched
     and flag used_fallback=True.
     """
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git_init(repo)
-
     rel = "docs/page.md"
     _write(repo, rel, "---\ndeeplabcut:\n  notes: hi\n---\n")
     _git_commit(
@@ -153,28 +174,20 @@ def test_git_content_date_fallback_when_only_meta_commits(tool, tmp_path: Path):
     assert used_fallback is True
 
 
-def test_scan_is_read_only(tool, tmp_path: Path, monkeypatch):
+def test_scan_is_read_only(tool, repo: Path, cfg):
     """
     Contract: report/check (scan_files) must be read-only.
     We validate by asserting file content does not change.
     """
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git_init(repo)
-
     rel = "docs/page.md"
     orig = "---\ndeeplabcut:\n  last_verified: 2020-01-01\n---\n# hello\n"
     _write(repo, rel, orig)
     _git_commit(repo, "docs: add page", "2020-01-01T12:00:00+00:00")
 
-    cfg = tool.ToolConfig(
-        version=1,
-        scan=tool.ScanConfig(include=[rel], exclude=[]),
-        policy=tool.PolicyConfig(),
-    )
+    tool_cfg = cfg(include=[rel])
 
     before = (repo / rel).read_text(encoding="utf-8")
-    records = tool.scan_files(repo, cfg, targets=[r".\docs\page.md"])
+    records = tool.scan_files(repo, tool_cfg, targets=[r".\docs\page.md"])
     after = (repo / rel).read_text(encoding="utf-8")
 
     assert before == after
@@ -183,11 +196,7 @@ def test_scan_is_read_only(tool, tmp_path: Path, monkeypatch):
     assert records[0].kind == "md"
 
 
-def test_scan_targets_support_directory_and_glob(tool, tmp_path: Path):
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git_init(repo)
-
+def test_scan_targets_support_directory_and_glob(tool, repo: Path, cfg):
     rel_a = "docs/gui/napari/basic_usage.md"
     rel_b = "docs/gui/napari/advanced_usage.md"
     rel_c = "docs/other/overview.md"
@@ -197,33 +206,59 @@ def test_scan_targets_support_directory_and_glob(tool, tmp_path: Path):
     _write(repo, rel_c, "# c\n")
     _git_commit(repo, "docs: add pages", "2020-01-01T12:00:00+00:00")
 
-    cfg = tool.ToolConfig(
-        version=1,
-        scan=tool.ScanConfig(include=["docs/**/*.md"], exclude=[]),
-        policy=tool.PolicyConfig(),
-    )
+    tool_cfg = cfg(include=["docs/**/*.md"])
 
     # Directory selector
-    recs_dir = tool.scan_files(repo, cfg, targets=["docs/gui/napari/"])
+    recs_dir = tool.scan_files(repo, tool_cfg, targets=["docs/gui/napari/"])
     paths_dir = sorted(r.path for r in recs_dir)
     assert set(paths_dir) == {rel_a, rel_b}
 
     # Glob selector
-    recs_glob = tool.scan_files(repo, cfg, targets=["docs/gui/napari/*.md"])
+    recs_glob = tool.scan_files(repo, tool_cfg, targets=["docs/gui/napari/*.md"])
     paths_glob = sorted(r.path for r in recs_glob)
     assert set(paths_glob) == {rel_a, rel_b}
 
     # Recursive glob selector
-    recs_recursive = tool.scan_files(repo, cfg, targets=["docs/**/*.md"])
+    recs_recursive = tool.scan_files(repo, tool_cfg, targets=["docs/**/*.md"])
     paths_recursive = sorted(r.path for r in recs_recursive)
     assert set(paths_recursive) == {rel_a, rel_b, rel_c}
 
 
-def test_validate_requested_targets_reports_unmatched(tool, tmp_path: Path):
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git_init(repo)
+def test_validate_requested_targets_treats_dot_slash_as_unmatched(tool, repo: Path, cfg):
+    _write(repo, "docs/page.md", "# hello\n")
+    tool_cfg = cfg(include=["docs/**/*.md"])
 
+    matched, unmatched = tool.validate_requested_targets(repo, tool_cfg, ["./"])
+    assert matched == []
+    assert unmatched == ["./"]
+
+
+def test_validate_requested_targets_treats_empty_like_unmatched(tool, repo: Path, cfg):
+    _write(repo, "docs/page.md", "# hello\n")
+    tool_cfg = cfg(include=["docs/**/*.md"])
+
+    matched, unmatched = tool.validate_requested_targets(repo, tool_cfg, ["", "   "])
+    assert matched == []
+    assert unmatched == ["", "   "]
+
+
+def test_validate_requested_targets_reports_mixed_valid_and_invalid_targets(tool, repo: Path, cfg):
+    rel = "docs/page.md"
+    _write(repo, rel, "# hello\n")
+    tool_cfg = cfg(include=["docs/**/*.md"])
+
+    matched, unmatched = tool.validate_requested_targets(repo, tool_cfg, [rel, "./"])
+    assert rel in matched
+    assert unmatched == ["./"]
+
+
+def test_scan_files_with_invalid_only_targets_matches_nothing(tool, repo: Path, cfg):
+    tool_cfg = cfg(include=["docs/**/*.md"])
+    records = tool.scan_files(repo, tool_cfg, targets=["./"])
+    assert records == []
+
+
+def test_validate_requested_targets_reports_unmatched(tool, repo: Path, cfg):
     rel_a = "docs/gui/napari/basic_usage.md"
     rel_b = "docs/gui/napari/advanced_usage.md"
 
@@ -231,15 +266,11 @@ def test_validate_requested_targets_reports_unmatched(tool, tmp_path: Path):
     _write(repo, rel_b, "# b\n")
     _git_commit(repo, "docs: add pages", "2020-01-01T12:00:00+00:00")
 
-    cfg = tool.ToolConfig(
-        version=1,
-        scan=tool.ScanConfig(include=["docs/**/*.md"], exclude=[]),
-        policy=tool.PolicyConfig(),
-    )
+    tool_cfg = cfg(include=["docs/**/*.md"])
 
     matched, unmatched = tool.validate_requested_targets(
         repo,
-        cfg,
+        tool_cfg,
         targets=[
             r".\docs\gui\napari\basic_usage.md",
             "docs/gui/napari/",
@@ -253,29 +284,21 @@ def test_validate_requested_targets_reports_unmatched(tool, tmp_path: Path):
     assert unmatched == ["docs/missing/", "examples/**/*.ipynb"]
 
 
-def test_update_requires_ack_when_write(tool, tmp_path: Path):
+def test_update_requires_ack_when_write(tool, repo: Path, cfg):
     """
     Contract: write mode should refuse unless --ack-meta-commit-marker is provided.
     """
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git_init(repo)
-
     rel = "docs/page.md"
     _write(repo, rel, "# hello\n")
     _git_commit(repo, "docs: initial content", "2020-01-01T12:00:00+00:00")
 
-    cfg = tool.ToolConfig(
-        version=1,
-        scan=tool.ScanConfig(include=[rel], exclude=[]),
-        policy=tool.PolicyConfig(),
-    )
+    tool_cfg = cfg(include=[rel])
 
     # should refuse to write without ack
     with pytest.raises(SystemExit):
         tool.update_files(
             repo_root=repo,
-            cfg=cfg,
+            cfg=tool_cfg,
             targets=[rel],
             write=True,
             set_content_date_from_git=True,
@@ -285,30 +308,22 @@ def test_update_requires_ack_when_write(tool, tmp_path: Path):
         )
 
 
-def test_update_set_content_date_from_git_only_changes_that_field(tool, tmp_path: Path):
+def test_update_set_content_date_from_git_only_changes_that_field(tool, repo: Path, cfg):
     """
     Contract: update --set-content-date-from-git only sets last_content_updated
     (plus last_metadata_updated when writing),
     does NOT override last_verified/verified_for unless explicitly provided.
     """
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git_init(repo)
-
     rel = "docs/page.md"
     initial = "---\ndeeplabcut:\n  last_verified: 2020-02-02\n  verified_for: 3.0.0rc1\n---\n# hello\n"
     _write(repo, rel, initial)
     _git_commit(repo, "docs: initial content", "2020-01-01T12:00:00+00:00")
 
-    cfg = tool.ToolConfig(
-        version=1,
-        scan=tool.ScanConfig(include=[rel], exclude=[]),
-        policy=tool.PolicyConfig(),
-    )
+    tool_cfg = cfg(include=[rel])
 
     records = tool.update_files(
         repo_root=repo,
-        cfg=cfg,
+        cfg=tool_cfg,
         targets=[rel],
         write=True,
         set_content_date_from_git=True,
@@ -320,7 +335,7 @@ def test_update_set_content_date_from_git_only_changes_that_field(tool, tmp_path
 
     # Read back and confirm verified fields unchanged
     text = (repo / rel).read_text(encoding="utf-8")
-    fm, body, _ = tool.read_md_frontmatter(text)
+    fm, _body, _ = tool.read_md_frontmatter(text)
     assert isinstance(fm, dict) and tool.DLC_NAMESPACE in fm
     meta = fm[tool.DLC_NAMESPACE]
 
@@ -334,29 +349,21 @@ def test_update_set_content_date_from_git_only_changes_that_field(tool, tmp_path
     assert "last_metadata_updated" in meta
 
 
-def test_update_set_verified_fields_only_changes_verified(tool, tmp_path: Path):
+def test_update_set_verified_fields_only_changes_verified(tool, repo: Path, cfg):
     """
     Contract: update with --set-last-verified / --set-verified-for changes only those fields
     (plus last_metadata_updated if writing), and does not set last_content_updated unless requested.
     """
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git_init(repo)
-
     rel = "docs/page.md"
     initial = "---\ndeeplabcut:\n  last_content_updated: 2000-01-01\n---\n# hello\n"
     _write(repo, rel, initial)
     _git_commit(repo, "docs: initial content", "2020-01-01T12:00:00+00:00")
 
-    cfg = tool.ToolConfig(
-        version=1,
-        scan=tool.ScanConfig(include=[rel], exclude=[]),
-        policy=tool.PolicyConfig(),
-    )
+    tool_cfg = cfg(include=[rel])
 
     records = tool.update_files(
         repo_root=repo,
-        cfg=cfg,
+        cfg=tool_cfg,
         targets=[rel],
         write=True,
         set_content_date_from_git=False,
@@ -378,31 +385,23 @@ def test_update_set_verified_fields_only_changes_verified(tool, tmp_path: Path):
     assert meta["last_content_updated"] == "2000-01-01"
 
 
-def test_normalize_is_explicit_and_marks_would_change(tool, tmp_path: Path):
+def test_normalize_is_explicit_and_marks_would_change(tool, repo: Path, cfg):
     """
     Contract: normalize is separate and explicit; in dry-run it should mark would_change
     if notebook is not already in canonical nbformat output.
     """
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git_init(repo)
-
     rel = "docs/nbs/nb.ipynb"
     # Minimal notebook JSON but not in nbformat canonical formatting (indent/newline differences)
     raw = '{\n  "cells": [],\n  "metadata": {},\n  "nbformat": 4,\n  "nbformat_minor": 5\n}\n'
     _write(repo, rel, raw)
     _git_commit(repo, "docs: add notebook", "2020-01-01T12:00:00+00:00")
 
-    cfg = tool.ToolConfig(
-        version=1,
-        scan=tool.ScanConfig(include=[rel], exclude=[]),
-        policy=tool.PolicyConfig(),
-    )
+    tool_cfg = cfg(include=[rel])
 
     # Dry-run normalize: should set would_change True if not normalized
     records = tool.normalize_notebooks(
         repo_root=repo,
-        cfg=cfg,
+        cfg=tool_cfg,
         targets=[rel],
         write=False,
         ack_meta_commit_marker=True,
@@ -413,24 +412,16 @@ def test_normalize_is_explicit_and_marks_would_change(tool, tmp_path: Path):
     assert records[0].would_change
 
 
-def test_write_outputs_contract(tool, tmp_path: Path):
+def test_write_outputs_contract(tool, repo: Path, cfg, tmp_path: Path):
     """
     Contract: write_outputs creates both JSON and Markdown files and JSON is schema-valid.
     """
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git_init(repo)
-
     rel = "docs/page.md"
     _write(repo, rel, "# hello\n")
     _git_commit(repo, "docs: initial content", "2020-01-01T12:00:00+00:00")
 
-    cfg = tool.ToolConfig(
-        version=1,
-        scan=tool.ScanConfig(include=[rel], exclude=[]),
-        policy=tool.PolicyConfig(),
-    )
-    records = tool.scan_files(repo, cfg, targets=[rel])
+    tool_cfg = cfg(include=[rel])
+    records = tool.scan_files(repo, tool_cfg, targets=[rel])
 
     report = tool.Report(
         generated_at=datetime.now(timezone.utc),
@@ -441,7 +432,7 @@ def test_write_outputs_contract(tool, tmp_path: Path):
     )
 
     out_dir = tmp_path / "out"
-    json_path, md_path = tool.write_outputs(report, cfg, out_dir)
+    json_path, md_path = tool.write_outputs(report, tool_cfg, out_dir)
 
     assert json_path.exists()
     assert md_path.exists()
@@ -452,24 +443,16 @@ def test_write_outputs_contract(tool, tmp_path: Path):
     assert md_path.read_text(encoding="utf-8").startswith("#")
 
 
-def test_notebook_missing_dlc_namespace_warns_missing_metadata(tool, tmp_path: Path):
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git_init(repo)
-
+def test_notebook_missing_dlc_namespace_warns_missing_metadata(tool, repo: Path, cfg):
     rel = "docs/nbs/nb.ipynb"
     # Valid minimal notebook, but no "deeplabcut" namespace under metadata
     nb = '{\n  "cells": [],\n  "metadata": {},\n  "nbformat": 4,\n  "nbformat_minor": 5\n}\n'
     _write(repo, rel, nb)
     _git_commit(repo, "docs: add notebook", "2020-01-01T12:00:00+00:00")
 
-    cfg = tool.ToolConfig(
-        version=1,
-        scan=tool.ScanConfig(include=[rel], exclude=[]),
-        policy=tool.PolicyConfig(),
-    )
+    tool_cfg = cfg(include=[rel])
 
-    records = tool.scan_files(repo, cfg, targets=[rel])
+    records = tool.scan_files(repo, tool_cfg, targets=[rel])
     assert len(records) == 1
     r = records[0]
     assert r.kind == "ipynb"
@@ -477,11 +460,7 @@ def test_notebook_missing_dlc_namespace_warns_missing_metadata(tool, tmp_path: P
     assert r.meta is None
 
 
-def test_notebook_invalid_dlc_namespace_warns_invalid_metadata(tool, tmp_path: Path):
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git_init(repo)
-
+def test_notebook_invalid_dlc_namespace_warns_invalid_metadata(tool, repo: Path, cfg):
     rel = "docs/nbs/nb.ipynb"
     # deeplabcut namespace exists but is invalid: last_verified must be a date
     nb = (
@@ -499,13 +478,9 @@ def test_notebook_invalid_dlc_namespace_warns_invalid_metadata(tool, tmp_path: P
     _write(repo, rel, nb)
     _git_commit(repo, "docs: add notebook with bad meta", "2020-01-01T12:00:00+00:00")
 
-    cfg = tool.ToolConfig(
-        version=1,
-        scan=tool.ScanConfig(include=[rel], exclude=[]),
-        policy=tool.PolicyConfig(),
-    )
+    tool_cfg = cfg(include=[rel])
 
-    records = tool.scan_files(repo, cfg, targets=[rel])
+    records = tool.scan_files(repo, tool_cfg, targets=[rel])
     assert len(records) == 1
     r = records[0]
     assert r.kind == "ipynb"
@@ -513,11 +488,7 @@ def test_notebook_invalid_dlc_namespace_warns_invalid_metadata(tool, tmp_path: P
     assert r.meta is None
 
 
-def test_main_prints_matched_files_and_fails_on_unmatched_targets(tool, tmp_path: Path, monkeypatch, capsys):
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git_init(repo)
-
+def test_main_prints_matched_files_and_fails_on_unmatched_targets(tool, repo: Path, monkeypatch, capsys):
     rel = "docs/gui/napari/basic_usage.md"
     _write(repo, rel, "# hello\n")
     _git_commit(repo, "docs: add page", "2020-01-01T12:00:00+00:00")
@@ -545,11 +516,7 @@ def test_main_prints_matched_files_and_fails_on_unmatched_targets(tool, tmp_path
     assert "- docs/missing/" in out
 
 
-def test_main_prints_matched_files_for_valid_targets(tool, tmp_path: Path, monkeypatch, capsys):
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    _git_init(repo)
-
+def test_main_prints_matched_files_for_valid_targets(tool, repo: Path, monkeypatch, capsys):
     rel = "docs/gui/napari/basic_usage.md"
     _write(repo, rel, "# hello\n")
     _git_commit(repo, "docs: add page", "2020-01-01T12:00:00+00:00")
@@ -572,3 +539,14 @@ def test_main_prints_matched_files_for_valid_targets(tool, tmp_path: Path, monke
     assert "Matched 1 file(s) from --targets:" in out
     assert f"- {rel}" in out
     assert "Report generated:" in out
+
+
+def test_main_returns_2_for_invalid_target_selector(tool, repo: Path, monkeypatch):
+    _write(repo, "docs/page.md", "# hello\n")
+    _git_commit(repo, "docs: add page", "2020-01-01T12:00:00+00:00")
+    cfg_path = _write_default_cfg(repo, include=["docs/**/*.md"])
+
+    monkeypatch.chdir(repo)
+
+    rc = tool.main(["--config", str(cfg_path), "report", "--targets", "./"])
+    assert rc == 2

--- a/tests/tools/docs_and_notebooks_checks/test_check_contracts.py
+++ b/tests/tools/docs_and_notebooks_checks/test_check_contracts.py
@@ -31,6 +31,26 @@ def tool() -> ModuleType:
     return load_tool_module()
 
 
+def _write_default_cfg(repo: Path, include: list[str]) -> Path:
+    cfg_path = repo / "tools" / "docs_and_notebooks_report_config.yml"
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        "version: 1\n"
+        "scan:\n"
+        "  include:\n" + "".join(f"    - {pat}\n" for pat in include) + "  exclude: []\n"
+        "policy:\n"
+        "  warn_if_content_older_than_days: 365\n"
+        "  warn_if_verified_older_than_days: 365\n"
+        "  missing_last_verified_is_warning: true\n"
+        "  fail_on_scan_errors: false\n"
+        "  require_metadata: []\n"
+        "  require_recent_verification: []\n"
+        "  require_notebook_normalized: []\n",
+        encoding="utf-8",
+    )
+    return cfg_path
+
+
 # -----------------------------
 # Git helpers for a temp repo
 # -----------------------------
@@ -154,13 +174,83 @@ def test_scan_is_read_only(tool, tmp_path: Path, monkeypatch):
     )
 
     before = (repo / rel).read_text(encoding="utf-8")
-    records = tool.scan_files(repo, cfg, targets=[rel])
+    records = tool.scan_files(repo, cfg, targets=[r".\docs\page.md"])
     after = (repo / rel).read_text(encoding="utf-8")
 
     assert before == after
     assert len(records) == 1
     assert records[0].path == rel
     assert records[0].kind == "md"
+
+
+def test_scan_targets_support_directory_and_glob(tool, tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_init(repo)
+
+    rel_a = "docs/gui/napari/basic_usage.md"
+    rel_b = "docs/gui/napari/advanced_usage.md"
+    rel_c = "docs/other/overview.md"
+
+    _write(repo, rel_a, "# a\n")
+    _write(repo, rel_b, "# b\n")
+    _write(repo, rel_c, "# c\n")
+    _git_commit(repo, "docs: add pages", "2020-01-01T12:00:00+00:00")
+
+    cfg = tool.ToolConfig(
+        version=1,
+        scan=tool.ScanConfig(include=["docs/**/*.md"], exclude=[]),
+        policy=tool.PolicyConfig(),
+    )
+
+    # Directory selector
+    recs_dir = tool.scan_files(repo, cfg, targets=["docs/gui/napari/"])
+    paths_dir = sorted(r.path for r in recs_dir)
+    assert set(paths_dir) == {rel_a, rel_b}
+
+    # Glob selector
+    recs_glob = tool.scan_files(repo, cfg, targets=["docs/gui/napari/*.md"])
+    paths_glob = sorted(r.path for r in recs_glob)
+    assert set(paths_glob) == {rel_a, rel_b}
+
+    # Recursive glob selector
+    recs_recursive = tool.scan_files(repo, cfg, targets=["docs/**/*.md"])
+    paths_recursive = sorted(r.path for r in recs_recursive)
+    assert set(paths_recursive) == {rel_a, rel_b, rel_c}
+
+
+def test_validate_requested_targets_reports_unmatched(tool, tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_init(repo)
+
+    rel_a = "docs/gui/napari/basic_usage.md"
+    rel_b = "docs/gui/napari/advanced_usage.md"
+
+    _write(repo, rel_a, "# a\n")
+    _write(repo, rel_b, "# b\n")
+    _git_commit(repo, "docs: add pages", "2020-01-01T12:00:00+00:00")
+
+    cfg = tool.ToolConfig(
+        version=1,
+        scan=tool.ScanConfig(include=["docs/**/*.md"], exclude=[]),
+        policy=tool.PolicyConfig(),
+    )
+
+    matched, unmatched = tool.validate_requested_targets(
+        repo,
+        cfg,
+        targets=[
+            r".\docs\gui\napari\basic_usage.md",
+            "docs/gui/napari/",
+            "docs/**/*.md",
+            "docs/missing/",
+            "examples/**/*.ipynb",
+        ],
+    )
+
+    assert matched == sorted([rel_a, rel_b])
+    assert unmatched == ["docs/missing/", "examples/**/*.ipynb"]
 
 
 def test_update_requires_ack_when_write(tool, tmp_path: Path):
@@ -421,3 +511,64 @@ def test_notebook_invalid_dlc_namespace_warns_invalid_metadata(tool, tmp_path: P
     assert r.kind == "ipynb"
     assert "invalid_metadata" in r.warnings
     assert r.meta is None
+
+
+def test_main_prints_matched_files_and_fails_on_unmatched_targets(tool, tmp_path: Path, monkeypatch, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_init(repo)
+
+    rel = "docs/gui/napari/basic_usage.md"
+    _write(repo, rel, "# hello\n")
+    _git_commit(repo, "docs: add page", "2020-01-01T12:00:00+00:00")
+
+    cfg_path = _write_default_cfg(repo, include=["docs/**/*.md"])
+
+    monkeypatch.chdir(repo)
+
+    rc = tool.main(
+        [
+            "--config",
+            str(cfg_path),
+            "report",
+            "--targets",
+            r".\docs\gui\napari\basic_usage.md",
+            "docs/missing/",
+        ]
+    )
+
+    out = capsys.readouterr().out
+    assert rc == 2
+    assert "Matched 1 file(s) from --targets:" in out
+    assert f"- {rel}" in out
+    assert "Unmatched --targets:" in out
+    assert "- docs/missing/" in out
+
+
+def test_main_prints_matched_files_for_valid_targets(tool, tmp_path: Path, monkeypatch, capsys):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git_init(repo)
+
+    rel = "docs/gui/napari/basic_usage.md"
+    _write(repo, rel, "# hello\n")
+    _git_commit(repo, "docs: add page", "2020-01-01T12:00:00+00:00")
+    cfg_path = _write_default_cfg(repo, include=["docs/**/*.md"])
+
+    monkeypatch.chdir(repo)
+
+    rc = tool.main(
+        [
+            "--config",
+            str(cfg_path),
+            "report",
+            "--targets",
+            "docs/gui/napari/",
+        ]
+    )
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Matched 1 file(s) from --targets:" in out
+    assert f"- {rel}" in out
+    assert "Report generated:" in out

--- a/tools/docs_and_notebooks_check.py
+++ b/tools/docs_and_notebooks_check.py
@@ -1070,7 +1070,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     chk.add_argument(
         "--targets",
         nargs="*",
-        help="Optional list of relative file paths to scan (limits scan to these files)",
+        help=(
+            "Optional list of relative file paths to scan (limits scan to these files). "
+            "Supports exact files, directories, and glob patterns (e.g. docs/page.md, docs/gui/, 'docs/**/*.md'). "
+            "Both '/' and '\\' are accepted."
+        ),
     )
     chk.add_argument(
         "--strict-mode",

--- a/tools/docs_and_notebooks_check.py
+++ b/tools/docs_and_notebooks_check.py
@@ -83,8 +83,8 @@ import re
 import subprocess
 from collections.abc import Sequence
 from datetime import date, datetime, timezone
-from pathlib import Path, PurePosixPath
-from typing import Any, Literal
+from pathlib import Path
+from typing import Any, Literal, TypedDict
 
 import nbformat
 import yaml
@@ -161,9 +161,12 @@ class ToolConfig(BaseModel):
     policy: PolicyConfig
 
 
+FileKind = Literal["ipynb", "md", "other"]
+
+
 class FileRecord(BaseModel):
     path: str
-    kind: str  # ipynb | md | other
+    kind: FileKind
 
     # Computed from git (excluding metadata-only commits)
     last_content_updated: date | None = None
@@ -201,6 +204,14 @@ PolicyConfig.model_rebuild()
 ToolConfig.model_rebuild()
 FileRecord.model_rebuild()
 Report.model_rebuild()
+
+TargetKind = Literal["invalid", "file", "dir", "glob"]
+
+
+class TargetSpec(TypedDict):
+    raw: str
+    normalized: str
+    kind: TargetKind
 
 
 # -----------------------------
@@ -247,7 +258,7 @@ def normalize_target_spec(spec: str, repo_root: Path) -> str:
     return s
 
 
-def compile_target_specs(targets: list[str] | None, repo_root: Path) -> list[dict[str, str]] | None:
+def compile_target_specs(targets: list[str] | None, repo_root: Path) -> list[TargetSpec] | None:
     """
     Convert raw CLI targets into normalized selector specs.
 
@@ -259,7 +270,7 @@ def compile_target_specs(targets: list[str] | None, repo_root: Path) -> list[dic
     if not targets:
         return None
 
-    specs: list[dict[str, str]] = []
+    specs: list[TargetSpec] = []
 
     for raw in targets:
         normalized = normalize_target_spec(raw, repo_root)
@@ -286,9 +297,8 @@ def compile_target_specs(targets: list[str] | None, repo_root: Path) -> list[dic
     return specs
 
 
-def target_spec_matches_path(rel_path: str, spec: dict[str, str]) -> bool:
+def target_spec_matches_path(rel_path: str, spec: TargetSpec) -> bool:
     rel_path = rel_path.replace("\\", "/")
-    rel_pure = PurePosixPath(rel_path)
 
     kind = spec["kind"]
     normalized = spec["normalized"]
@@ -303,13 +313,14 @@ def target_spec_matches_path(rel_path: str, spec: dict[str, str]) -> bool:
         return rel_path == normalized or rel_path.startswith(normalized + "/")
 
     if kind == "glob":
-        # Support both classic glob matching and ** recursive patterns
-        return fnmatch.fnmatchcase(rel_path, normalized) or rel_pure.match(normalized)
+        # Intentionally use simple shell-style matching here so patterns like
+        # docs/**/*.md behave the way users generally expect across platforms.
+        return fnmatch.fnmatchcase(rel_path, normalized)
 
     return False
 
 
-def target_matches(rel_path: str, specs: list[dict[str, str]] | None) -> bool:
+def target_matches(rel_path: str, specs: list[TargetSpec] | None) -> bool:
     if specs is None:
         return True
     return any(target_spec_matches_path(rel_path, spec) for spec in specs)

--- a/tools/docs_and_notebooks_check.py
+++ b/tools/docs_and_notebooks_check.py
@@ -303,8 +303,9 @@ def target_spec_matches_path(rel_path: str, spec: dict[str, str]) -> bool:
         return rel_path == normalized or rel_path.startswith(normalized + "/")
 
     if kind == "glob":
-        # Support both classic glob matching and ** recursive patterns
-        return fnmatch.fnmatchcase(rel_path, normalized) or rel_pure.match(normalized)
+        # Use path-aware matching so '*' does not span directories, while
+        # still supporting recursive '**' patterns.
+        return rel_pure.match(normalized)
 
     return False
 

--- a/tools/docs_and_notebooks_check.py
+++ b/tools/docs_and_notebooks_check.py
@@ -303,9 +303,8 @@ def target_spec_matches_path(rel_path: str, spec: dict[str, str]) -> bool:
         return rel_path == normalized or rel_path.startswith(normalized + "/")
 
     if kind == "glob":
-        # Use path-aware matching so '*' does not span directories, while
-        # still supporting recursive '**' patterns.
-        return rel_pure.match(normalized)
+        # Support both classic glob matching and ** recursive patterns
+        return fnmatch.fnmatchcase(rel_path, normalized) or rel_pure.match(normalized)
 
     return False
 

--- a/tools/docs_and_notebooks_check.py
+++ b/tools/docs_and_notebooks_check.py
@@ -83,7 +83,7 @@ import re
 import subprocess
 from collections.abc import Sequence
 from datetime import date, datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Literal
 
 import nbformat
@@ -92,6 +92,7 @@ from nbformat.validator import NotebookValidationError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 SCHEMA_VERSION = 1
+GLOB_CHARS = set("*?[")
 DLC_NAMESPACE = "deeplabcut"
 OUTPUT_FILENAME = "docs_nb_checks"
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -200,9 +201,173 @@ PolicyConfig.model_rebuild()
 ToolConfig.model_rebuild()
 FileRecord.model_rebuild()
 Report.model_rebuild()
+
+
 # -----------------------------
 # Helpers
 # -----------------------------
+def normalize_target_spec(spec: str, repo_root: Path) -> str:
+    """
+    Normalize a CLI target into a repo-relative POSIX-style path/pattern.
+
+    Examples
+    --------
+    .\\docs\\a.md          -> docs/a.md
+    ./docs/a.md            -> docs/a.md
+    docs\\gui\\            -> docs/gui
+    /abs/path/in/repo/a.md -> docs/a.md   (if inside repo)
+    """
+    s = spec.strip()
+    if not s:
+        return s
+
+    # Normalize slashes first so Windows-style input works everywhere
+    s = s.replace("\\", "/")
+
+    # Strip leading ./ repeatedly
+    while s.startswith("./"):
+        s = s[2:]
+
+    # If absolute and inside repo, make it repo-relative
+    p = Path(s)
+    if p.is_absolute():
+        try:
+            s = str(p.resolve().relative_to(repo_root)).replace(os.sep, "/")
+        except ValueError:
+            # Outside repo: keep normalized absolute text so it can fail validation cleanly
+            s = str(p).replace(os.sep, "/")
+
+    # Collapse repeated slashes
+    s = re.sub(r"/+", "/", s)
+
+    # Remove trailing slash for canonical matching
+    if len(s) > 1:
+        s = s.rstrip("/")
+
+    return s
+
+
+def compile_target_specs(targets: list[str] | None, repo_root: Path) -> list[dict[str, str]] | None:
+    """
+    Convert raw CLI targets into normalized selector specs.
+
+    Each spec is a dict with:
+      - raw: original user input
+      - normalized: normalized repo-relative selector
+      - kind: file | dir | glob
+    """
+    if not targets:
+        return None
+
+    specs: list[dict[str, str]] = []
+
+    for raw in targets:
+        normalized = normalize_target_spec(raw, repo_root)
+        if not normalized:
+            continue
+
+        if any(ch in normalized for ch in GLOB_CHARS):
+            specs.append({"raw": raw, "normalized": normalized, "kind": "glob"})
+            continue
+
+        # Treat explicit trailing slash/backslash as directory intent
+        if raw.endswith(("/", "\\")):
+            specs.append({"raw": raw, "normalized": normalized, "kind": "dir"})
+            continue
+
+        candidate = Path(normalized)
+        abs_candidate = candidate if candidate.is_absolute() else (repo_root / candidate)
+        if abs_candidate.exists() and abs_candidate.is_dir():
+            specs.append({"raw": raw, "normalized": normalized, "kind": "dir"})
+        else:
+            specs.append({"raw": raw, "normalized": normalized, "kind": "file"})
+
+    return specs
+
+
+def target_spec_matches_path(rel_path: str, spec: dict[str, str]) -> bool:
+    rel_path = rel_path.replace("\\", "/")
+    rel_pure = PurePosixPath(rel_path)
+
+    kind = spec["kind"]
+    normalized = spec["normalized"]
+
+    if kind == "file":
+        return rel_path == normalized
+
+    if kind == "dir":
+        return rel_path == normalized or rel_path.startswith(normalized + "/")
+
+    if kind == "glob":
+        # Support both classic glob matching and ** recursive patterns
+        return fnmatch.fnmatchcase(rel_path, normalized) or rel_pure.match(normalized)
+
+    return False
+
+
+def target_matches(rel_path: str, specs: list[dict[str, str]] | None) -> bool:
+    if specs is None:
+        return True
+    return any(target_spec_matches_path(rel_path, spec) for spec in specs)
+
+
+def iter_scan_candidate_paths(repo_root: Path, cfg: ToolConfig) -> list[str]:
+    """
+    Return all repo-relative paths that are in scope for scanning, before applying --targets.
+    """
+    rels: list[str] = []
+    for p in glob_paths(repo_root, cfg.scan.include):
+        rel = str(p.resolve().relative_to(repo_root)).replace(os.sep, "/")
+        if is_excluded(rel, cfg.scan.exclude):
+            continue
+        rels.append(rel)
+    return sorted(set(rels))
+
+
+def validate_requested_targets(
+    repo_root: Path,
+    cfg: ToolConfig,
+    targets: list[str] | None,
+) -> tuple[list[str], list[str]]:
+    """
+    Validate CLI target selectors against the current scan universe.
+
+    Returns:
+      matched_paths: repo-relative file paths matched by any selector
+      unmatched_targets: raw target strings that matched nothing
+    """
+    if not targets:
+        return [], []
+
+    specs = compile_target_specs(targets, repo_root)
+    if not specs:
+        return [], []
+
+    candidates = iter_scan_candidate_paths(repo_root, cfg)
+
+    matched_paths = sorted({rel for rel in candidates if target_matches(rel, specs)})
+
+    unmatched_targets: list[str] = []
+    for spec in specs:
+        if not any(target_spec_matches_path(rel, spec) for rel in candidates):
+            unmatched_targets.append(spec["raw"])
+
+    return matched_paths, unmatched_targets
+
+
+def print_target_match_summary(matched_paths: list[str], requested_targets: list[str] | None) -> None:
+    """
+    Print a small CLI summary whenever --targets is used.
+    """
+    if not requested_targets:
+        return
+
+    print(f"\nMatched {len(matched_paths)} file(s) from --targets:")
+    preview_limit = 50
+    for rel in matched_paths[:preview_limit]:
+        print(f"- {rel}")
+    if len(matched_paths) > preview_limit:
+        print(f"... and {len(matched_paths) - preview_limit} more")
 
 
 def _iso_today() -> date:
@@ -428,15 +593,13 @@ def scan_files(repo_root: Path, cfg: ToolConfig, targets: list[str] | None = Non
     today = _iso_today()
     paths = glob_paths(repo_root, cfg.scan.include)
     records: list[FileRecord] = []
-    target_set = None
-    if targets:
-        target_set = set(t.replace(os.sep, "/") for t in targets)
+    target_specs = compile_target_specs(targets, repo_root)
 
     for p in paths:
         rel = str(p.resolve().relative_to(repo_root)).replace(os.sep, "/")
         if is_excluded(rel, cfg.scan.exclude):
             continue
-        if target_set is not None and rel not in target_set:
+        if not target_matches(rel, target_specs):
             continue
         kind = file_kind(p)
         rec = FileRecord(path=rel, kind=kind)
@@ -565,14 +728,11 @@ def update_files(
 ) -> list[FileRecord]:
     today = _iso_today()
     records = scan_files(repo_root, cfg, targets=targets)
-    target_set = set(t.replace(os.sep, "/") for t in targets) if targets else None
 
     for rec in records:
         if rec.kind not in {"ipynb", "md"}:
             continue
         if rec.meta and rec.meta.ignore:
-            continue
-        if target_set is not None and rec.path not in target_set:
             continue
 
         meta = rec.meta or DLCMeta()
@@ -889,7 +1049,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     rep.add_argument(
         "--targets",
         nargs="*",
-        help="Optional list of relative file paths to scan (limits scan to these files)",
+        help=(
+            "Optional repo-relative targets to limit the operation. "
+            "Supports exact files, directories, and glob patterns "
+            "(e.g. docs/page.md, docs/gui/, 'docs/**/*.md'). "
+            "Both '/' and '\\' are accepted."
+        ),
     )
 
     chk = sub.add_parser(
@@ -956,6 +1121,23 @@ def main(argv: Sequence[str] | None = None) -> int:
     repo_root = find_repo_root(Path.cwd())
     cfg = load_config(config_path)
     out_dir = Path(args.out_dir)
+
+    requested_targets = getattr(args, "targets", None)
+
+    if requested_targets:
+        matched_paths, unmatched_targets = validate_requested_targets(repo_root, cfg, requested_targets)
+        print_target_match_summary(matched_paths, requested_targets)
+
+        if unmatched_targets:
+            print("\nUnmatched --targets:")
+            for raw in unmatched_targets:
+                print(f"- {raw}")
+            print(
+                "\nEach --targets selector must match at least one file in the configured scan set. "
+                "Use repo-relative paths, directories, or glob patterns "
+                "(for example: docs/page.md, docs/gui/, 'docs/**/*.md')."
+            )
+            return 2
 
     if args.cmd in {"report", "check"}:
         records = scan_files(repo_root, cfg, targets=getattr(args, "targets", None))

--- a/tools/docs_and_notebooks_check.py
+++ b/tools/docs_and_notebooks_check.py
@@ -1089,7 +1089,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         action="store_true",
         help="Set embedded last_content_updated from computed git content date",
     )
-    up.add_argument("--targets", nargs="*", help="Optional list of relative file paths to update")
+    up.add_argument(
+        "--targets",
+        nargs="*",
+        help=(
+            "Optional list of relative file paths to update. "
+            "Supports exact files, directories, and glob patterns (e.g. docs/page.md, docs/gui/, 'docs/**/*.md'). "
+            "Both '/' and '\\' are accepted."
+        ),
+    )
     up.add_argument("--set-last-verified", default=None, help="YYYY-MM-DD or 'today'")
     up.add_argument("--set-verified-for", default=None, help="String like 3.0.0rc13")
     up.add_argument(
@@ -1110,7 +1118,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     norm.add_argument(
         "--targets",
         nargs="*",
-        help="Optional list of relative notebook paths to normalize",
+        help=(
+            "Optional list of relative notebook paths to normalize. "
+            "Supports exact files, directories, and glob patterns "
+            "(e.g. notebooks/example.ipynb, notebooks/, 'notebooks/**/*.ipynb'). "
+            "Both '/' and '\\' are accepted."
+        ),
     )
     norm.add_argument(
         "--ack-meta-commit-marker",

--- a/tools/docs_and_notebooks_check.py
+++ b/tools/docs_and_notebooks_check.py
@@ -254,7 +254,7 @@ def compile_target_specs(targets: list[str] | None, repo_root: Path) -> list[dic
     Each spec is a dict with:
       - raw: original user input
       - normalized: normalized repo-relative selector
-      - kind: file | dir | glob
+      - kind: file | dir | glob | invalid
     """
     if not targets:
         return None
@@ -264,6 +264,7 @@ def compile_target_specs(targets: list[str] | None, repo_root: Path) -> list[dic
     for raw in targets:
         normalized = normalize_target_spec(raw, repo_root)
         if not normalized:
+            specs.append({"raw": raw, "normalized": "", "kind": "invalid"})
             continue
 
         if any(ch in normalized for ch in GLOB_CHARS):
@@ -291,6 +292,9 @@ def target_spec_matches_path(rel_path: str, spec: dict[str, str]) -> bool:
 
     kind = spec["kind"]
     normalized = spec["normalized"]
+
+    if kind == "invalid":
+        return False
 
     if kind == "file":
         return rel_path == normalized
@@ -340,16 +344,15 @@ def validate_requested_targets(
         return [], []
 
     specs = compile_target_specs(targets, repo_root)
-    if not specs:
-        return [], []
-
     candidates = iter_scan_candidate_paths(repo_root, cfg)
 
     matched_paths = sorted({rel for rel in candidates if target_matches(rel, specs)})
 
     unmatched_targets: list[str] = []
-    for spec in specs:
-        if not any(target_spec_matches_path(rel, spec) for rel in candidates):
+    for spec in specs or []:
+        if spec["kind"] == "invalid":
+            unmatched_targets.append(spec["raw"])
+        elif not any(target_spec_matches_path(rel, spec) for rel in candidates):
             unmatched_targets.append(spec["raw"])
 
     return matched_paths, unmatched_targets


### PR DESCRIPTION
### Purpose

The docs & notebook versioning tool currently does not support small QoL features such as glob matching, early exit when no files were matched in --targets, and listing which files it ran on.
This PR aims to extend the file to address these points and make it more comfortable to use.

###  Changes

- Normalize CLI target specs (handle Windows/backslashes, ./, absolute paths) and classify them as file/dir/glob. 
- Implement matching logic and validation (report matched files and unmatched selectors, return rc=2 on unmatched), and apply target specs in scan/update. 
- Add helpers (normalize_target_spec, compile_target_specs, validate_requested_targets, print_target_match_summary, iter_scan_candidate_paths) to perform the above and adjust main argument help. 
- Update tests to cover directory, glob, Windows-style paths, and CLI reporting.