### PR TITLE
deeplabcut-docker: version 0.1.0

### DIFF
--- a/docker/package/changelog/v0.1.0.md
+++ b/docker/package/changelog/v0.1.0.md
@@ -1,0 +1,55 @@
+# deeplabcut-docker Changelog
+
+## 0.1.0 — 2026-05-29
+
+This release revives and modernises the `deeplabcut-docker` helper, which was
+not actively maintenance and was broken for the Jupyter images on Docker Hub.
+The vendored shell script (`deeplabcut_docker.sh`) has been replaced with
+a pure-Python implementation, and the package setup has been modernised.
+
+### Breaking changes / migration
+
+- The package now requires Python ≥ 3.10.
+- `setup.cfg` / `MANIFEST.in` have been replaced by `pyproject.toml`.
+  Re-install from the new package to pick up the updated entry point.
+
+### New features
+
+- **Pure-Python rewrite** — replaced the vendored shell script with a single
+  `deeplabcut_docker.py` module; no shell dependency required.
+- **`--image` flag** — pass an arbitrary `repo:tag` or digest to override the
+  default image selection from `DLC_VERSION` / `CUDA_VERSION`.
+- **Local image support** — skips the registry pull when a matching image is
+  already present locally (or when a specific version/image is requested).
+- **Supplementary group forwarding** — all supplementary groups of the current
+  host user are forwarded into the container via `--group-add`.
+- **Jupyter image validation** — warns at startup when the pulled image does
+  not appear to have a Jupyter entrypoint.
+- **Configurable Docker binary** — override via `DOCKER` environment variable
+  (e.g. `DOCKER="sudo docker"`).
+- **Token privacy** — the notebook token is no longer echoed to the terminal by
+  default; users are instructed to use the value of `NOTEBOOK_TOKEN` instead.
+
+### Security
+
+- **Empty-token warning** — setting `NOTEBOOK_TOKEN=` (empty string) disables
+  Jupyter token authentication. `deeplabcut-docker notebook` now logs a
+  prominent warning in this case.
+
+### Bug fixes
+
+- Fixed broken Jupyter image support on the current Docker Hub tags.
+- Fixed default user home directory (`/home/{user}` instead of root).
+- Fixed notebook token not being propagated into the container environment.
+- Improved error logging and exit-status propagation from `docker` subprocesses.
+
+### Infrastructure
+
+- Replaced `setup.cfg` + `MANIFEST.in` with `pyproject.toml`.
+- Added `LICENSE` (LGPL-3.0) and `Makefile` for local build and PyPI release.
+
+---
+
+## 0.0.12-alpha — (prior release)
+
+Initial alpha release on PyPI. Based on a vendored shell script.

--- a/docker/package/changelog/v0.1.0.md
+++ b/docker/package/changelog/v0.1.0.md
@@ -1,19 +1,17 @@
-# deeplabcut-docker Changelog
-
-## 0.1.0 — 2026-05-29
+# 0.1.0 — 2026-05-29
 
 This release revives and modernises the `deeplabcut-docker` helper, which was
-not actively maintenance and was broken for the Jupyter images on Docker Hub.
+not actively maintained and was broken for the Jupyter images on Docker Hub.
 The vendored shell script (`deeplabcut_docker.sh`) has been replaced with
 a pure-Python implementation, and the package setup has been modernised.
 
-### Breaking changes / migration
+## Breaking changes / migration
 
 - The package now requires Python ≥ 3.10.
 - `setup.cfg` / `MANIFEST.in` have been replaced by `pyproject.toml`.
   Re-install from the new package to pick up the updated entry point.
 
-### New features
+## New features
 
 - **Pure-Python rewrite** — replaced the vendored shell script with a single
   `deeplabcut_docker.py` module; no shell dependency required.
@@ -30,26 +28,20 @@ a pure-Python implementation, and the package setup has been modernised.
 - **Token privacy** — the notebook token is no longer echoed to the terminal by
   default; users are instructed to use the value of `NOTEBOOK_TOKEN` instead.
 
-### Security
+## Security
 
 - **Empty-token warning** — setting `NOTEBOOK_TOKEN=` (empty string) disables
   Jupyter token authentication. `deeplabcut-docker notebook` now logs a
   prominent warning in this case.
 
-### Bug fixes
+## Bug fixes
 
 - Fixed broken Jupyter image support on the current Docker Hub tags.
 - Fixed default user home directory (`/home/{user}` instead of root).
 - Fixed notebook token not being propagated into the container environment.
 - Improved error logging and exit-status propagation from `docker` subprocesses.
 
