### PR TITLE
Update deeplabcut-docker - version 0.1.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,25 +3,27 @@
 ARG PYTORCH_VERSION=2.5.1
 ARG CUDA_VERSION=12.4
 ARG CUDNN_VERSION=9
-ARG DEEPLABCUT_VERSION=3.0.0rc14
+ARG DEEPLABCUT_VERSION=3.0.0
 
 # ── core ──────────────────────────────────────────────────────────────────────
 FROM pytorch/pytorch:${PYTORCH_VERSION}-cuda${CUDA_VERSION}-cudnn${CUDNN_VERSION}-runtime AS core
 
 ARG DEEPLABCUT_VERSION
+ARG CUDA_VERSION
+ARG PYTORCH_VERSION
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -yy && \
     apt-get install -yy --no-install-recommends \
       libgl1 \
       libglib2.0-0 \
+      ffmpeg \
       build-essential \
       git \
-      ffmpeg \
+    && pip install --upgrade pip \
+    && pip install "deeplabcut[modelzoo,wandb]==${DEEPLABCUT_VERSION}" \
+    && apt-get purge -yy --auto-remove build-essential git \
     && rm -rf /var/lib/apt/lists/*
-
-RUN pip install --upgrade pip && \
-    pip install "deeplabcut[modelzoo,wandb]==${DEEPLABCUT_VERSION}"
 
 # Create pretrained weights directory and make it writable
 # (same default as HuggingFaceWeightsMixin in backbones/base.py: Path(__file__).parent / "pretrained_weights")
@@ -44,14 +46,15 @@ WORKDIR /app
 # (runs as root intentionally; deeplabcut-docker adds a host-matched user at runtime)
 FROM core AS jupyter
 
+# Default Jupyter token (override with -e NOTEBOOK_TOKEN=<secret>).
+# An empty value (-e NOTEBOOK_TOKEN=) disables token auth — see docker/README.md.
 ENV NOTEBOOK_TOKEN=deeplabcut
 
 RUN pip install "notebook<7"
 EXPOSE 8888
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8888/api/', timeout=3).read()" || exit 1
-ENTRYPOINT ["jupyter", "notebook", \
-    "--no-browser", "--NotebookApp.token=${NOTEBOOK_TOKEN}", "--ip", "0.0.0.0"]
+ENTRYPOINT exec jupyter notebook --no-browser --NotebookApp.token="${NOTEBOOK_TOKEN}" --ip 0.0.0.0
 
 # ── test (CI only, not published to Hub) ─────────────────────────────────────
 FROM core AS test

--- a/docker/README.md
+++ b/docker/README.md
@@ -76,7 +76,8 @@ code in the container. Do not expose port 8888 to the internet (e.g. via
 a cloud VM's firewall or a public 0.0.0.0 binding without a reverse proxy).
 For local use, bind the port to localhost only (e.g. -p 127.0.0.1:8888:8888)
 and use SSH port forwarding to access the server remotely, as described below.
-To use a custom token, pass -e NOTEBOOK_TOKEN=<your-token> to docker run
+To use a custom token, pass `-e NOTEBOOK_TOKEN=<your-token>` to `docker run`.
+Passing `-e NOTEBOOK_TOKEN=` (i.e. an empty string) **disables** token-authentication.
 ```
 
 This can easily be done with `deeplabcut-docker`. To run a DeepLabCut notebook on a

--- a/docker/package/changelog/v0.1.0.md
+++ b/docker/package/changelog/v0.1.0.md
@@ -1,0 +1,46 @@
+# 0.1.0 — 2026-05-29
+
+This release modernizes the deeplabcut-docker helper. The vendored shell script
+(deeplabcut_docker.sh) has been replaced with a pure-Python implementation,
+and the package setup has been updated to use pyproject.toml.
+
+## Breaking changes / migration
+
+- The package now requires Python ≥ 3.10.
+- `setup.cfg` / `MANIFEST.in` have been replaced by `pyproject.toml`.
+  Re-install from the new package to pick up the updated entry point.
+
+## New features
+
+- **Pure-Python rewrite** — replaced the vendored shell script with a single
+  `deeplabcut_docker.py` module; no shell dependency required.
+- **`--image` flag** — pass an arbitrary `repo:tag` or digest to override the
+  default image selection from `DLC_VERSION` / `CUDA_VERSION`.
+- **Local image support** — skips the registry pull when a matching image is
+  already present locally (or when a specific version/image is requested).
+- **Supplementary group forwarding** — all supplementary groups of the current
+  host user are forwarded into the container via `--group-add`.
+- **Jupyter image validation** — warns at startup when the pulled image does
+  not appear to have a Jupyter entrypoint.
+- **Configurable Docker binary** — override via `DOCKER` environment variable
+  (e.g. `DOCKER="sudo docker"`).
+- **Token privacy** — the notebook token is no longer echoed to the terminal by
+  default; users are instructed to use the value of `NOTEBOOK_TOKEN` instead.
+
+## Security
+
+- **Empty-token warning** — setting `NOTEBOOK_TOKEN=` (empty string) disables
+  Jupyter token authentication. `deeplabcut-docker notebook` now logs a
+  prominent warning in this case.
+
+## Bug fixes
+
+- Fixed broken Jupyter image support on the current Docker Hub tags.
+- Fixed default user home directory (`/home/{user}` instead of root).
+- Fixed notebook token not being propagated into the container environment.
+- Improved error logging and exit-status propagation from `docker` subprocesses.
+
+## Infrastructure
+
+- Replaced `setup.cfg` + `MANIFEST.in` with `pyproject.toml`.
+- Added `LICENSE` (LGPL-3.0) and `Makefile` for local build and PyPI release.

--- a/docker/package/deeplabcut_docker.py
+++ b/docker/package/deeplabcut_docker.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 
-__version__ = "0.0.12-alpha"
+__version__ = "0.1.0"
 
 _IMAGE = "deeplabcut/deeplabcut"
 _DEFAULT_CUDA = "12.4"

--- a/docker/package/deeplabcut_docker.py
+++ b/docker/package/deeplabcut_docker.py
@@ -116,6 +116,16 @@ def _build_user_image(remote: str, local: str) -> None:
     _log("Build succeeded")
 
 
+def _supplementary_group_args() -> list[str]:
+    """Return --group-add flags for each supplementary group of the current user."""
+    primary_gid = os.getgid()
+    args = []
+    for gid in os.getgroups():
+        if gid != primary_gid:
+            args += ["--group-add", str(gid)]
+    return args
+
+
 def _parse_args() -> tuple[argparse.Namespace, list[str]]:
     """Parse CLI args and return (namespace, extra args for docker run)."""
     parser = argparse.ArgumentParser(
@@ -149,6 +159,27 @@ def _parse_args() -> tuple[argparse.Namespace, list[str]]:
     return parser.parse_known_args()
 
 
+def _pull_image(remote: str, *, skip_if_local: bool = True) -> None:
+    """Pull the image; skip the pull if it already exists locally and skip_if_local is True."""
+    if skip_if_local:
+        r = subprocess.run(
+            _docker() + ["image", "inspect", remote],
+            capture_output=True,
+            text=True,
+        )
+        if r.returncode == 0:
+            _log(f"Using local image {remote!r} (skipping pull)")
+            return
+        if r.stderr:
+            _log(f"`docker image inspect` stderr: {r.stderr.strip()}")
+    _log(f"Pulling image {remote!r}...")
+    try:
+        subprocess.run(_docker() + ["pull", remote], check=True)
+    except subprocess.CalledProcessError as e:
+        _log(f"Failed to pull image {remote!r}. Verify the image name/tag and that Docker is running and accessible.")
+        sys.exit(e.returncode)
+
+
 def main() -> None:
     """Entry point: pull, user-layer build, and run the container."""
     _check_system()
@@ -157,19 +188,26 @@ def main() -> None:
 
     remote = args.image or _remote_tag(mode)
     local = f"deeplabcut-local-{mode}"
-    subprocess.run(_docker() + ["pull", remote], check=True)
-    if mode == "notebook" and args.image:
+    try_local_image = bool(args.image or os.environ.get("DLC_VERSION", "").strip())
+    _pull_image(remote, skip_if_local=try_local_image)
+    if mode == "notebook":
         _warn_if_not_jupyter_image(remote)
     _build_user_image(remote, local)
 
     run = _docker() + ["run", "-it", "--rm", "-v", f"{os.getcwd()}:/app", "-w", "/app"]
+    run += _supplementary_group_args()
     if mode == "notebook":
         port = os.environ.get("DLC_NOTEBOOK_PORT", "8888")
+        token = os.environ.get("NOTEBOOK_TOKEN", "deeplabcut")
         _log("Starting the notebook server.")
         _log(f"Open your browser at http://127.0.0.1:{port}")
-        _log("If prompted for a token, enter 'deeplabcut' (default).")
-        _log("To use a custom token: add -e NOTEBOOK_TOKEN=<your-token> to your arguments.")
-        run += ["-p", f"127.0.0.1:{port}:8888"]
+        if token == "":
+            _log("Warning: NOTEBOOK_TOKEN is empty — Jupyter token authentication is disabled.")
+        elif token == "deeplabcut":
+            _log(f"If prompted for a token, enter {token!r}.")
+        else:
+            _log("If prompted for a token, enter the value of NOTEBOOK_TOKEN.")
+        run += ["-p", f"127.0.0.1:{port}:8888", "-e", f"NOTEBOOK_TOKEN={token}"]
     run += docker_run_args + [local] + ([] if mode == "notebook" else ["bash"])
     sys.exit(subprocess.run(run).returncode)
 


### PR DESCRIPTION
This PR aligns the downstream package `deeplabcut-docker` with the new DeepLabCut 3.0 release and fixes some final issues before release of the new package (see version bump PR #3351).  Note that these are minor additions to a larger previous update in PR #3291. 

*changes*:
- [x] Bugfix in dockerfile for jupyter image (NOTEBOOK_TOKEN was not evaluated)
- [x] Update dockerfile default deeplabcut version: 3.0.0
- [x] Allow local image name / tag
- [x] better error logging when providing wrong image name
- [x] warning for empty notebook token
- [x] version bump + changelog **version 0.1.0**