### PR TITLE
Docs audit [April 2026]: Merge GUI guide entry and update guide title

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -23,8 +23,8 @@ parts:
   - caption: GUI workflow
     chapters:
       - file: docs/gui/PROJECT_GUI
-      - file: docs/beginner-guides/beginners-guide
         sections:
+          - file: docs/beginner-guides/beginners-guide
           - file: docs/beginner-guides/manage-project
           - file: docs/beginner-guides/labeling
           - file: docs/beginner-guides/Training-Evaluation

--- a/docs/beginner-guides/beginners-guide.md
+++ b/docs/beginner-guides/beginners-guide.md
@@ -11,7 +11,7 @@ deeplabcut:
 
 (file:beginners-guide)=
 
-# Project Manager GUI - Step by step
+# Setting up a new project
 
 <img src="https://images.squarespace-cdn.com/content/v1/57f6d51c9f74566f55ecf271/1572296495650-Y4ZTJ2XP2Z9XF1AD74VW/ke17ZwdGBToddI8pDm48kMulEJPOrz9Y8HeI7oJuXxR7gQa3H78H3Y0txjaiv_0fDoOvxcdMmMKkDsyUqMSsMWxHk725yiiHCCLfrh8O1z5QPOohDIaIeljMHgDF5CVlOqpeNLcJ80NK65_fV7S1UZiU3J6AN9rgO1lHw9nGbkYQrCLTag1XBHRgOrY8YAdXW07ycm2Trb21kYhaLJjddA/DLC_logo_blk-01.png?format=1000w" width="150" title="DLC-live" alt="DLC LIVE!" align="right" vspace = "50">
 


### PR DESCRIPTION
Move beginners-guide into the GUI workflow sections in _toc.yml so it appears under the GUI chapter, and update the document heading in docs/beginner-guides/beginners-guide.md from "Project Manager GUI - Step by step" to "Setting up a new project".