-### Infrastructure
+## Infrastructure
 
 - Replaced `setup.cfg` + `MANIFEST.in` with `pyproject.toml`.
 - Added `LICENSE` (LGPL-3.0) and `Makefile` for local build and PyPI release.
-
----
-
-## 0.0.12-alpha — (prior release)
-
-Initial alpha release on PyPI. Based on a vendored shell script.

--- a/docker/package/changelog/v0.1.0.md
+++ b/docker/package/changelog/v0.1.0.md
@@ -1,9 +1,8 @@
 # 0.1.0 — 2026-05-29
 
-This release revives and modernizes the `deeplabcut-docker` helper, which was
-not actively maintained and was broken for the Jupyter images on Docker Hub.
-The vendored shell script (`deeplabcut_docker.sh`) has been replaced with
-a pure-Python implementation, and the package setup has been modernised.
+This release modernizes the deeplabcut-docker helper. The vendored shell script
+(deeplabcut_docker.sh) has been replaced with a pure-Python implementation,
+and the package setup has been updated to use pyproject.toml.
 
 ## Breaking changes / migration
 

--- a/docker/package/changelog/v0.1.0.md
+++ b/docker/package/changelog/v0.1.0.md
@@ -1,6 +1,6 @@
 # 0.1.0 — 2026-05-29
 
-This release revives and modernises the `deeplabcut-docker` helper, which was
+This release revives and modernizes the `deeplabcut-docker` helper, which was
 not actively maintained and was broken for the Jupyter images on Docker Hub.
 The vendored shell script (`deeplabcut_docker.sh`) has been replaced with
 a pure-Python implementation, and the package setup has been modernised.

--- a/docker/package/deeplabcut_docker.py
+++ b/docker/package/deeplabcut_docker.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 
-__version__ = "0.0.12-alpha"
+__version__ = "0.1.0"
 
 _IMAGE = "deeplabcut/deeplabcut"
 _DEFAULT_CUDA = "12.4"


### PR DESCRIPTION
Version bump, for releasing deeplabcut-docker 0.1.0

See changelog below

> [!CAUTION]
>Merge this PR into **main** before making the latest release.

---

## v0.1.0 — 2026-05-29

This release revives and modernises the `deeplabcut-docker` helper, which was
not actively maintenance and was broken for the Jupyter images on Docker Hub.
The vendored shell script (`deeplabcut_docker.sh`) has been replaced with
a pure-Python implementation, and the package setup has been modernised.

### Breaking changes / migration

- The package now requires Python ≥ 3.10.
- `setup.cfg` / `MANIFEST.in` have been replaced by `pyproject.toml`.
  Re-install from the new package to pick up the updated entry point.

### New features

- **Pure-Python rewrite** — replaced the vendored shell script with a single
  `deeplabcut_docker.py` module; no shell dependency required.
- **`--image` flag** — pass an arbitrary `repo:tag` or digest to override the
  default image selection from `DLC_VERSION` / `CUDA_VERSION`.
- **Local image support** — skips the registry pull when a matching image is
  already present locally (or when a specific version/image is requested).
- **Supplementary group forwarding** — all supplementary groups of the current
  host user are forwarded into the container via `--group-add`.
- **Jupyter image validation** — warns at startup when the pulled image does
  not appear to have a Jupyter entrypoint.
- **Configurable Docker binary** — override via `DOCKER` environment variable
  (e.g. `DOCKER="sudo docker"`).
- **Token privacy** — the notebook token is no longer echoed to the terminal by
  default; users are instructed to use the value of `NOTEBOOK_TOKEN` instead.

### Security

- **Empty-token warning** — setting `NOTEBOOK_TOKEN=` (empty string) disables
  Jupyter token authentication. `deeplabcut-docker notebook` now logs a
  prominent warning in this case.

### Bug fixes

- Fixed broken Jupyter image support on the current Docker Hub tags.
- Fixed default user home directory (`/home/{user}` instead of root).
- Fixed notebook token not being propagated into the container environment.
- Improved error logging and exit-status propagation from `docker` subprocesses.

### Infrastructure

- Replaced `setup.cfg` + `MANIFEST.in` with `pyproject.toml`.
- Added `LICENSE` (LGPL-3.0) and `Makefile` for local build and PyPI release.
