### PR TITLE
Prepare migration to pandas 3.0

### DIFF
--- a/deeplabcut/core/inferenceutils.py
+++ b/deeplabcut/core/inferenceutils.py
@@ -1046,7 +1046,7 @@ def parse_ground_truth_data_file(h5_file):
         pass
     # Cast columns of dtype 'object' to float to avoid TypeError
     # further down in _parse_ground_truth_data.
-    # TODO @deruyter92 2026-06-10: pandas migration 3.0 requires us to add support for string dtype columns.
+    # TODO @deruyter92 2026-06-10 (#3362): pandas migration 3.0 requires us to add support for string dtype columns.
     cols = df.select_dtypes(include="object").columns
     if cols.to_list():
         df[cols] = df[cols].astype("float")

--- a/deeplabcut/core/inferenceutils.py
+++ b/deeplabcut/core/inferenceutils.py
@@ -1046,6 +1046,7 @@ def parse_ground_truth_data_file(h5_file):
         pass
     # Cast columns of dtype 'object' to float to avoid TypeError
     # further down in _parse_ground_truth_data.
+    # TODO @deruyter92 2026-06-10: pandas migration 3.0 requires us to add support for string dtype columns.
     cols = df.select_dtypes(include="object").columns
     if cols.to_list():
         df[cols] = df[cols].astype("float")

--- a/deeplabcut/gui/tracklet_toolbox.py
+++ b/deeplabcut/gui/tracklet_toolbox.py
@@ -876,6 +876,7 @@ class TrackletVisualizer:
         df = data.iloc[inds]
 
         # Uncertain keypoints are ignored
+        # TODO @deruyter92 2026-06-10: pandas migration 3.0 forbids in-place mutations of dataframe subset views.
         def filter_low_prob(cols, prob):
             mask = cols.iloc[:, 2] < prob
             cols.loc[mask] = np.nan

--- a/deeplabcut/gui/tracklet_toolbox.py
+++ b/deeplabcut/gui/tracklet_toolbox.py
@@ -876,7 +876,8 @@ class TrackletVisualizer:
         df = data.iloc[inds]
 
         # Uncertain keypoints are ignored
-        # TODO @deruyter92 2026-06-10 (#3362): pandas migration 3.0 forbids in-place mutations of dataframe subset views.
+        # TODO @deruyter92 2026-06-10 (#3362):
+        # pandas migration 3.0 forbids in-place mutations of dataframe subset views.
         def filter_low_prob(cols, prob):
             mask = cols.iloc[:, 2] < prob
             cols.loc[mask] = np.nan

--- a/deeplabcut/gui/tracklet_toolbox.py
+++ b/deeplabcut/gui/tracklet_toolbox.py
@@ -876,7 +876,7 @@ class TrackletVisualizer:
         df = data.iloc[inds]
 
         # Uncertain keypoints are ignored
-        # TODO @deruyter92 2026-06-10: pandas migration 3.0 forbids in-place mutations of dataframe subset views.
+        # TODO @deruyter92 2026-06-10 (#3362): pandas migration 3.0 forbids in-place mutations of dataframe subset views.
         def filter_low_prob(cols, prob):
             mask = cols.iloc[:, 2] < prob
             cols.loc[mask] = np.nan

