### PR TITLE
Add GUI extra in auto-updater; support uv

### DIFF
--- a/deeplabcut/gui/utils.py
+++ b/deeplabcut/gui/utils.py
@@ -10,6 +10,8 @@
 #
 import json
 import re
+import shutil
+import sys
 import urllib.request
 from collections.abc import Callable
 
@@ -234,3 +236,57 @@ class UpdateChecker(QtCore.QObject):
             except InvalidVersion:
                 return installed == latest
         return installed == latest
+
+
+def package_specs_for_update(packages: list[str]) -> list[str]:
+    """Return package specs to install for GUI updates.
+
+    DeepLabCut itself should be updated with the GUI extra so GUI dependencies
+    are kept in sync.
+    """
+    specs = []
+
+    for package in packages:
+        normalized = package.strip()
+
+        if normalized == "deeplabcut":
+            specs.append("deeplabcut[gui]")
+        else:
+            specs.append(normalized)
+
+    return specs
+
+
+def build_update_commands(packages: list[str]) -> list[tuple[str, str, list[str]]]:
+    """Build installer commands, ordered from preferred to fallback.
+
+    Returns tuples of:
+
+        (backend_name, program, arguments)
+
+    The order is:
+      1. uv, if available
+      2. current-interpreter pip fallback
+    """
+    specs = package_specs_for_update(packages)
+    commands = []
+
+    uv = shutil.which("uv")
+    if uv:
+        commands.append(
+            (
+                "uv",
+                uv,
+                ["pip", "install", "--python", sys.executable, "-U", *specs],
+            )
+        )
+
+    commands.append(
+        (
+            "pip",
+            sys.executable,
+            ["-m", "pip", "install", "-U", *specs],
+        )
+    )
+
+    return commands

--- a/deeplabcut/gui/utils.py
+++ b/deeplabcut/gui/utils.py
@@ -238,7 +238,7 @@ class UpdateChecker(QtCore.QObject):
         return installed == latest
 
 
-def package_specs_for_update(packages: list[str]) -> list[str]:
+def _package_specs_for_update(packages: list[str]) -> list[str]:
     """Return package specs to install for GUI updates.
 
     DeepLabCut itself should be updated with the GUI extra so GUI dependencies
@@ -257,7 +257,7 @@ def package_specs_for_update(packages: list[str]) -> list[str]:
     return specs
 
 
-def build_update_commands(packages: list[str]) -> list[tuple[str, str, list[str]]]:
+def _build_update_commands(packages: list[str]) -> list[tuple[str, str, list[str]]]:
     """Build installer commands, ordered from preferred to fallback.
 
     Returns tuples of:
