### PR TITLE
Enable check-json hook in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,8 @@ repos:
       - id: name-tests-test
         args: [--pytest-test-first]
         stages: [pre-commit, manual]
+      - id: check-json
+        stages: [pre-commit, manual]
 
       # These modify files. Run locally only (pre-commit stage).
       - id: end-of-file-fixer


### PR DESCRIPTION
Add the check-json built-in hook to .pre-commit-config.yaml and configure it to run locally and in CI via stages. 

This ensures JSON files are validated before commits to catch syntax errors early.