### PR TITLE
Add isatty method to StreamWriter

### DIFF
--- a/deeplabcut/gui/widgets.py
+++ b/deeplabcut/gui/widgets.py
@@ -183,6 +183,9 @@ class StreamWriter:
         if text != "\n":
             self.queue.put(text)
 
+    def isatty(self):
+        return False
+
     def flush(self):
         pass
 


### PR DESCRIPTION
Add an isatty(self) method that returns False on StreamWriter so external libraries treat this stream as non-interactive (avoiding potential issues with IPython 9.13.0). 
No functional changes to write/flush behavior; this makes sense to have in general  as it is not an interactive terminal.

Closes https://github.com/DeepLabCut/napari-deeplabcut/issues/196.