@@ -268,7 +268,7 @@ def build_update_commands(packages: list[str]) -> list[tuple[str, str, list[str]
       1. uv, if available
       2. current-interpreter pip fallback
     """
-    specs = package_specs_for_update(packages)
+    specs = _package_specs_for_update(packages)
     commands = []
 
     uv = shutil.which("uv")

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -459,9 +459,7 @@ class MainWindow(QMainWindow):
 
         output = "".join(self._update_process_output).strip()
         message = error_strings.get(error, f"An unknown {backend} update error occurred.")
-        failed_output = (
-            f"{message}\n\n{output}" if output else message
-        )
+        failed_output = f"{message}\n\n{output}" if output else message
         self.logger.warning(failed_output)
         self._update_attempt_outputs.append(failed_output)
 

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -454,13 +454,21 @@ class MainWindow(QMainWindow):
             QtCore.QProcess.UnknownError: f"An unknown {backend} update error occurred.",
         }
 
+        if process is not None:
+            self._drain_update_process_output(process)
+
+        output = "".join(self._update_process_output).strip()
         message = error_strings.get(error, f"An unknown {backend} update error occurred.")
-        self.logger.warning(message)
-        self._update_attempt_outputs.append(message)
+        failed_output = (
+            f"{message}\n\n{output}" if output else message
+        )
+        self.logger.warning(failed_output)
+        self._update_attempt_outputs.append(failed_output)
 
         self._disconnect_update_process(process)
         self._update_process.deleteLater()
         self._update_process = None
+        self._update_process_output = []
 
         if self._start_next_update_command():
             return

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -56,7 +56,7 @@ from deeplabcut.gui.tabs import (
     UnsupervizedIdTracking,
     VideoEditor,
 )
-from deeplabcut.gui.utils import UpdateChecker
+from deeplabcut.gui.utils import UpdateChecker, build_update_commands
 from deeplabcut.gui.widgets import StreamReceiver, StreamWriter
 
 warnings.filterwarnings(
@@ -98,6 +98,9 @@ class MainWindow(QMainWindow):
         # Update checks
         self._update_process = None
         self._update_process_output = []
+        self._update_commands = []
+        self._update_attempt_outputs = []
+        self._current_update_backend = None
 
         self._scheduled_update_check_silent = True
         self._update_check_timer = QtCore.QTimer(self)
@@ -330,6 +333,29 @@ class MainWindow(QMainWindow):
             return
         self._updater.check(silent=self._scheduled_update_check_silent)
 
+    def _start_next_update_command(self):
+        """Start the next update backend. Return True if one was started."""
+        if not self._update_commands:
+            return False
+
+        backend_name, program, arguments = self._update_commands.pop(0)
+        self._current_update_backend = backend_name
+
+        self.status_bar.showMessage(f"Installing updates with {backend_name}...")
+
+        self._update_process = QtCore.QProcess(self)
+        self._update_process.setProgram(program)
+        self._update_process.setArguments(arguments)
+
+        self._update_process.finished.connect(self._on_update_process_finished)
+        self._update_process.errorOccurred.connect(self._on_update_process_error)
+        self._update_process.readyRead.connect(self._drain_update_process_output)
+        self._update_process.setProcessChannelMode(QtCore.QProcess.MergedChannels)
+        self._update_process.start()
+
+        self.logger.info("Starting update command: %s %s", program, " ".join(arguments))
+        return True
+
     def _run_update_command(self, packages):
         if not packages:
             return
@@ -341,15 +367,17 @@ class MainWindow(QMainWindow):
         self.status_bar.showMessage("Installing updates...")
 
         self._update_process_output = []
-        self._update_process = QtCore.QProcess(self)
-        self._update_process.setProgram(sys.executable)
-        self._update_process.setArguments(["-m", "pip", "install", "-U", *packages])
+        self._update_attempt_outputs = []
+        self._update_commands = build_update_commands(packages)
+        self._current_update_backend = None
 
-        self._update_process.finished.connect(self._on_update_process_finished)
-        self._update_process.errorOccurred.connect(self._on_update_process_error)
-        self._update_process.readyRead.connect(self._drain_update_process_output)
-        self._update_process.setProcessChannelMode(QtCore.QProcess.MergedChannels)
-        self._update_process.start()
+        if not self._start_next_update_command():
+            self._cleanup_update_process()
+            QtWidgets.QMessageBox.warning(
+                self,
+                "Update failed",
+                "No available installer backend was found.",
+            )
 
     def _drain_update_process_output(self):
         if self._update_process is None:
@@ -373,7 +401,12 @@ class MainWindow(QMainWindow):
         if self._update_process is not None:
             self._update_process.deleteLater()
             self._update_process = None
+
         self._update_process_output = []
+        self._update_commands = []
+        self._update_attempt_outputs = []
+        self._current_update_backend = None
+
         self._progress_bar.hide()
         self.status_bar.showMessage("www.deeplabcut.org")
 
@@ -382,19 +415,33 @@ class MainWindow(QMainWindow):
             self._cleanup_update_process()
             return
 
-        error_strings = {
-            QtCore.QProcess.FailedToStart: (
-                "Process failed to start. Check that pip is available and you have sufficient permissions."
-            ),
-            QtCore.QProcess.Crashed: "Update process crashed unexpectedly.",
-            QtCore.QProcess.Timedout: "Update process timed out.",
-            QtCore.QProcess.WriteError: "Could not write to update process.",
-            QtCore.QProcess.ReadError: "Could not read from update process.",
-            QtCore.QProcess.UnknownError: "An unknown error occurred.",
-        }
-        message = error_strings.get(error, "An unknown error occurred.")
-        QtWidgets.QMessageBox.warning(self, "Update failed", message)
+        backend = self._current_update_backend or "installer"
 
+        error_strings = {
+            QtCore.QProcess.FailedToStart: f"The {backend} update process failed to start.",
+            QtCore.QProcess.Crashed: f"The {backend} update process crashed unexpectedly.",
+            QtCore.QProcess.Timedout: f"The {backend} update process timed out.",
+            QtCore.QProcess.WriteError: f"Could not write to the {backend} update process.",
+            QtCore.QProcess.ReadError: f"Could not read from the {backend} update process.",
+            QtCore.QProcess.UnknownError: f"An unknown {backend} update error occurred.",
+        }
+
+        message = error_strings.get(error, f"An unknown {backend} update error occurred.")
+        self.logger.warning(message)
+        self._update_attempt_outputs.append(message)
+
+        if self._update_process is not None:
+            self._update_process.deleteLater()
+            self._update_process = None
+
+        if self._start_next_update_command():
+            return
+
+        QtWidgets.QMessageBox.warning(
+            self,
+            "Update failed",
+            "No update backend completed successfully.\n\n" + "\n\n---\n\n".join(self._update_attempt_outputs),
+        )
         self._cleanup_update_process()
 
     def _on_update_process_finished(self, exit_code, exit_status):
@@ -405,28 +452,44 @@ class MainWindow(QMainWindow):
         if self._update_process is None:
             return
 
-        self._progress_bar.hide()
         self._drain_update_process_output()
 
         output = "".join(self._update_process_output).strip()
+        backend = self._current_update_backend or "installer"
 
         if exit_status == QtCore.QProcess.NormalExit and exit_code == 0:
+            self._progress_bar.hide()
+
             QtWidgets.QMessageBox.information(
                 self,
                 "Update complete",
                 "The update completed successfully.\n\nPlease restart DeepLabCut to use the updated packages.",
             )
+
             if output:
                 self.logger.info(output)
-        else:
-            QtWidgets.QMessageBox.warning(
-                self,
-                "Update failed",
-                "The update command did not complete successfully.\n\n"
-                f"{output or 'No additional output was captured.'}",
-            )
-            if output:
-                self.logger.error(output)
+
+            self._cleanup_update_process()
+            return
+
+        failed_output = (
+            f"{backend} failed with exit code {exit_code}.\n\n{output or 'No additional output was captured.'}"
+        )
+        self._update_attempt_outputs.append(failed_output)
+        self.logger.warning(failed_output)
+
+        self._update_process.deleteLater()
+        self._update_process = None
+        self._update_process_output = []
+
+        if self._start_next_update_command():
+            return
+
+        QtWidgets.QMessageBox.warning(
+            self,
+            "Update failed",
+            "No update backend completed successfully.\n\n" + "\n\n---\n\n".join(self._update_attempt_outputs),
+        )
 
         self._cleanup_update_process()
 

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -432,6 +432,7 @@ class MainWindow(QMainWindow):
 
         if self._update_process is not None:
             self._update_process.deleteLater()
+            self._update_process_output = []
             self._update_process = None
 
         if self._start_next_update_command():

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -312,6 +312,20 @@ class MainWindow(QMainWindow):
     def video_files(self):
         return self.files
 
+    def _disconnect_update_process(self, process):
+        if process is None:
+            return
+
+        for signal, slot in (
+            (process.finished, self._on_update_process_finished),
+            (process.errorOccurred, self._on_update_process_error),
+            (process.readyRead, self._drain_update_process_output),
+        ):
+            try:
+                signal.disconnect(slot)
+            except (TypeError, RuntimeError):
+                pass
+
     def check_for_updates(self, *, silent=True, delay_ms=0):
         """Start an update check immediately or schedule it after a delay."""
         if self._closing:
@@ -379,11 +393,19 @@ class MainWindow(QMainWindow):
                 "No available installer backend was found.",
             )
 
-    def _drain_update_process_output(self):
-        if self._update_process is None:
+    def _drain_update_process_output(self, process=None):
+
+        if process is None:
+            sender = self.sender()
+            process = sender if sender is not None else self._update_process
+
+        if process is not self._update_process:
             return
 
-        data = bytes(self._update_process.readAll())
+        if process is None:
+            return
+
+        data = bytes(process.readAll())
         if not data:
             return
 
@@ -399,6 +421,7 @@ class MainWindow(QMainWindow):
 
     def _cleanup_update_process(self):
         if self._update_process is not None:
+            self._disconnect_update_process(self._update_process)
             self._update_process.deleteLater()
             self._update_process = None
 
@@ -411,6 +434,11 @@ class MainWindow(QMainWindow):
         self.status_bar.showMessage("www.deeplabcut.org")
 
     def _on_update_process_error(self, error):
+
+        process = self.sender()
+        if process is not self._update_process:
+            return
+
         if self._closing:
             self._cleanup_update_process()
             return
@@ -430,10 +458,9 @@ class MainWindow(QMainWindow):
         self.logger.warning(message)
         self._update_attempt_outputs.append(message)
 
-        if self._update_process is not None:
-            self._update_process.deleteLater()
-            self._update_process_output = []
-            self._update_process = None
+        self._disconnect_update_process(process)
+        self._update_process.deleteLater()
+        self._update_process = None
 
         if self._start_next_update_command():
             return
@@ -446,14 +473,18 @@ class MainWindow(QMainWindow):
         self._cleanup_update_process()
 
     def _on_update_process_finished(self, exit_code, exit_status):
+        process = self.sender()
+        if process is not self._update_process:
+            return
+
         if self._closing:
             self._cleanup_update_process()
             return
 
-        if self._update_process is None:
+        if process is None:
             return
 
-        self._drain_update_process_output()
+        self._drain_update_process_output(process)
 
         output = "".join(self._update_process_output).strip()
         backend = self._current_update_backend or "installer"
@@ -479,7 +510,8 @@ class MainWindow(QMainWindow):
         self._update_attempt_outputs.append(failed_output)
         self.logger.warning(failed_output)
 
-        self._update_process.deleteLater()
+        self._disconnect_update_process(process)
+        process.deleteLater()
         self._update_process = None
         self._update_process_output = []
 

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -390,7 +390,7 @@ class MainWindow(QMainWindow):
             QtWidgets.QMessageBox.warning(
                 self,
                 "Update failed",
-                "No available installer backend was found.",
+                "No update commands were generated.",
             )
 
     def _drain_update_process_output(self, process=None):

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -56,7 +56,7 @@ from deeplabcut.gui.tabs import (
     UnsupervizedIdTracking,
     VideoEditor,
 )
-from deeplabcut.gui.utils import UpdateChecker, build_update_commands
+from deeplabcut.gui.utils import UpdateChecker, _build_update_commands
 from deeplabcut.gui.widgets import StreamReceiver, StreamWriter
 
 warnings.filterwarnings(
@@ -382,7 +382,7 @@ class MainWindow(QMainWindow):
 
         self._update_process_output = []
         self._update_attempt_outputs = []
-        self._update_commands = build_update_commands(packages)
+        self._update_commands = _build_update_commands(packages)
         self._current_update_backend = None
 
         if not self._start_next_update_command():
@@ -399,10 +399,7 @@ class MainWindow(QMainWindow):
             sender = self.sender()
             process = sender if sender is not None else self._update_process
 
-        if process is not self._update_process:
-            return
-
-        if process is None:
+        if process is None or process is not self._update_process:
             return
 
         data = bytes(process.readAll())
@@ -464,7 +461,7 @@ class MainWindow(QMainWindow):
         self._update_attempt_outputs.append(failed_output)
 
         self._disconnect_update_process(process)
-        self._update_process.deleteLater()
+        process.deleteLater()
         self._update_process = None
         self._update_process_output = []
 
@@ -480,7 +477,7 @@ class MainWindow(QMainWindow):
 
     def _on_update_process_finished(self, exit_code, exit_status):
         process = self.sender()
-        if process is not self._update_process:
+        if process is None or process is not self._update_process:
             return
 
         if self._closing:
@@ -496,8 +493,6 @@ class MainWindow(QMainWindow):
         backend = self._current_update_backend or "installer"
 
         if exit_status == QtCore.QProcess.NormalExit and exit_code == 0:
-            self._progress_bar.hide()
-
             QtWidgets.QMessageBox.information(
                 self,
                 "Update complete",

--- a/tests/gui/test_auto_update.py
+++ b/tests/gui/test_auto_update.py
@@ -34,10 +34,6 @@ def test_package_specs_for_update_strips_whitespace():
     [
         ({}, ["pip"]),
         ({"uv": "/mock/bin/uv"}, ["uv", "pip"]),
-        (
-            {"uv": "/mock/bin/uv"},
-            ["uv", "pip"],
-        ),
     ],
 )
 def test_build_update_commands_backend_order(monkeypatch, available_installers, expected_backends):

--- a/tests/gui/test_auto_update.py
+++ b/tests/gui/test_auto_update.py
@@ -2,6 +2,8 @@ import sys
 
 import pytest
 
+pytest.importorskip("PySide6")
+
 from deeplabcut.gui.utils import build_update_commands, package_specs_for_update
 
 

--- a/tests/gui/test_auto_update.py
+++ b/tests/gui/test_auto_update.py
@@ -1,0 +1,143 @@
+import sys
+
+import pytest
+
+from deeplabcut.gui.utils import build_update_commands, package_specs_for_update
+
+
+def test_package_specs_for_update_adds_gui_extra_to_deeplabcut():
+    assert package_specs_for_update(["deeplabcut"]) == ["deeplabcut[gui]"]
+
+
+def test_package_specs_for_update_preserves_other_packages():
+    assert package_specs_for_update(["napari-deeplabcut"]) == ["napari-deeplabcut"]
+
+
+def test_package_specs_for_update_handles_mixed_packages():
+    assert package_specs_for_update(["deeplabcut", "napari-deeplabcut"]) == [
+        "deeplabcut[gui]",
+        "napari-deeplabcut",
+    ]
+
+
+def test_package_specs_for_update_strips_whitespace():
+    assert package_specs_for_update([" deeplabcut ", " napari-deeplabcut "]) == [
+        "deeplabcut[gui]",
+        "napari-deeplabcut",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("available_installers", "expected_backends"),
+    [
+        ({}, ["pip"]),
+        ({"uv": "/mock/bin/uv"}, ["uv", "pip"]),
+        (
+            {"uv": "/mock/bin/uv"},
+            ["uv", "pip"],
+        ),
+    ],
+)
+def test_build_update_commands_backend_order(monkeypatch, available_installers, expected_backends):
+    def fake_which(name):
+        return available_installers.get(name)
+
+    monkeypatch.setattr("deeplabcut.gui.utils.shutil.which", fake_which)
+
+    commands = build_update_commands(["deeplabcut", "napari-deeplabcut"])
+
+    assert [backend for backend, _program, _args in commands] == expected_backends
+
+
+def test_build_update_commands_uses_uv_when_available(monkeypatch):
+    monkeypatch.setattr(
+        "deeplabcut.gui.utils.shutil.which",
+        lambda name: "/mock/bin/uv" if name == "uv" else None,
+    )
+
+    commands = build_update_commands(["deeplabcut", "napari-deeplabcut"])
+
+    assert commands == [
+        (
+            "uv",
+            "/mock/bin/uv",
+            [
+                "pip",
+                "install",
+                "--python",
+                sys.executable,
+                "-U",
+                "deeplabcut[gui]",
+                "napari-deeplabcut",
+            ],
+        ),
+        (
+            "pip",
+            sys.executable,
+            [
+                "-m",
+                "pip",
+                "install",
+                "-U",
+                "deeplabcut[gui]",
+                "napari-deeplabcut",
+            ],
+        ),
+    ]
+
+
+def test_build_update_commands_uses_uv_then_pip(monkeypatch):
+    installers = {"uv": "/mock/bin/uv"}
+
+    monkeypatch.setattr(
+        "deeplabcut.gui.utils.shutil.which",
+        lambda name: installers.get(name),
+    )
+
+    commands = build_update_commands(["deeplabcut"])
+
+    assert commands == [
+        (
+            "uv",
+            "/mock/bin/uv",
+            [
+                "pip",
+                "install",
+                "--python",
+                sys.executable,
+                "-U",
+                "deeplabcut[gui]",
+            ],
+        ),
+        (
+            "pip",
+            sys.executable,
+            [
+                "-m",
+                "pip",
+                "install",
+                "-U",
+                "deeplabcut[gui]",
+            ],
+        ),
+    ]
+
+
+def test_build_update_commands_always_has_pip_fallback(monkeypatch):
+    monkeypatch.setattr("deeplabcut.gui.utils.shutil.which", lambda _name: None)
+
+    commands = build_update_commands(["deeplabcut"])
+
+    assert commands == [
+        (
+            "pip",
+            sys.executable,
+            [
+                "-m",
+                "pip",
+                "install",
+                "-U",
+                "deeplabcut[gui]",
+            ],
+        )
+    ]

--- a/tests/gui/test_auto_update.py
+++ b/tests/gui/test_auto_update.py
@@ -4,26 +4,26 @@ import pytest
 
 pytest.importorskip("PySide6")
 
-from deeplabcut.gui.utils import build_update_commands, package_specs_for_update
+from deeplabcut.gui.utils import _build_update_commands, _package_specs_for_update
 
 
 def test_package_specs_for_update_adds_gui_extra_to_deeplabcut():
-    assert package_specs_for_update(["deeplabcut"]) == ["deeplabcut[gui]"]
+    assert _package_specs_for_update(["deeplabcut"]) == ["deeplabcut[gui]"]
 
 
 def test_package_specs_for_update_preserves_other_packages():
-    assert package_specs_for_update(["napari-deeplabcut"]) == ["napari-deeplabcut"]
+    assert _package_specs_for_update(["napari-deeplabcut"]) == ["napari-deeplabcut"]
 
 
 def test_package_specs_for_update_handles_mixed_packages():
-    assert package_specs_for_update(["deeplabcut", "napari-deeplabcut"]) == [
+    assert _package_specs_for_update(["deeplabcut", "napari-deeplabcut"]) == [
         "deeplabcut[gui]",
         "napari-deeplabcut",
     ]
 
 
 def test_package_specs_for_update_strips_whitespace():
-    assert package_specs_for_update([" deeplabcut ", " napari-deeplabcut "]) == [
+    assert _package_specs_for_update([" deeplabcut ", " napari-deeplabcut "]) == [
         "deeplabcut[gui]",
         "napari-deeplabcut",
     ]
@@ -42,7 +42,7 @@ def test_build_update_commands_backend_order(monkeypatch, available_installers, 
 
     monkeypatch.setattr("deeplabcut.gui.utils.shutil.which", fake_which)
 
-    commands = build_update_commands(["deeplabcut", "napari-deeplabcut"])
+    commands = _build_update_commands(["deeplabcut", "napari-deeplabcut"])
 
     assert [backend for backend, _program, _args in commands] == expected_backends
 
@@ -53,7 +53,7 @@ def test_build_update_commands_uses_uv_when_available(monkeypatch):
         lambda name: "/mock/bin/uv" if name == "uv" else None,
     )
 
-    commands = build_update_commands(["deeplabcut", "napari-deeplabcut"])
+    commands = _build_update_commands(["deeplabcut", "napari-deeplabcut"])
 
     assert commands == [
         (
@@ -92,7 +92,7 @@ def test_build_update_commands_uses_uv_then_pip(monkeypatch):
         lambda name: installers.get(name),
     )
 
-    commands = build_update_commands(["deeplabcut"])
+    commands = _build_update_commands(["deeplabcut"])
 
     assert commands == [
         (
@@ -124,7 +124,7 @@ def test_build_update_commands_uses_uv_then_pip(monkeypatch):
 def test_build_update_commands_always_has_pip_fallback(monkeypatch):
     monkeypatch.setattr("deeplabcut.gui.utils.shutil.which", lambda _name: None)
 
-    commands = build_update_commands(["deeplabcut"])
+    commands = _build_update_commands(["deeplabcut"])
 
     assert commands == [
         (


### PR DESCRIPTION
## Scope

- Introduces support for multiple installer backends (such as `uv` instead of just`pip`)
- Added GUI extra since the auto-update process runs only there

Adds new utility functions for building update commands, refactors the update process to try preferred installers first with fallbacks, and adds tests for these.

## Automated summary

**Update backend improvements:**

* Added `package_specs_for_update` and `build_update_commands` utility functions in `deeplabcut/gui/utils.py` to generate the correct package specifications (ensuring `deeplabcut` is updated with `[gui]` extra) and to build a prioritized list of installer commands, preferring `uv` if available and always falling back to `pip` (`[deeplabcut/gui/utils.pyR239-R292](diffhunk://#diff-4279538071ed35262d378e598eb69f5d2e1aced94717f42138692f0d8c718e3cR239-R292)`).
* Refactored the update process in `deeplabcut/gui/window.py` to use the new backend selection logic, attempting each backend in order and providing more informative error messages and logs for each attempt (`[[1]](diffhunk://#diff-4dbcd4272a9f0fb80775a2e54ed8d52f229695085258e5b5d0172f05870a3772L344-R380)`, `[[2]](diffhunk://#diff-4dbcd4272a9f0fb80775a2e54ed8d52f229695085258e5b5d0172f05870a3772R336-R358)`, `[[3]](diffhunk://#diff-4dbcd4272a9f0fb80775a2e54ed8d52f229695085258e5b5d0172f05870a3772L408-L429)`, `[[4]](diffhunk://#diff-4dbcd4272a9f0fb80775a2e54ed8d52f229695085258e5b5d0172f05870a3772R418-R444)`, `[[5]](diffhunk://#diff-4dbcd4272a9f0fb80775a2e54ed8d52f229695085258e5b5d0172f05870a3772R404-R409)`).

**Testing and reliability:**

* Added a new test suite `tests/gui/test_auto_update.py` to verify that package specs are built correctly and that the update command selection logic works as intended, including backend prioritization and fallback behavior (`[tests/gui/test_auto_update.pyR1-R143](diffhunk://#diff-fe6347302c05d4e806136ae254f592f3a74c323a95a79724b435dd5c0d83c75eR1-R143)`).

**Dependency management:**

* Ensured that updates to DeepLabCut via the GUI always include the `[gui]` extra, keeping GUI dependencies in sync and reducing the risk of mismatched versions (`[deeplabcut/gui/utils.pyR239-R292](diffhunk://#diff-4279538071ed35262d378e598eb69f5d2e1aced94717f42138692f0d8c718e3cR239-R292)`).