--- a/deeplabcut/modelzoo/generalized_data_converter/datasets/materialize.py
+++ b/deeplabcut/modelzoo/generalized_data_converter/datasets/materialize.py
@@ -233,11 +233,11 @@ def _generic2madlc(
                 # need to be careful here to assign right keypoints to right people
                 if coord[0] > 0 and coord[1] > 0:
                     # leave them to NaN if values are 0
-                    df.loc[file_name][scorer, f"individual{individual_id}", kpt_name, "x"] = coord[0]
-                    df.loc[file_name][scorer, f"individual{individual_id}", kpt_name, "y"] = coord[1]
+                    df.loc[file_name, (scorer, f"individual{individual_id}", kpt_name, "x")] = coord[0]
+                    df.loc[file_name, (scorer, f"individual{individual_id}", kpt_name, "y")] = coord[1]
                 elif coord[2] == -1:
-                    df.loc[file_name][scorer, f"individual{individual_id}", kpt_name, "x"] = -1
-                    df.loc[file_name][scorer, f"individual{individual_id}", kpt_name, "y"] = -1
+                    df.loc[file_name, (scorer, f"individual{individual_id}", kpt_name, "x")] = -1
+                    df.loc[file_name, (scorer, f"individual{individual_id}", kpt_name, "y")] = -1
         df.to_hdf(
             os.path.join(proj_root, "labeled-data", dataset_name, f"CollectedData_{scorer}.h5"),
             key="df_with_missing",
@@ -443,12 +443,12 @@ def _generic2sdlc(
                 # need to be careful here to assign right keypoints to right people
 
                 if coord[0] > 0 and coord[1] > 0:
-                    df.loc[file_name][scorer, kpt_name, "x"] = coord[0]
-                    df.loc[file_name][scorer, kpt_name, "y"] = coord[1]
+                    df.loc[file_name, (scorer, kpt_name, "x")] = coord[0]
+                    df.loc[file_name, (scorer, kpt_name, "y")] = coord[1]
                 elif coord[2] == -1:
                     # if -1, this visibility flag means a given keypoint was not annotated in the original dataset
-                    df.loc[file_name][scorer, kpt_name, "x"] = -1
-                    df.loc[file_name][scorer, kpt_name, "y"] = -1
+                    df.loc[file_name, (scorer, kpt_name, "x")] = -1
+                    df.loc[file_name, (scorer, kpt_name, "y")] = -1
 
         df = df.dropna(how="all")
         df.to_hdf(

--- a/deeplabcut/modelzoo/generalized_data_converter/utils.py
+++ b/deeplabcut/modelzoo/generalized_data_converter/utils.py
@@ -170,9 +170,9 @@ def create_video_h5_from_pickle(proj_root, cfg, reference_pickle, videopath):
 
     for imagename, kpts in zip(imagenames, detections, strict=False):
         for kpt_id, kpt_name in enumerate(keypoint_names):
-            df.loc[imagename][scorer, kpt_name, "x"] = kpts[kpt_id, 0]
-            df.loc[imagename][scorer, kpt_name, "y"] = kpts[kpt_id, 1]
-            df.loc[imagename][scorer, kpt_name, "likelihood"] = kpts[kpt_id, 2]
+            df.loc[imagename, (scorer, kpt_name, "x")] = kpts[kpt_id, 0]
+            df.loc[imagename, (scorer, kpt_name, "y")] = kpts[kpt_id, 1]
+            df.loc[imagename, (scorer, kpt_name, "likelihood")] = kpts[kpt_id, 2]
 
     vname = Path(videopath).stem
     DLCscorer = ""

--- a/deeplabcut/pose_estimation_pytorch/metrics/scoring.py
+++ b/deeplabcut/pose_estimation_pytorch/metrics/scoring.py
@@ -41,7 +41,8 @@ def _match_identity_preds_to_gt(config_path: str, full_pickle_path: str) -> tupl
 
         df = df_gt.unstack("coords").reindex(joints, level="bodyparts")
         xy_pred = dict_["prediction"]["coordinates"][0]
-        for bpt, xy_gt in df.groupby(level="bodyparts"):
+        for bpt, xy_gt in df.T.groupby(level="bodyparts"):
+            xy_gt = xy_gt.T
             inds_gt = np.flatnonzero(np.all(~np.isnan(xy_gt), axis=1))
             n_joint = joints.index(bpt)
             xy = xy_pred[n_joint]

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -326,7 +326,7 @@ def evaluate_multianimal_full(
                         # Form 2D array of shape (n_rows, 4) where the last dim is
                         # (sample_index, peak_y, peak_x, bpt_index) to slice the PAFs.
                         temp = df.reset_index(level="bodyparts").dropna()
-                        # TODO @deruyter92 2026-06-10: pandas migration 3.0 - this will break if bodyparts is a str type
+                        # TODO @deruyter92 2026-06-10 (#3362): pandas migration 3.0 - this will break if bodyparts is a str type
                         # and future.no_silent_downcasting is also removed in pandas 3.0.
                         with pd.option_context("future.no_silent_downcasting", True):
                             temp["bodyparts"] = (

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -367,7 +367,6 @@ def evaluate_multianimal_full(
                         coords_pred = pred["coordinates"][0]
                         probs_pred = pred["confidence"]
                         for bpt, xy_gt in df.groupby(level="bodyparts"):
-                            # xy_gt = xy_gt.T
                             inds_gt = np.flatnonzero(np.all(~np.isnan(xy_gt), axis=1))
                             n_joint = joints.index(bpt)
                             xy = coords_pred[n_joint]

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -366,8 +366,8 @@ def evaluate_multianimal_full(
 
                         coords_pred = pred["coordinates"][0]
                         probs_pred = pred["confidence"]
-                        for bpt, xy_gt in df.T.groupby(level="bodyparts"):
-                            xy_gt = xy_gt.T
+                        for bpt, xy_gt in df.groupby(level="bodyparts"):
+                            # xy_gt = xy_gt.T
                             inds_gt = np.flatnonzero(np.all(~np.isnan(xy_gt), axis=1))
                             n_joint = joints.index(bpt)
                             xy = coords_pred[n_joint]

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -326,6 +326,8 @@ def evaluate_multianimal_full(
                         # Form 2D array of shape (n_rows, 4) where the last dim is
                         # (sample_index, peak_y, peak_x, bpt_index) to slice the PAFs.
                         temp = df.reset_index(level="bodyparts").dropna()
+                        # TODO @deruyter92 2026-06-10: pandas migration 3.0 - this will break if bodyparts is a str type
+                        # and future.no_silent_downcasting is also removed in pandas 3.0.
                         with pd.option_context("future.no_silent_downcasting", True):
                             temp["bodyparts"] = (
                                 temp["bodyparts"]
@@ -364,7 +366,8 @@ def evaluate_multianimal_full(
 
                         coords_pred = pred["coordinates"][0]
                         probs_pred = pred["confidence"]
-                        for bpt, xy_gt in df.groupby(level="bodyparts"):
+                        for bpt, xy_gt in df.T.groupby(level="bodyparts"):
+                            xy_gt = xy_gt.T
                             inds_gt = np.flatnonzero(np.all(~np.isnan(xy_gt), axis=1))
                             n_joint = joints.index(bpt)
                             xy = coords_pred[n_joint]
@@ -491,9 +494,9 @@ def evaluate_multianimal_full(
 
                         print("##########################################")
                         print("Average Euclidean distance to GT per individual (in pixels; test-only)")
-                        print(error_masked.iloc[testIndices].groupby("individuals", axis=1).mean().mean().to_string())
+                        print(error_masked.iloc[testIndices].T.groupby("individuals").mean().T.mean().to_string())
                         print("Average Euclidean distance to GT per bodypart (in pixels; test-only)")
-                        print(error_masked.iloc[testIndices].groupby("bodyparts", axis=1).mean().mean().to_string())
+                        print(error_masked.iloc[testIndices].T.groupby("bodyparts").mean().T.mean().to_string())
 
                     PredicteData["metadata"] = {
                         "nms radius": test_pose_cfg["nmsradius"],

--- a/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/evaluate_multianimal.py
@@ -326,8 +326,8 @@ def evaluate_multianimal_full(
                         # Form 2D array of shape (n_rows, 4) where the last dim is
                         # (sample_index, peak_y, peak_x, bpt_index) to slice the PAFs.
                         temp = df.reset_index(level="bodyparts").dropna()
-                        # TODO @deruyter92 2026-06-10 (#3362): pandas migration 3.0 - this will break if bodyparts is a str type
-                        # and future.no_silent_downcasting is also removed in pandas 3.0.
+                        # TODO @deruyter92 2026-06-10 (#3362): pandas migration 3.0 - this will break if bodyparts
+                        #  is a str type and future.no_silent_downcasting is also removed in pandas 3.0.
                         with pd.option_context("future.no_silent_downcasting", True):
                             temp["bodyparts"] = (
                                 temp["bodyparts"]

--- a/deeplabcut/post_processing/analyze_skeleton.py
+++ b/deeplabcut/post_processing/analyze_skeleton.py
@@ -292,7 +292,8 @@ def analyzeskeleton(
 
         bones = {}
         if "individuals" in df.columns.names:
-            for animal_name, df_ in df.groupby(level="individuals", axis=1):
+            for animal_name, df_ in df.T.groupby(level="individuals"):
+                df_ = df_.T
                 temp = df_.droplevel(["scorer", "individuals"], axis=1)
                 if animal_name != "single":
                     for bp1, bp2 in cfg["skeleton"]:

--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -448,7 +448,7 @@ def extract_outlier_frames(
             elif outlieralgorithm == "jump":
                 temp_dt = df_temp.diff(axis=0) ** 2
                 temp_dt.drop("likelihood", axis=1, level="coords", inplace=True)
-                sum_ = temp_dt.groupby(level="bodyparts", axis=1).sum()
+                sum_ = temp_dt.T.groupby(level="bodyparts").sum().T
                 ind = df_temp.index[(sum_ > epsilon**2).any(axis=1)].tolist()
                 Indices.extend(ind)
             elif outlieralgorithm == "fitting":

--- a/deeplabcut/utils/auxiliaryfunctions_3d.py
+++ b/deeplabcut/utils/auxiliaryfunctions_3d.py
@@ -264,7 +264,8 @@ def _reconstruct_tracks_as_tracklets(df):
     from deeplabcut.refine_training_dataset.stitch import Tracklet
 
     tracklets = []
-    for _, group in df.groupby("individuals", axis=1):
+    for _, group in df.T.groupby("individuals"):
+        group = group.T
         temp = group.dropna(how="all")
         inds = temp.index.to_numpy()
         track = Tracklet(temp.to_numpy().reshape((len(temp), -1, 3)), inds)

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -135,7 +135,7 @@ def CreateVideo(
     else:
         nindividuals = len(Dataframe.columns.get_level_values("individuals").unique())
         map2bp = [bplist.index(bp) for bp in all_bpts]
-        nbpts_per_ind = Dataframe.groupby(level="individuals", axis=1).size().values // 3
+        nbpts_per_ind = Dataframe.T.groupby(level="individuals").size().values // 3
         map2id = []
         for i, j in enumerate(nbpts_per_ind):
             map2id.extend([i] * j)
@@ -283,7 +283,7 @@ def CreateVideoSlow(
     else:
         nindividuals = len(Dataframe.columns.get_level_values("individuals").unique())
         map2bp = [bplist.index(bp) for bp in all_bpts]
-        nbpts_per_ind = Dataframe.groupby(level="individuals", axis=1).size().values // 3
+        nbpts_per_ind = Dataframe.T.groupby(level="individuals").size().values // 3
         map2id = []
         for i, j in enumerate(nbpts_per_ind):
             map2id.extend([i] * j)

--- a/deeplabcut/utils/pandas_future_mode.py
+++ b/deeplabcut/utils/pandas_future_mode.py
@@ -1,0 +1,32 @@
+"""Opt-in pandas 2.3 future-behavior checks for CI/local DLC test runs."""
+
+from __future__ import annotations
+
+import os
+
+import pandas as pd
+from packaging.version import Version
+
+ENABLED_ENV = "DLC_PANDAS_FUTURE"
+
+
+def is_enabled() -> bool:
+    return os.environ.get(ENABLED_ENV, "").lower() in {"1", "true", "yes"}
+
+
+def configure_pandas_future_if_enabled() -> None:
+    if not is_enabled():
+        return
+
+    ver = Version(pd.__version__)
+    if ver < Version("2.3") or ver >= Version("3"):
+        raise RuntimeError(f"pandas future mode requires pandas 2.3.x, got {pd.__version__}")
+
+    pd.options.future.infer_string = True
+    pd.options.mode.copy_on_write = "warn"
+
+    print(
+        f"pandas future mode enabled: pandas={pd.__version__}, "
+        f"infer_string={pd.options.future.infer_string}, "
+        f"copy_on_write={pd.options.mode.copy_on_write}"
+    )

--- a/examples/testscript_pytorch_multi_animal.py
+++ b/examples/testscript_pytorch_multi_animal.py
@@ -22,12 +22,14 @@ from utils import (
     run,
 )
 
-import deeplabcut.utils.auxiliaryfunctions as af
-from deeplabcut.compat import Engine
-from deeplabcut.pose_estimation_pytorch.config.utils import (
-    is_model_cond_top_down,
-    is_model_top_down,
-)
+# Enable pandas future mode warnings if DLC_PANDAS_FUTURE env var is set
+from deeplabcut.utils.pandas_future_mode import configure_pandas_future_if_enabled
+
+configure_pandas_future_if_enabled()
+
+import deeplabcut.utils.auxiliaryfunctions as af  # noqa: E402
+from deeplabcut.compat import Engine  # noqa: E402
+from deeplabcut.pose_estimation_pytorch.config.utils import is_model_cond_top_down, is_model_top_down  # noqa: E402
 
 
 def main(

--- a/examples/testscript_pytorch_single_animal.py
+++ b/examples/testscript_pytorch_single_animal.py
@@ -13,8 +13,13 @@ from utils import (
     run,
 )
 
-import deeplabcut.utils.auxiliaryfunctions as af
-from deeplabcut.compat import Engine
+# Enable pandas future mode warnings if DLC_PANDAS_FUTURE env var is set
+from deeplabcut.utils.pandas_future_mode import configure_pandas_future_if_enabled
+
+configure_pandas_future_if_enabled()
+
+import deeplabcut.utils.auxiliaryfunctions as af  # noqa: E402
+from deeplabcut.compat import Engine  # noqa: E402
 
 
 def main(

--- a/examples/testscript_tensorflow_multi_animal.py
+++ b/examples/testscript_tensorflow_multi_animal.py
@@ -19,10 +19,15 @@ import pandas as pd
 
 matplotlib.use("Agg")  # Non-interactive backend, for CI/CD on Windows
 
-import deeplabcut
-from deeplabcut.core.engine import Engine
-from deeplabcut.utils import auxfun_multianimal, auxiliaryfunctions
-from deeplabcut.utils.auxfun_videos import VideoReader
+# Enable pandas future mode warnings if DLC_PANDAS_FUTURE env var is set
+from deeplabcut.utils.pandas_future_mode import configure_pandas_future_if_enabled
+
+configure_pandas_future_if_enabled()
+
+import deeplabcut  # noqa: E402
+from deeplabcut.core.engine import Engine  # noqa: E402
+from deeplabcut.utils import auxfun_multianimal, auxiliaryfunctions  # noqa: E402
+from deeplabcut.utils.auxfun_videos import VideoReader  # noqa: E402
 
 MODELS = ["dlcrnet_ms5", "dlcr101_ms5", "efficientnet-b0"]
 

--- a/examples/testscript_tensorflow_single_animal.py
+++ b/examples/testscript_tensorflow_single_animal.py
@@ -32,9 +32,14 @@ import numpy as np
 import pandas as pd
 import scipy.io as sio
 
-import deeplabcut
-from deeplabcut.core.engine import Engine
-from deeplabcut.utils import auxiliaryfunctions
+# Enable pandas future mode warnings if DLC_PANDAS_FUTURE env var is set
+from deeplabcut.utils.pandas_future_mode import configure_pandas_future_if_enabled
+
+configure_pandas_future_if_enabled()
+
+import deeplabcut  # noqa: E402
+from deeplabcut.core.engine import Engine  # noqa: E402
+from deeplabcut.utils import auxiliaryfunctions  # noqa: E402
 
 matplotlib.use("Agg")  # Non-interactive backend, for CI/CD on Windows
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
   "numba>=0.54",
   "numpy>=1.18.5,<2",
   "packaging>=26",
+  # Migration to pandas 3.0 is tracked in https://github.com/DeepLabCut/DeepLabCut/issues/3362.
   "pandas[hdf5,performance]>=2.2,<3",
   "pillow>=7.1",
   "pycocotools",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,12 @@ import pytest
 from PIL import Image
 from tqdm import tqdm
 
-from deeplabcut.core import inferenceutils
+# Enable pandas future mode warnings if DLC_PANDAS_FUTURE env var is set
+from deeplabcut.utils.pandas_future_mode import configure_pandas_future_if_enabled
+
+configure_pandas_future_if_enabled()
+
+from deeplabcut.core import inferenceutils  # noqa: E402
 
 TESTS_DIR = os.path.dirname(os.path.realpath(__file__))
 TEST_DATA_DIR = os.path.join(TESTS_DIR, "data")


### PR DESCRIPTION
Pandas released version 3.0 in Jan 2026 which introduces breaking changes for our codebase. It would be useful to address the places where it currently breaks, so we can remove the upperbound version we introduced in https://github.com/DeepLabCut/DeepLabCut/pull/3186. See the full tracking issue #3362, for an overview of related PRs. 

**Small fixes and flagged patterns:**
As exploratory preparation, this PR implements small fixes in preparation to 3.0 migration. Also it flags breaking instances based on a targeted search for these patterns:  
- Chained `.loc` assignment (copy on write; CoW) -> mutate parent object directly instead of a subset view
- groupby(..., axis=1) -> groupby on the transposed df
- Column-level groupby(level=...) -> groupby on the transposed df
- `select_dtypes(include="object")` -> string type migration
- deprecated options like `future.no_silent_downcasting`


**Future mode testing:**
Also this PR adds a new tool for CI or local testing, using the pandas 2.3 _future_ options that warns for CoW patterns and detects where `str` type should be included instead of only `object`.



