### PR TITLE
Remove trailing comma in models_to_framework.json

### DIFF
--- a/deeplabcut/modelzoo/models_to_framework.json
+++ b/deeplabcut/modelzoo/models_to_framework.json
@@ -5,5 +5,5 @@
     "rtmpose_s": "pytorch",
     "rtmpose_x": "pytorch",
     "fmpose3d_humans": "pytorch",
-    "fmpose3d_animals": "pytorch",
+    "fmpose3d_animals": "pytorch"
 }


### PR DESCRIPTION
Fix JSON formatting by removing the trailing comma after the fmpose3d_animals entry. 

This makes the file valid JSON, the current version breaks all ModelZoo functionality in the GUI. 