### PR TITLE
Increase CircleCI timeout for tests to 30m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
           name: TestDLC
           # uv handles the installation of the dependencies
           command: python testscript_cli.py
+          no_output_timeout: 30m
 
 workflows:
   main:


### PR DESCRIPTION
Add `no_output_timeout: 30m` to the run step for the TestDLC job in .circleci/config.yml to prevent CircleCI from timing out during long-running testscript_cli.py executions, specifically during HF model download. Tokenless downloads may have been adjusted downwards, which makes the job consistently hit timeout limits that previously were not a problem.