### PR TITLE
Remove unused create_folder function from utils.py

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/utils.py
@@ -10,21 +10,10 @@
 #
 from __future__ import annotations
 
-import os
 import random
 
 import numpy as np
 import torch
-
-
-def create_folder(path_to_folder):
-    """Creates all folders contained in the path.
-
-    Args:
-        path_to_folder: Path to the folder that should be created
-    """
-    if not os.path.exists(path_to_folder):
-        os.makedirs(path_to_folder)
 
 
 def fix_seeds(seed: int) -> None:


### PR DESCRIPTION
The `create_folder` function in `deeplabcut/pose_estimation_pytorch/utils.py` was defined but never imported or called anywhere in the codebase. This PR removes it along with the now-unnecessary `import os`.