### PR TITLE
CircleCI: disable hugginface xet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,42 +8,66 @@ jobs:
     executor:
       name: python/default
       tag: '3.10' # or '3.12'
+    environment:
+      # HuggingFace: disable xet and use cache directory
+      # NOTE @deruyter92 2026-05-07: "xet" opens many simultaneous connections
+      # to different data chunks. Currently doesn't work well with CircleCI.
+      # See: https://github.com/huggingface/xet-core/issues/800
+      HF_HUB_DISABLE_XET: 1
+      HF_HOME: ~/.cache/huggingface
+
     steps:
       - checkout
 
-      # 1) Restore uv cache
+      # Restore uv cache
       - restore_cache:
           name: Restore uv cache
           keys:
             - v2-uv-pip-{{ checksum "pyproject.toml" }}
             - v2-uv-pip-
-      # 2) Install uv
+
+      # Restore HuggingFace weights cache
+      - restore_cache:
+          name: Restore Hugging Face cache
+          keys:
+            - hf-weights-v1-{{ checksum "pyproject.toml" }}
+            - hf-weights-v1-
+
+      # Install uv
       - run:
           name: Install uv
           command: |
             pip install uv
 
+      # Install DeepLabCut runtime deps only
       - run:
           name: Install DeepLabCut runtime deps only
           command: |
             uv pip install --system -e .
 
-      # 3) (Optional) Trim the cache for CI so uploads stay small and fast
+      # (Optional) Trim the cache for CI so uploads stay small and fast
       - run:
           name: Prune uv cache for CI
           command: uv cache prune --ci || true
 
-      # 4) Save the cache for next runs
+      # Save the uv cache for next runs
       - save_cache:
           name: Save uv cache
           key: v2-uv-pip-{{ checksum "pyproject.toml" }}
           paths:
             - ~/.cache/uv
 
+      # Test DLC
       - run:
           name: TestDLC
-          # uv handles the installation of the dependencies
           command: python testscript_cli.py
+
+      # Save the HF weights cache for next runs
+      - save_cache:
+          name: Save huggingface cache
+          key: hf-weights-v1-{{ checksum "pyproject.toml" }}
+          paths:
+            - ~/.cache/huggingface
 
 workflows:
   main:


### PR DESCRIPTION
### Motivation
Currently CircleCI fails because of hanging connections with HuggingFace using xet. 
```
Loading pretrained weights from Hugging Face hub (timm/resnet50_gn.a1h_in1k)
HTTP Request: GET https://huggingface.co/api/models/timm/resnet50_gn.a1h_in1k/xet-read-token/b5b1dcfc1a526af275ec440b8d697c66c90a98b1 "HTTP/1.1 200 OK"
model.safetensors:   0% 70.5k/102M [00:01<24:59, 68.1kB/s]
Too long with no output (exceeded 10m0s): context deadline exceeded
```

Xet is Hugging Face’s new storage backend designed to replace the aging Git LFS (Large File Storage). While Git LFS treats every file as a single "blob," Xet breaks files into small "chunks."

In restricted CI environments (like CircleCI, GCP, or Kaggle), the Xet "chunked" download often stalls. Because Xet opens many simultaneous connections to different data chunks, CI firewalls or NAT gateways sometimes flag this as suspicious activity or simply drop the connections when they hit a certain threshold.

### Changes
This PR **disables Xet**:
```yaml
environment:
    HF_HUB_DISABLE_XET: 1
```

and **sets caching** for the huggingface weights, to avoid repeated downloading. This also improves stability in case of a bad network connection.
```yaml
- restore_cache:
    name: Restore Hugging Face cache
    keys:
      - hf-weights-v1-{{ checksum "pyproject.toml" }}
      - hf-weights-v1-
```


### More information
- HuggingFace Xet: https://huggingface.co/join/xet
- Similar issue: https://github.com/huggingface/xet-core/issues/800