### PR TITLE
Documentation: Add XROMM+DeepLabCut local integration guide

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -106,6 +106,8 @@ parts:
           - file: docs/recipes/pose_cfg_file_breakdown
           # - file: docs/course
       - file: docs/dlc-utils/index
+        sections:
+          - file: docs/dlc-utils/XROMM/usage
 
   - caption: Project & Community
     chapters:

--- a/docs/dlc-utils/XROMM/usage.md
+++ b/docs/dlc-utils/XROMM/usage.md
@@ -1,0 +1,64 @@
+(file:xamalab-dlc-integration)=
+
+# XROMM + DeepLabCut local integration
+
+These notes describe how this repository is used in the local 3-repo XROMM workflow together with `../XROMM_DLCTools` and `../xmalab`.
+
+> Contributed by [@homfunc](https://github.com/homfunc)
+
+## 1) Expected local layout
+
+Recommended sibling checkout layout:
+
+- `XROMM_DLCTools/`
+- `DeepLabCut/`
+- `xmalab/`
+  `XROMM_DLCTools/pyproject.toml` maps its optional `dlc` dependency group to this repository through `tool.uv.sources`.
+
+## 2) DeepLabCut’s role in the workflow
+
+Within the integrated workflow, DeepLabCut provides:
+
+- project creation / dataset generation support
+- video analysis / prediction entrypoints
+- the local import target used by `XROMM_DLCTools`
+- synthetic smoke coverage through the baseline harness
+  The current local integration suite also uses this repo to verify that the newer workflow service in `XROMM_DLCTools` still interoperates with a sibling DeepLabCut checkout.
+
+## 3) Local setup for this repo
+
+Standard developer setup:
+
+```bash
+uv sync --group dev
+```
+
+When working from `../XROMM_DLCTools`, enable the sibling import path there with:
+
+```bash
+uv sync --group dlc
+```
+
+## 4) Integration validation from XROMM_DLCTools
+
+Run these commands from `../XROMM_DLCTools`:
+
+```bash
+uv run python scripts/baseline_harness.py --scenario deeplabcut_repo_smoke --output-dir baseline_artifacts/deeplabcut_smoke --deeplabcut-repo ../DeepLabCut
+```
+
+Full multi-repo suite:
+
+```bash
+uv run python scripts/baseline_harness.py --scenario all --output-dir baseline_artifacts/integration_all --deeplabcut-repo ../DeepLabCut --xmalab-repo ../xmalab
+```
+
+True end-to-end local workflow scenario:
+
+```bash
+uv run python scripts/baseline_harness.py --scenario phase3_local_workflow_e2e --output-dir baseline_artifacts/e2e_local_workflow --deeplabcut-repo ../DeepLabCut --xmalab-repo ../xmalab
+```
+
+## 5) Compatibility notes
+
+The local workflow integration path expects this repo to remain importable in “lite mode” when GUI dependencies are unavailable, and relies on the public `deeplabcut` import surface plus the synthetic project helpers under `examples/utils.py`.

--- a/docs/dlc-utils/index.md
+++ b/docs/dlc-utils/index.md
@@ -18,7 +18,14 @@ align: right
 ---
 ```
 
-This repository contains various scripts as well as links to other packages related to [DeepLabCut](https://github.com/DeepLabCut/DeepLabCut). Feel free to contribute your own analysis methods, and perhaps some short notebook of how to use it. Thanks!
+The DeepLabCut-Utils repository contains various scripts as well as links to other packages related to [DeepLabCut](https://github.com/DeepLabCut/DeepLabCut). Feel free to contribute your own analysis methods, and perhaps some short notebook of how to use it. Thanks!
+
+```{admonition} DLC-Utils
+---
+class: tip
+---
+[Link to repository](https://github.com/DeepLabCut/DLCutils)
+```
 
 ```{caution}
 Please direct inquiries to the **contributors/code maintainers of that code**. Note that the software(s) are provided "as is", without warranty of any kind, express.
@@ -33,6 +40,19 @@ These two scripts illustrate how to train, test, and analyze videos for multiple
 - [Code: `scale_training_and_evaluation.py`](https://github.com/DeepLabCut/DLCutils/blob/master/SCALE_YOUR_ANALYSIS/scale_training_and_evaluation.py)
 
 Contributed by [Alexander Mathis](https://github.com/AlexEMG)
+
+## Using DLC + XROMM_DLCTools + xmalab
+
+> Contributed by [@homfunc](https://github.com/homfunc)
+
+The DeepLabCut repository can also be used as a sibling checkout together with:
+
+- `../XROMM_DLCTools`
+- `../xmalab`
+
+In that local layout, `XROMM_DLCTools` uses the optional `dlc` dependency group to import this checkout directly, and its baseline harness runs both a DeepLabCut smoke scenario and a broader end-to-end local workflow integration scenario.
+
+See {ref}`file:xamalab-dlc-integration` for the local integration notes and exact commands.
 
 ## Using your DLC outputs, loading, simple ROI analysis, visualization examples
 


### PR DESCRIPTION
### Goal

Adds the XROMM community contribution by @homfunc in #3301 to the updated community contribution section from #3309.

### Scope & content

Add docs/dlc-utils/XROMM/usage.md describing the local 3-repo XROMM workflow with XROMM_DLCTools, DeepLabCut, and xmalab. Covers recommended sibling checkout layout, DeepLabCut's role in the workflow, developer setup (uv sync --group dev/dlc), example validation and end-to-end commands to run the baseline harness, and a compatibility note about lite-mode importability when GUI deps are unavailable.