### PR TITLE
Document local sibling-repo integration for XROMM workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ version with PyTorch and TensorFlow). We aim to depreciate the TF part in 2027.
 
 We recommend using our conda file, see [here](https://github.com/DeepLabCut/DeepLabCut/blob/main/conda-environments/README.md) or the [`deeplabcut-docker` package](https://github.com/DeepLabCut/DeepLabCut/tree/main/docker). 
 
+## Local sibling-repo integration
+This repository can also be used as a sibling checkout together with:
+- `../XROMM_DLCTools`
+- `../xmalab`
+
+In that local layout, `XROMM_DLCTools` uses the optional `dlc` dependency group to import this checkout directly, and its baseline harness runs both a DeepLabCut smoke scenario and a broader end-to-end local workflow integration scenario.
+
+See `instructions.md` in this repo for the local integration notes and exact commands.
+
 # [Documentation: The DeepLabCut Process](https://deeplabcut.github.io/DeepLabCut/README.html)
 
 Our docs walk you through using DeepLabCut, and key API points. For an overview of the toolbox and workflow for project management, see our step-by-step at [Nature Protocols paper](https://doi.org/10.1038/s41596-019-0176-0).

--- a/instructions.md
+++ b/instructions.md
@@ -1,0 +1,39 @@
+# DeepLabCut Local Integration Instructions
+These notes describe how this repository is used in the local 3-repo XROMM workflow together with `../XROMM_DLCTools` and `../xmalab`.
+## 1) Expected local layout
+Recommended sibling checkout layout:
+- `XROMM_DLCTools/`
+- `DeepLabCut/`
+- `xmalab/`
+`XROMM_DLCTools/pyproject.toml` maps its optional `dlc` dependency group to this repository through `tool.uv.sources`.
+## 2) DeepLabCut’s role in the workflow
+Within the integrated workflow, DeepLabCut provides:
+- project creation / dataset generation support
+- video analysis / prediction entrypoints
+- the local import target used by `XROMM_DLCTools`
+- synthetic smoke coverage through the baseline harness
+The current local integration suite also uses this repo to verify that the newer workflow service in `XROMM_DLCTools` still interoperates with a sibling DeepLabCut checkout.
+## 3) Local setup for this repo
+Standard developer setup:
+```bash
+uv sync --group dev
+```
+When working from `../XROMM_DLCTools`, enable the sibling import path there with:
+```bash
+uv sync --group dlc
+```
+## 4) Integration validation from XROMM_DLCTools
+Run these commands from `../XROMM_DLCTools`:
+```bash
+uv run python scripts/baseline_harness.py --scenario deeplabcut_repo_smoke --output-dir baseline_artifacts/deeplabcut_smoke --deeplabcut-repo ../DeepLabCut
+```
+Full multi-repo suite:
+```bash
+uv run python scripts/baseline_harness.py --scenario all --output-dir baseline_artifacts/integration_all --deeplabcut-repo ../DeepLabCut --xmalab-repo ../xmalab
+```
+True end-to-end local workflow scenario:
+```bash
+uv run python scripts/baseline_harness.py --scenario phase3_local_workflow_e2e --output-dir baseline_artifacts/e2e_local_workflow --deeplabcut-repo ../DeepLabCut --xmalab-repo ../xmalab
+```
+## 5) Compatibility notes
+The local workflow integration path expects this repo to remain importable in “lite mode” when GUI dependencies are unavailable, and relies on the public `deeplabcut` import surface plus the synthetic project helpers under `examples/utils.py`.


### PR DESCRIPTION
## Summary
- add README guidance for using this repo as a sibling checkout with `XROMM_DLCTools` and `xmalab`
- add a new `instructions.md` describing the local integration layout and harness commands
- document the smoke and end-to-end scenarios that rely on the sibling DeepLabCut checkout

## Testing
- documentation-only change

## Context
- Conversation: https://app.warp.dev/conversation/1b2c021e-180c-4756-8dbf-e3d4d8f88862
- Plan artifact: https://app.warp.dev/drive/notebook/7BJxCzv8PFodD3pQOqqlIP

Co-Authored-By: Oz <oz-agent@warp.dev>
