### PR TITLE
[dev] Refactor config constructors via `build()` methods

### DIFF
--- a/deeplabcut/core/config/project_config.py
+++ b/deeplabcut/core/config/project_config.py
@@ -189,6 +189,13 @@ class ProjectConfig(DLCVersionedConfig):
     )
     croppedtraining: bool | None = None
 
+    @property
+    def bodyparts_list(self) -> list[str]:
+        # Animal-count agnostic; Always return a list (never "MULTI!", None, etc.)
+        if self.multianimalproject:
+            return list(self.multianimalbodyparts)
+        return list(self.bodyparts)
+
     def _post_yaml_load_updates(self, *, yaml_path: Path) -> None:
         """
         Override method for post-yaml load updates. Called automatically by from_yaml().

--- a/deeplabcut/core/config/project_config.py
+++ b/deeplabcut/core/config/project_config.py
@@ -194,6 +194,8 @@ class ProjectConfig(DLCVersionedConfig):
         # Animal-count agnostic; Always return a list (never "MULTI!", None, etc.)
         if self.multianimalproject:
             return list(self.multianimalbodyparts)
+        if self.bodyparts == "MULTI!":
+            raise ValueError("bodyparts must be a list of strings when multianimalproject is False, got 'MULTI!'")
         return list(self.bodyparts)
 
     def _post_yaml_load_updates(self, *, yaml_path: Path) -> None:

--- a/deeplabcut/core/config/versioning.py
+++ b/deeplabcut/core/config/versioning.py
@@ -239,38 +239,26 @@ def migrate_config(
 @register_migration(0, 1, config_type="ProjectConfig")
 def migrate_project_v0_to_v1(config: dict) -> dict:
     """Migrate ProjectConfig from unversioned/legacy (v0) to v1."""
-    # TODO @deruyter92 2026-01-30: Migration logic goes here.
-    # e.g. renaming uniquebodyparts -> unique_bodyparts, with_identity -> identity
+    # Migration logic goes here, when migrating to v1.
     return config
 
 
 @register_migration(1, 0, config_type="ProjectConfig")
 def migrate_project_v1_to_v0(config: dict) -> dict:
     """Migrate ProjectConfig from v1 back to v0 (legacy format)."""
-    # TODO @deruyter92 2026-01-30: Migration logic goes here.
+    # Migration logic goes here, when migrating to v1.
     return config
 
 
 @register_migration(0, 1, config_type="PoseConfig")
 def migrate_pose_v0_to_v1(config: dict) -> dict:
     """Migrate PoseConfig from v0 to v1."""
-    # TODO: Migration logic goes here.
+    # Migration logic goes here, when migrating to v1.
     return config
 
 
 @register_migration(1, 0, config_type="PoseConfig")
 def migrate_pose_v1_to_v0(config: dict) -> dict:
     """Migrate PoseConfig from v1 back to v0."""
-    # TODO: Migration logic goes here.
+    # Migration logic goes here, when migrating to v1.
     return config
-
-
-# ============================================================================
-# Future migrations — add per-config-type pairs following the pattern above:
-# ============================================================================
-#
-# @register_migration(1, 2, config_type="ProjectConfig")
-# def migrate_project_v1_to_v2(config: dict) -> dict:
-#     """Migrate ProjectConfig from v1 to v2."""
-#     # The wrapper passes a copy, so mutate directly.
-#     return config

--- a/deeplabcut/create_project/modelzoo.py
+++ b/deeplabcut/create_project/modelzoo.py
@@ -35,9 +35,10 @@ from deeplabcut.generate_training_dataset.trainingsetmanipulation import (
 )
 from deeplabcut.modelzoo.utils import get_super_animal_project_cfg
 from deeplabcut.pose_estimation_pytorch.config.make_pose_config import (
-    add_metadata,
+    # add_metadata,
     make_pytorch_test_config,
 )
+from deeplabcut.pose_estimation_pytorch.config.metadata import PoseMetadata
 from deeplabcut.pose_estimation_pytorch.modelzoo.utils import load_super_animal_config
 from deeplabcut.utils import auxiliaryfunctions
 from deeplabcut.utils.deprecation import renamed_parameter
@@ -442,7 +443,7 @@ def create_pretrained_project_pytorch(
         model_name=net_name,
         detector_name=detector_name,
     )
-    pytorch_config = add_metadata(config, pytorch_config, train_cfg_path)
+    pytorch_config["metadata"] = PoseMetadata.build(config, train_cfg_path).to_dict()
     pytorch_config["resume_training_from"] = str(train_dir / new_snapshot_name)
     pytorch_config["detector"]["resume_training_from"] = str(train_dir / new_detector_name)
     write_config(train_cfg_path, pytorch_config)

--- a/deeplabcut/create_project/modelzoo.py
+++ b/deeplabcut/create_project/modelzoo.py
@@ -443,7 +443,7 @@ def create_pretrained_project_pytorch(
         model_name=net_name,
         detector_name=detector_name,
     )
-    pytorch_config["metadata"] = PoseMetadata.build(config, train_cfg_path).to_dict()
+    pytorch_config["metadata"] = PoseMetadata.build(config, pose_config_path=train_cfg_path).to_dict()
     pytorch_config["resume_training_from"] = str(train_dir / new_snapshot_name)
     pytorch_config["detector"]["resume_training_from"] = str(train_dir / new_detector_name)
     write_config(train_cfg_path, pytorch_config)

--- a/deeplabcut/modelzoo/video_inference.py
+++ b/deeplabcut/modelzoo/video_inference.py
@@ -20,14 +20,12 @@ from pathlib import Path
 import torch
 from dlclibrary.dlcmodelzoo.modelzoo_download import download_huggingface_model
 
-from deeplabcut.core.config import read_config_as_dict, write_config
 from deeplabcut.modelzoo.utils import get_super_animal_scorer
+from deeplabcut.pose_estimation_pytorch.config import PoseConfig
 from deeplabcut.pose_estimation_pytorch.modelzoo.train_from_coco import adaptation_train
 from deeplabcut.pose_estimation_pytorch.modelzoo.utils import (
     get_snapshot_folder_path,
     get_super_animal_snapshot_path,
-    load_super_animal_config,
-    update_config,
 )
 from deeplabcut.utils.auxiliaryfunctions import get_deeplabcut_path
 from deeplabcut.utils.deprecation import renamed_parameter
@@ -417,12 +415,14 @@ def video_inference_superanimal(
         )
 
         if customized_model_config is not None:
-            config = read_config_as_dict(customized_model_config)
+            config = PoseConfig.from_any(customized_model_config)
         else:
-            config = load_super_animal_config(
+            config = PoseConfig.build_for_superanimal_inference(
                 super_animal=superanimal_name,
                 model_name=model_name,
                 detector_name=(detector_name if superanimal_name != "superanimal_humanbody" else None),
+                max_individuals=max_individuals,
+                device=device,
             )
 
         pose_model_path = customized_pose_checkpoint
@@ -442,10 +442,6 @@ def video_inference_superanimal(
         dlc_scorer = get_super_animal_scorer(
             superanimal_name, pose_model_path, detector_path, torchvision_detector_name
         )
-
-        # TODO @deruyter92: This is currently not validated against the PoseConfig schema.
-        # We should create the validated config (with override arguments) in an early stage.
-        config = update_config(config, max_individuals, device)
 
         output_suffix = "_before_adapt"
 
@@ -529,7 +525,7 @@ def video_inference_superanimal(
 
             # the model config's parameters need to be updated for adaptation training
             model_config_path = model_folder / "pytorch_config.yaml"
-            write_config(model_config_path, config)
+            config.to_yaml(model_config_path, overwrite=True)
 
             # get the current epoch of the pose model
             current_pose_epoch = get_checkpoint_epoch(pose_model_path)

--- a/deeplabcut/modelzoo/webapp/inference.py
+++ b/deeplabcut/modelzoo/webapp/inference.py
@@ -13,7 +13,6 @@ import numpy as np
 
 import deeplabcut.pose_estimation_pytorch.modelzoo as modelzoo
 from deeplabcut.pose_estimation_pytorch.apis.utils import get_inference_runners
-from deeplabcut.pose_estimation_pytorch.modelzoo.utils import update_config
 
 
 class SingletonTopDownRunners:
@@ -78,10 +77,9 @@ class SuperanimalPyTorchInference:
             super_animal=project_name,
             model_name=pose_model_type,
             detector_name=detector_model_type,
+            max_individuals=max_individuals,
+            device=device,
         )
-        # TODO @deruyter92: super animal configs are currently not
-        # validated against the pydantic schema. We should add this functionality.
-        config = update_config(config, max_individuals, device)
         self._config = config
 
     def initialize_models(self, pose_model_path: str, detector_model_path: str):

--- a/deeplabcut/pose_estimation_pytorch/apis/analyze_images.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/analyze_images.py
@@ -41,7 +41,6 @@ from deeplabcut.pose_estimation_pytorch.config.pose import PoseConfig
 from deeplabcut.pose_estimation_pytorch.data.ctd import CondFromModel
 from deeplabcut.pose_estimation_pytorch.modelzoo.utils import (
     COCO_PERSON_CATEGORY_ID,
-    update_config,
 )
 from deeplabcut.pose_estimation_pytorch.task import Task
 from deeplabcut.pose_estimation_pytorch.utils import resolve_device
@@ -188,13 +187,12 @@ def superanimal_analyze_images(
             super_animal=superanimal_name,
             model_name=model_name,
             detector_name=(detector_name if superanimal_name != "superanimal_humanbody" else None),
+            max_individuals=max_individuals,
+            device=device,
         )
     else:
         config = PoseConfig.from_any(customized_model_config)
 
-    # TODO @deruyter92: This is currently not validated against the pydantic schema.
-    # We should add this functionality (and do updates in an early stage).
-    config = update_config(config, max_individuals, device)
     config["metadata"]["individuals"] = [f"animal{i}" for i in range(max_individuals)]
     if config.get("detector") is not None:
         config["detector"]["model"]["box_score_thresh"] = bbox_threshold

--- a/deeplabcut/pose_estimation_pytorch/config/__init__.py
+++ b/deeplabcut/pose_estimation_pytorch/config/__init__.py
@@ -22,6 +22,12 @@ from deeplabcut.pose_estimation_pytorch.config.data import (
     DLCLoaderConfig,
     GenSamplingConfig,
 )
+from deeplabcut.pose_estimation_pytorch.config.enums import (
+    DatasetType,
+    DetectorType,
+    MethodType,
+    NetType,
+)
 from deeplabcut.pose_estimation_pytorch.config.inference import (
     AutocastConfig,
     CompileConfig,
@@ -36,27 +42,25 @@ from deeplabcut.pose_estimation_pytorch.config.logger import (
     WandbLoggerConfig,
 )
 from deeplabcut.pose_estimation_pytorch.config.make_pose_config import (
-    add_detector,
-    add_identity_head,
-    add_metadata,
-    add_unique_bodypart_head,
-    create_backbone_with_heatmap_model,
-    create_backbone_with_paf_model,
+    # add_detector,
+    # add_identity_head,
+    # add_metadata,
+    # add_unique_bodypart_head,
+    # create_backbone_with_heatmap_model,
+    # create_backbone_with_paf_model,
     make_basic_project_config,
     make_pytorch_pose_config,
     make_pytorch_test_config,
 )
+from deeplabcut.pose_estimation_pytorch.config.metadata import PoseMetadata
 from deeplabcut.pose_estimation_pytorch.config.model import (
     DetectorModelConfig,
     ModelConfig,
 )
+from deeplabcut.pose_estimation_pytorch.config.paf_parameters import PAFParameters
 from deeplabcut.pose_estimation_pytorch.config.pose import (
-    DatasetType,
     DetectorConfig,
-    MethodType,
-    NetType,
     PoseConfig,
-    PoseMetadata,
     TestConfig,
 )
 from deeplabcut.pose_estimation_pytorch.config.runner import (
@@ -86,15 +90,15 @@ __all__ = [
     "read_config_as_dict",
     "write_config",
     # Config creation API
-    "add_detector",
-    "add_identity_head",
-    "add_metadata",
-    "add_unique_bodypart_head",
-    "create_backbone_with_heatmap_model",
-    "create_backbone_with_paf_model",
-    "make_basic_project_config",
-    "make_pytorch_pose_config",
-    "make_pytorch_test_config",
+    # "add_detector",
+    # "add_identity_head",
+    # "add_metadata",
+    # "add_unique_bodypart_head",
+    # "create_backbone_with_heatmap_model",
+    # "create_backbone_with_paf_model",
+    "make_basic_project_config",  # deprecated
+    "make_pytorch_pose_config",  # deprecated
+    "make_pytorch_test_config",  # deprecated
     # Config utilities
     "available_detectors",
     "available_models",
@@ -129,6 +133,7 @@ __all__ = [
     "DetectorModelConfig",
     "ModelConfig",
     # Pose config
+    "DetectorType",
     "DatasetType",
     "DetectorConfig",
     "MethodType",
@@ -143,4 +148,6 @@ __all__ = [
     "SnapshotCheckpointConfig",
     # Training config
     "TrainSettingsConfig",
+    # PAF parameters
+    "PAFParameters",
 ]

--- a/deeplabcut/pose_estimation_pytorch/config/enums.py
+++ b/deeplabcut/pose_estimation_pytorch/config/enums.py
@@ -1,4 +1,12 @@
+from __future__ import annotations
+
+import functools
 from enum import Enum
+
+_LEGACY_NET_TYPE_ALIASES = {
+    "dlcrnet_ms5": "dlcrnet_stride16_ms5",
+}
+_TOP_DOWN_PREFIX = "top_down_"
 
 
 class MethodType(str, Enum):
@@ -10,42 +18,29 @@ class MethodType(str, Enum):
 
 
 class NetType(str, Enum):
-    """Enumeration of network architecture types."""
+    """Enumeration of network architecture types as stored in configs.
 
-    # ResNet variants (bottom-up)
+    Note:
+        Aliases (e.g. ``top_down_resnet_50``) are user-facing names that map to
+        a canonical member plus an optional top-down flag. See ``alias``,
+        ``from_alias``, and ``available_aliases``
+    """
+
     RESNET_50 = "resnet_50"
     RESNET_101 = "resnet_101"
 
-    # ResNet variants (top-down)
-    TOP_DOWN_RESNET_50 = "top_down_resnet_50"
-    TOP_DOWN_RESNET_101 = "top_down_resnet_101"
-
-    # HRNet variants (bottom-up)
     HRNET_W18 = "hrnet_w18"
     HRNET_W32 = "hrnet_w32"
     HRNET_W48 = "hrnet_w48"
 
-    # HRNet variants (top-down)
-    TOP_DOWN_HRNET_W18 = "top_down_hrnet_w18"
-    TOP_DOWN_HRNET_W32 = "top_down_hrnet_w32"
-    TOP_DOWN_HRNET_W48 = "top_down_hrnet_w48"
-
-    # CSPNeXt variants (bottom-up)
     CSPNEXT_S = "cspnext_s"
     CSPNEXT_M = "cspnext_m"
     CSPNEXT_X = "cspnext_x"
 
-    # CSPNeXt variants (top-down)
-    TOP_DOWN_CSPNEXT_S = "top_down_cspnext_s"
-    TOP_DOWN_CSPNEXT_M = "top_down_cspnext_m"
-    TOP_DOWN_CSPNEXT_X = "top_down_cspnext_x"
-
-    # DEKR variants (bottom-up with HRNet backbone)
     DEKR_W18 = "dekr_w18"
     DEKR_W32 = "dekr_w32"
     DEKR_W48 = "dekr_w48"
 
-    # BUCTD variants (Conditional Top-Down)
     CTD_COAM_W32 = "ctd_coam_w32"
     CTD_COAM_W48 = "ctd_coam_w48"
     CTD_COAM_W48_HUMAN = "ctd_coam_w48_human"
@@ -56,17 +51,49 @@ class NetType(str, Enum):
     CTD_PRENET_RTMPOSE_X = "ctd_prenet_rtmpose_x"
     CTD_PRENET_RTMPOSE_X_HUMAN = "ctd_prenet_rtmpose_x_human"
 
-    # DLCRNet variants
     DLCRNET_STRIDE16_MS5 = "dlcrnet_stride16_ms5"
     DLCRNET_STRIDE32_MS5 = "dlcrnet_stride32_ms5"
 
-    # RTMPose variants (top-down)
     RTMPOSE_S = "rtmpose_s"
     RTMPOSE_M = "rtmpose_m"
     RTMPOSE_X = "rtmpose_x"
 
-    # AnimalTokenPose variant (inference only)
     ANIMALTOKENPOSE_BASE = "animaltokenpose_base"
+
+    @functools.cached_property
+    def is_backbone(self) -> bool:
+        from deeplabcut.pose_estimation_pytorch.config.utils import (
+            get_config_folder_path,
+            load_backbones,
+        )
+
+        return self.value in frozenset(load_backbones(get_config_folder_path()))
+
+    def alias(self, *, top_down: bool = False) -> str:
+        """User-facing name (e.g. ``top_down_resnet_50`` for backbone + TD)."""
+        if top_down and self.is_backbone:
+            return f"{_TOP_DOWN_PREFIX}{self.value}"
+        return self.value
+
+    @classmethod
+    def from_alias(cls, label: str) -> tuple[NetType, bool]:
+        """Parse user-facing / legacy name → (canonical enum, top_down)."""
+        label = _LEGACY_NET_TYPE_ALIASES.get(label, label)
+        label_has_td_prefix = False
+        if label.startswith(_TOP_DOWN_PREFIX):
+            label = label.removeprefix(_TOP_DOWN_PREFIX)
+            label_has_td_prefix = True
+        return cls(label), label_has_td_prefix
+
+    @classmethod
+    def available_aliases(cls) -> list[str]:
+        """All selectable model names for GUI / docs / ``create_training_dataset``."""
+        labels: list[str] = []
+        for net_type in cls:
+            labels.append(net_type.alias(top_down=False))
+            if net_type.is_backbone:
+                labels.append(net_type.alias(top_down=True))
+        return sorted(labels)
 
 
 class DetectorType(str, Enum):

--- a/deeplabcut/pose_estimation_pytorch/config/enums.py
+++ b/deeplabcut/pose_estimation_pytorch/config/enums.py
@@ -1,0 +1,84 @@
+from enum import Enum
+
+
+class MethodType(str, Enum):
+    """Enumeration of pose estimation method types."""
+
+    BOTTOM_UP = "bu"
+    TOP_DOWN = "td"
+    CONDITIONAL_TOP_DOWN = "ctd"
+
+
+class NetType(str, Enum):
+    """Enumeration of network architecture types."""
+
+    # ResNet variants (bottom-up)
+    RESNET_50 = "resnet_50"
+    RESNET_101 = "resnet_101"
+
+    # ResNet variants (top-down)
+    TOP_DOWN_RESNET_50 = "top_down_resnet_50"
+    TOP_DOWN_RESNET_101 = "top_down_resnet_101"
+
+    # HRNet variants (bottom-up)
+    HRNET_W18 = "hrnet_w18"
+    HRNET_W32 = "hrnet_w32"
+    HRNET_W48 = "hrnet_w48"
+
+    # HRNet variants (top-down)
+    TOP_DOWN_HRNET_W18 = "top_down_hrnet_w18"
+    TOP_DOWN_HRNET_W32 = "top_down_hrnet_w32"
+    TOP_DOWN_HRNET_W48 = "top_down_hrnet_w48"
+
+    # CSPNeXt variants (bottom-up)
+    CSPNEXT_S = "cspnext_s"
+    CSPNEXT_M = "cspnext_m"
+    CSPNEXT_X = "cspnext_x"
+
+    # CSPNeXt variants (top-down)
+    TOP_DOWN_CSPNEXT_S = "top_down_cspnext_s"
+    TOP_DOWN_CSPNEXT_M = "top_down_cspnext_m"
+    TOP_DOWN_CSPNEXT_X = "top_down_cspnext_x"
+
+    # DEKR variants (bottom-up with HRNet backbone)
+    DEKR_W18 = "dekr_w18"
+    DEKR_W32 = "dekr_w32"
+    DEKR_W48 = "dekr_w48"
+
+    # BUCTD variants (Conditional Top-Down)
+    CTD_COAM_W32 = "ctd_coam_w32"
+    CTD_COAM_W48 = "ctd_coam_w48"
+    CTD_COAM_W48_HUMAN = "ctd_coam_w48_human"
+    CTD_PRENET_HRNET_W32 = "ctd_prenet_hrnet_w32"
+    CTD_PRENET_HRNET_W48 = "ctd_prenet_hrnet_w48"
+    CTD_PRENET_RTMPOSE_S = "ctd_prenet_rtmpose_s"
+    CTD_PRENET_RTMPOSE_M = "ctd_prenet_rtmpose_m"
+    CTD_PRENET_RTMPOSE_X = "ctd_prenet_rtmpose_x"
+    CTD_PRENET_RTMPOSE_X_HUMAN = "ctd_prenet_rtmpose_x_human"
+
+    # DLCRNet variants
+    DLCRNET_STRIDE16_MS5 = "dlcrnet_stride16_ms5"
+    DLCRNET_STRIDE32_MS5 = "dlcrnet_stride32_ms5"
+
+    # RTMPose variants (top-down)
+    RTMPOSE_S = "rtmpose_s"
+    RTMPOSE_M = "rtmpose_m"
+    RTMPOSE_X = "rtmpose_x"
+
+    # AnimalTokenPose variant (inference only)
+    ANIMALTOKENPOSE_BASE = "animaltokenpose_base"
+
+
+class DetectorType(str, Enum):
+    """Enumeration of detector types."""
+
+    SSDLITE = "ssdlite"
+    FASTERRCNN_RESNET50_FPN_V2 = "fasterrcnn_resnet50_fpn_v2"
+    FASTERRCNN_MOBILENET_V3_LARGE_FPN = "fasterrcnn_mobilenet_v3_large_fpn"
+
+
+class DatasetType(str, Enum):
+    """Enumeration of dataset types."""
+
+    # TODO @deruyter92 2026-02-05: Add other dataset types as needed.
+    MULTIANIMAL_IMGAUG = "multi-animal-imgaug"

--- a/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
+++ b/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
@@ -306,9 +306,10 @@ def resolve_net_type_and_task(
     if net_type is None:
         try:
             net_type, td_prefix = NetType.from_alias(default)
-        except ValueError:
-            logger.warning(f"Invalid default_net_type in project config: {default} using resnet_50 instead.")
-            net_type, td_prefix = NetType.RESNET_50, False
+        except ValueError as e:
+            raise ValueError(
+                f"Invalid default_net_type in project config: {default}. Must be one of {NetType.available_aliases()}"
+            ) from e
     else:
         net_type, td_prefix = NetType.from_alias(str(net_type))  # fails loudly if invalid
 

--- a/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
+++ b/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
@@ -92,7 +92,7 @@ def make_basic_project_config(
 
 
 def build_pose_config_defaults(
-    net_type: NetType | str,
+    net_type: NetType,
     metadata: PoseMetadata,
     *,
     task: Task,
@@ -168,14 +168,14 @@ def build_pose_config_defaults(
                 top_down=task == Task.TOP_DOWN,
             )
     else:
-        architecture = net_type.split("_")[0]
+        architecture = net_type.value.split("_")[0]
         default_value_kwargs = {}
         if architecture == "dlcrnet":
             if paf_parameters is None:
                 raise ValueError("PAF parameters are required for DLCRNet models.")
             default_value_kwargs.update(paf_parameters.to_dict())
 
-        cfg_path = configs_dir / architecture / f"{net_type}.yaml"
+        cfg_path = configs_dir / architecture / f"{net_type.value}.yaml"
         model_cfg = read_config_as_dict(cfg_path)
         model_cfg = replace_default_values(
             model_cfg,
@@ -183,7 +183,7 @@ def build_pose_config_defaults(
             num_individuals=metadata.num_individuals,
             **default_value_kwargs,
         )
-    model_cfg["net_type"] = net_type
+    model_cfg["net_type"] = net_type.value
 
     if task == Task.TOP_DOWN:
         if detector_config is None:
@@ -201,7 +201,7 @@ def build_pose_config_defaults(
     if metadata.unique_bodyparts:
         if task != Task.BOTTOM_UP:
             raise ValueError(
-                f"You selected a top-down model architecture ({net_type}), but you have"
+                f"You selected a top-down model architecture ({net_type.value}), but you have"
                 f" unique bodyparts, which is not yet implemented for top-down models."
                 " Please select a bottom-up architecture such as `resnet_50` for single"
                 " animal projects or `dlcrnet_50` for multi-animal projects."
@@ -218,7 +218,7 @@ def build_pose_config_defaults(
     if metadata.with_identity:
         if task != Task.BOTTOM_UP:
             raise ValueError(
-                f"You selected a top-down model architecture ({net_type}), but you have"
+                f"You selected a top-down model architecture ({net_type.value}), but you have"
                 f" set `identity: true`, which is not yet implemented for top-down"
                 f" models. Please select a bottom-up architecture such as `dlcrnet_50`"
                 f" to train with identity, or set `identity: false`."
@@ -262,7 +262,7 @@ def build_detector_config_defaults(
     configs_dir = get_config_folder_path()
     detector_config = update_config(
         read_config_as_dict(configs_dir / "base" / "base_detector.yaml"),
-        read_config_as_dict(configs_dir / "detectors" / f"{detector_type}.yaml"),
+        read_config_as_dict(configs_dir / "detectors" / f"{detector_type.value}.yaml"),
     )
     detector_config = replace_default_values(
         detector_config,
@@ -274,13 +274,13 @@ def build_detector_config_defaults(
 # TODO @deruyter92 2026-06-12: currently, the responsibility for determining the task
 # is controlled either in the default config (for "non-backbone" models) or by the
 # API parameter `top_down` (for "backbone" models). This should be refactored.
-def _resolve_task(net_type: str, *, top_down: bool) -> Task:
+def _resolve_task(net_type: NetType, *, top_down: bool) -> Task:
     configs_dir = get_config_folder_path()
     backbones = load_backbones(configs_dir)
     if net_type in backbones:
         return Task.TOP_DOWN if top_down else Task.BOTTOM_UP
-    architecture = net_type.split("_")[0]
-    cfg_path = configs_dir / architecture / f"{net_type}.yaml"
+    architecture = net_type.value.split("_")[0]
+    cfg_path = configs_dir / architecture / f"{net_type.value}.yaml"
     model_cfg = read_config_as_dict(cfg_path)
     return Task(model_cfg.get("method", "BU").upper())
 
@@ -375,7 +375,7 @@ def _add_ctd_conditions(model_cfg: dict, ctd_conditions: int | str | Path | tupl
 
 def _create_backbone_with_heatmap_model(
     configs_dir: Path,
-    net_type: str,
+    net_type: NetType,
     multianimal_project: bool,
     bodyparts: list[str],
     top_down: bool,
@@ -404,11 +404,11 @@ def _create_backbone_with_heatmap_model(
             "A pose model formed of a backbone and simple heatmap + location refinement"
             " head can only be used for single animal projects. As you're working with"
             " a multi-animal project, please select a multi-individual model instead of"
-            f" {net_type} or use a detector to create a top-down model."
+            f" {net_type.value} or use a detector to create a top-down model."
         )
 
     # add the backbone to the config
-    model_config = read_config_as_dict(configs_dir / "backbones" / f"{net_type}.yaml")
+    model_config = read_config_as_dict(configs_dir / "backbones" / f"{net_type.value}.yaml")
     backbone_output_channels = model_config["model"]["backbone_output_channels"]
 
     model_config["method"] = "bu"
@@ -431,7 +431,7 @@ def _create_backbone_with_heatmap_model(
 
 def _create_backbone_with_paf_model(
     configs_dir: Path,
-    net_type: str,
+    net_type: NetType,
     num_individuals: int,
     bodyparts: list[str],
     paf_parameters: dict,
@@ -451,7 +451,7 @@ def _create_backbone_with_paf_model(
         the backbone + heatmap, location refinement, PAF model configuration
     """
     # add the backbone to the config
-    model_config = read_config_as_dict(configs_dir / "backbones" / f"{net_type}.yaml")
+    model_config = read_config_as_dict(configs_dir / "backbones" / f"{net_type.value}.yaml")
     backbone_output_channels = model_config["model"]["backbone_output_channels"]
 
     # add a bodypart head

--- a/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
+++ b/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
@@ -13,6 +13,7 @@
 from __future__ import annotations
 
 import copy
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -35,6 +36,8 @@ from deeplabcut.utils.deprecation import deprecated
 
 if TYPE_CHECKING:
     from deeplabcut.pose_estimation_pytorch.config import DetectorConfig, PoseConfig, TestConfig
+
+logger = logging.getLogger(__name__)
 
 
 @deprecated(replacement="pose_estimation_pytorch.config.TestConfig.build", since="3.1")
@@ -257,8 +260,6 @@ def build_detector_config_defaults(
         the model configuration with an added detector config
     """
     configs_dir = get_config_folder_path()
-
-    detector_type = detector_type.lower()
     detector_config = update_config(
         read_config_as_dict(configs_dir / "base" / "base_detector.yaml"),
         read_config_as_dict(configs_dir / "detectors" / f"{detector_type}.yaml"),
@@ -273,7 +274,7 @@ def build_detector_config_defaults(
 # TODO @deruyter92 2026-06-12: currently, the responsibility for determining the task
 # is controlled either in the default config (for "non-backbone" models) or by the
 # API parameter `top_down` (for "backbone" models). This should be refactored.
-def resolve_task(net_type: str, *, top_down: bool) -> Task:
+def _resolve_task(net_type: str, *, top_down: bool) -> Task:
     configs_dir = get_config_folder_path()
     backbones = load_backbones(configs_dir)
     if net_type in backbones:
@@ -282,6 +283,48 @@ def resolve_task(net_type: str, *, top_down: bool) -> Task:
     cfg_path = configs_dir / architecture / f"{net_type}.yaml"
     model_cfg = read_config_as_dict(cfg_path)
     return Task(model_cfg.get("method", "BU").upper())
+
+
+def resolve_net_type_and_task(
+    net_type: str | NetType | None,
+    *,
+    default: str,
+    top_down: bool,
+) -> tuple[NetType, Task]:
+    """Resolve the net type from build args and project config default.
+
+    Args:
+        net_type (str | None): Architecture name, or None to use ``default``
+            from project config.
+        default (str): Fallback when ``net_type`` is None. Invalid values warn
+            and fall back to ``resnet_50``.
+        top_down (bool): Build a top-down backbone (ignored for non-backbones).
+
+    Returns:
+        (NetType, Task): the resolved canonical NetType and Task
+    """
+    if net_type is None:
+        try:
+            net_type, td_prefix = NetType.from_alias(default)
+        except ValueError:
+            logger.warning(f"Invalid default_net_type in project config: {default} using resnet_50 instead.")
+            net_type, td_prefix = NetType.RESNET_50, False
+    else:
+        net_type, td_prefix = NetType.from_alias(str(net_type))  # fails loudly if invalid
+
+    if td_prefix:
+        if top_down:
+            logger.warning(
+                "Passed net_type with top_down prefix. Instead use "
+                "PoseConfig.build(..., top_down=True) to specify the task."
+            )
+        else:
+            raise ValueError(
+                "Passed net_type with top_down prefix. but top_down is False."
+                "Please use only PoseConfig.build(..., top_down=True/False) to specify the task."
+            )
+    task = _resolve_task(net_type, top_down=top_down)
+    return net_type, task
 
 
 def _add_ctd_conditions(model_cfg: dict, ctd_conditions: int | str | Path | tuple[int, str] | tuple[int, int]):

--- a/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
+++ b/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
@@ -14,14 +14,15 @@ from __future__ import annotations
 
 import copy
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from deeplabcut.core.config import read_config_as_dict
 from deeplabcut.core.config.project_config import ProjectConfig
-from deeplabcut.core.config.utils import ensure_plain_config
 from deeplabcut.core.weight_init import WeightInitialization
+from deeplabcut.pose_estimation_pytorch.config.enums import DetectorType, NetType
 from deeplabcut.pose_estimation_pytorch.config.inference import InferenceConfig
-from deeplabcut.pose_estimation_pytorch.config.pose import NetType, PoseConfig, PoseMetadata, TestConfig
-from deeplabcut.pose_estimation_pytorch.config.training import TrainSettingsConfig
+from deeplabcut.pose_estimation_pytorch.config.metadata import PoseMetadata
+from deeplabcut.pose_estimation_pytorch.config.paf_parameters import PAFParameters
 from deeplabcut.pose_estimation_pytorch.config.utils import (
     get_config_folder_path,
     load_backbones,
@@ -30,15 +31,72 @@ from deeplabcut.pose_estimation_pytorch.config.utils import (
     update_config,
 )
 from deeplabcut.pose_estimation_pytorch.task import Task
-from deeplabcut.utils import auxfun_multianimal, auxiliaryfunctions
+from deeplabcut.utils.deprecation import deprecated
+
+if TYPE_CHECKING:
+    from deeplabcut.pose_estimation_pytorch.config import DetectorConfig, PoseConfig, TestConfig
 
 
-@ensure_plain_config
-def _load_pose_config_defaults(
-    project_config: ProjectConfig | dict,
+@deprecated(replacement="pose_estimation_pytorch.config.TestConfig.build", since="3.1")
+def make_pytorch_test_config(
+    model_config: PoseConfig | dict | str | Path,
+    test_config_path: str | Path,
+    save: bool = False,
+) -> TestConfig:
+    from deeplabcut.pose_estimation_pytorch.config import TestConfig
+
+    return TestConfig.build(model_config, test_config_path=test_config_path, save=save)
+
+
+@deprecated(replacement="pose_estimation_pytorch.config.PoseConfig.build", since="3.1")
+def make_pytorch_pose_config(
+    project_config: ProjectConfig | dict | Path | str,
+    pose_config_path: str | Path,
     net_type: NetType | str | None = None,
     top_down: bool = False,
     detector_type: str | None = None,
+    weight_init: WeightInitialization | None = None,
+    save: bool = False,
+    ctd_conditions: int | str | Path | tuple[int, str] | tuple[int, int] | None = None,
+) -> PoseConfig:
+    from deeplabcut.pose_estimation_pytorch.config import PoseConfig
+
+    return PoseConfig.build(
+        project_config,
+        pose_config_path,
+        net_type=net_type,
+        top_down=top_down,
+        detector_type=detector_type,
+        weight_init=weight_init,
+        save=save,
+        ctd_conditions=ctd_conditions,
+    )
+
+
+@deprecated(replacement="pose_estimation_pytorch.config.PoseMetadata", since="3.1")
+def make_basic_project_config(
+    dataset_path: Path | str,
+    bodyparts: list[str],
+    max_individuals: int,
+    multi_animal: bool = True,
+) -> dict:
+    """Deprecated factory for basic config dict for non-DLC projects."""
+    return PoseMetadata(
+        project_path=dataset_path,
+        bodyparts=bodyparts,
+        individuals=[f"individual{i:03d}" for i in range(max_individuals)],
+    ).to_dict_legacy()
+
+
+def build_pose_config_defaults(
+    net_type: NetType | str,
+    metadata: PoseMetadata,
+    *,
+    task: Task,
+    multi_animal: bool,
+    paf_parameters: PAFParameters | None = None,
+    weight_init: WeightInitialization | None = None,
+    detector_config: DetectorConfig | None = None,
     ctd_conditions: int | str | Path | tuple[int, str] | tuple[int, int] | None = None,
 ) -> dict:
     """
@@ -63,7 +121,7 @@ def _load_pose_config_defaults(
     Args:
         project_config: the DeepLabCut project config (used to infer individuals, bodyparts and identity tracking)
         net_type: the architecture of the desired pose estimation model
-        top_down: when the net_type is a backbone, whether to create a top-down model
+        task: when the net_type is a backbone, whether to create a top-down model
             by associating a detector to the pose model. Required for multi-animal
             projects when net_type is a backbone (as a backbone + heatmap head can only
             predict pose for single individuals).
@@ -83,60 +141,45 @@ def _load_pose_config_defaults(
     Returns:
         The model configuration defaults as a dictionary.
     """
-    # TODO JR 2026-01-27: Model configs are currently still first loaded as plain dictionaries.
-    # We probably want to move to using typed config classes in the future.
-    multianimal_project = project_config.get("multianimalproject", False)
-    individuals = project_config.get("individuals", ["single"])
-    with_identity = project_config.get("identity")
-    bodyparts = auxiliaryfunctions.get_bodyparts(project_config)
-    unique_bpts = auxiliaryfunctions.get_unique_bodyparts(project_config)
-
-    if net_type is None:
-        net_type = project_config.get("default_net_type", "resnet_50")
-
     configs_dir = get_config_folder_path()
     base_cfg = load_base_config(configs_dir)
     backbones = load_backbones(configs_dir)
+
     if net_type in backbones:
-        if not top_down and multianimal_project:
-            model_cfg = create_backbone_with_paf_model(
+        if task == Task.BOTTOM_UP and multi_animal:
+            model_cfg = _create_backbone_with_paf_model(
                 configs_dir=configs_dir,
                 net_type=net_type,
-                num_individuals=len(individuals),
-                bodyparts=bodyparts,
-                paf_parameters=_get_paf_parameters(project_config, bodyparts),
+                num_individuals=metadata.num_individuals,
+                bodyparts=metadata.bodyparts,
+                paf_parameters=paf_parameters,
             )
         else:
-            model_cfg = create_backbone_with_heatmap_model(
+            model_cfg = _create_backbone_with_heatmap_model(
                 configs_dir=configs_dir,
                 net_type=net_type,
-                multianimal_project=multianimal_project,
-                bodyparts=bodyparts,
-                top_down=top_down,
+                multianimal_project=multi_animal,
+                bodyparts=metadata.bodyparts,
+                top_down=task == Task.TOP_DOWN,
             )
     else:
         architecture = net_type.split("_")[0]
         default_value_kwargs = {}
         if architecture == "dlcrnet":
-            default_value_kwargs.update(_get_paf_parameters(project_config, bodyparts))
+            default_value_kwargs.update(paf_parameters)
 
         cfg_path = configs_dir / architecture / f"{net_type}.yaml"
         model_cfg = read_config_as_dict(cfg_path)
         model_cfg = replace_default_values(
             model_cfg,
-            num_bodyparts=len(bodyparts),
-            num_individuals=len(individuals),
+            num_bodyparts=metadata.num_bodyparts,
+            num_individuals=metadata.num_individuals,
             **default_value_kwargs,
         )
+    model_cfg["net_type"] = net_type
 
-    task = Task(model_cfg.get("method", "BU").upper())
     if task == Task.TOP_DOWN:
-        model_cfg = add_detector(
-            configs_dir,
-            model_cfg,
-            len(individuals),
-            detector_type=detector_type,
-        )
+        model_cfg["detector"] = detector_config.to_dict()
 
     # add the default augmentations to the config
     aug_filename = "aug_default.yaml" if task == Task.BOTTOM_UP else "aug_top_down.yaml"
@@ -146,7 +189,7 @@ def _load_pose_config_defaults(
     model_cfg = update_config(base_cfg, model_cfg)
 
     # add a unique bodypart head if needed
-    if len(unique_bpts) > 0:
+    if metadata.unique_bodyparts:
         if task != Task.BOTTOM_UP:
             raise ValueError(
                 f"You selected a top-down model architecture ({net_type}), but you have"
@@ -155,15 +198,15 @@ def _load_pose_config_defaults(
                 " animal projects or `dlcrnet_50` for multi-animal projects."
             )
 
-        model_cfg = add_unique_bodypart_head(
+        model_cfg = _add_unique_bodypart_head(
             configs_dir,
             model_cfg,
-            num_unique_bodyparts=len(unique_bpts),
+            num_unique_bodyparts=metadata.num_unique_bodyparts,
             backbone_output_channels=model_cfg["model"]["backbone_output_channels"],
         )
 
     # add an identity head if needed
-    if with_identity:
+    if metadata.with_identity:
         if task != Task.BOTTOM_UP:
             raise ValueError(
                 f"You selected a top-down model architecture ({net_type}), but you have"
@@ -172,94 +215,69 @@ def _load_pose_config_defaults(
                 f" to train with identity, or set `identity: false`."
             )
 
-        model_cfg = add_identity_head(
+        model_cfg = _add_identity_head(
             configs_dir,
             model_cfg,
-            num_individuals=len(individuals),
+            num_individuals=metadata.num_individuals,
             backbone_output_channels=model_cfg["model"]["backbone_output_channels"],
         )
 
     model_cfg["inference"] = InferenceConfig().to_dict()
     # Add conditions for CTD models if specified
-    if task == Task.COND_TOP_DOWN and ctd_conditions is not None:
+    if task == Task.COND_TOP_DOWN:
+        if ctd_conditions is None:
+            raise ValueError("A CTD conditions is required for conditional-top-down models.")
         _add_ctd_conditions(model_cfg, ctd_conditions)
+
+    # Add metadata and weight init to the model config
+    model_cfg["metadata"] = metadata.to_dict()
+    if weight_init is not None:
+        model_cfg["train_settings"]["weight_init"] = weight_init
     return model_cfg
 
 
-def make_pytorch_pose_config(
-    project_config: ProjectConfig | dict | Path | str,
-    pose_config_path: str | Path,
-    net_type: NetType | str | None = None,
-    top_down: bool = False,
-    detector_type: str | None = None,
-    weight_init: WeightInitialization | None = None,
-    save: bool = False,
-    ctd_conditions: int | str | Path | tuple[int, str] | tuple[int, int] | None = None,
-) -> PoseConfig:
-    """Creates a PyTorch pose configuration file for a DeepLabCut project
+def build_detector_config_defaults(
+    num_individuals: int,
+    detector_type: DetectorType,
+) -> dict:
+    """Adds a detector to a model.
 
     Args:
-        project_config: the DeepLabCut project config (used to infer individuals, bodyparts and identity tracking)
-        pose_config_path: the path where the pose config should be saved
-        net_type: the architecture of the desired pose estimation model
-        top_down: when the net_type is a backbone, whether to create a top-down model
-            by associating a detector to the pose model. Required for multi-animal
-            projects when net_type is a backbone (as a backbone + heatmap head can only
-            predict pose for single individuals).
-        detector_type: for top-down pose models, the architecture of the desired object
-            detection model
-        weight_init: Specify how model weights should be initialized. If None, ImageNet
-            pretrained weights from Timm will be loaded when training.
-        save: Whether to save the model configuration file to the ``pose_config_path``.
-        ctd_conditions: int | str | Path | tuple[int, str] | tuple[int, int] , optional, default = None,
-            If using a conditional-top-down (CTD) net_type, this argument needs to be specified.
-            It defines the conditions that will be used with the CTD model.
-            It can be either:
-                * A shuffle number (ctd_conditions: int), which must correspond to a
-                  bottom-up (BU) network type.
-                * A predictions file path (ctd_conditions: string | Path), which must
-                  correspond to a .json or .h5 predictions file.
-                * A shuffle number and a particular snapshot
-                  (ctd_conditions: tuple[int, str] | tuple[int, int]), which respectively
-                  correspond to a bottom-up (BU) network type and a snapshot name or index.
+        configs_dir: path to the DeepLabCut "configs" directory
+        num_individuals: the maximum number of individuals the model should detect
+        detector_type: the type of detector to use (if None, uses ``ssdlite``)
+
     Returns:
-        the PyTorch pose configuration as a typed PoseConfig
+        the model configuration with an added detector config
     """
-    # Get metadata from project config
-    project_config = ProjectConfig.from_any(project_config)
-    metadata = PoseMetadata.from_project_config(project_config)
-    metadata.pose_config_path = pose_config_path
+    configs_dir = get_config_folder_path()
 
-    if weight_init is not None:
-        weight_init = WeightInitialization.from_any(weight_init)
-
-    # Build initial config as a plain dict for the merge phase
-    # (update_config only deep-merges plain dicts, not typed configs)
-    pose_config_dict = PoseConfig(
-        net_type=NetType(net_type) if net_type is not None else None,
-        metadata=metadata,
-        train_settings=TrainSettingsConfig(weight_init=weight_init),
-    ).to_dict()
-
-    # Update default values for the specific model architecture and project config.
-    defaults: dict = _load_pose_config_defaults(
-        project_config.to_dict(),
-        net_type,
-        top_down,
-        detector_type,
-        ctd_conditions,
+    detector_type = detector_type.lower()
+    detector_config = update_config(
+        read_config_as_dict(configs_dir / "base" / "base_detector.yaml"),
+        read_config_as_dict(configs_dir / "detectors" / f"{detector_type}.yaml"),
     )
-    pose_config_dict = update_config(pose_config_dict, defaults)
-
-    # Validate and convert back to typed PoseConfig
-    pose_config = PoseConfig.from_dict(pose_config_dict)
-
-    if save:
-        pose_config.to_yaml(pose_config_path, overwrite=True)
-    return pose_config
+    detector_config = replace_default_values(
+        detector_config,
+        num_individuals=num_individuals,
+    )
+    return dict(sorted(detector_config.items()))
 
 
-@ensure_plain_config
+# TODO @deruyter92 2026-06-12: currently, the responsibility for determining the task
+# is controlled either in the default config (for "non-backbone" models) or by the
+# API parameter `top_down` (for "backbone" models). This should be refactored.
+def resolve_task(net_type: str, *, top_down: bool) -> Task:
+    configs_dir = get_config_folder_path()
+    backbones = load_backbones(configs_dir)
+    if net_type in backbones:
+        return Task.TOP_DOWN if top_down else Task.BOTTOM_UP
+    architecture = net_type.split("_")[0]
+    cfg_path = configs_dir / architecture / f"{net_type}.yaml"
+    model_cfg = read_config_as_dict(cfg_path)
+    return Task(model_cfg.get("method", "BU").upper())
+
+
 def _add_ctd_conditions(model_cfg: dict, ctd_conditions: int | str | Path | tuple[int, str] | tuple[int, int]):
     """
     Args:
@@ -305,138 +323,7 @@ def _add_ctd_conditions(model_cfg: dict, ctd_conditions: int | str | Path | tupl
     model_cfg["inference"]["conditions"] = conditions
 
 
-def make_pytorch_test_config(
-    model_config: PoseConfig | dict | str | Path,
-    test_config_path: str | Path,
-    save: bool = False,
-) -> TestConfig:
-    """Creates the test configuration for a model
-
-    Args:
-        model_config (PoseConfig | dict | str | Path): The PyTorch pose configuration.
-        test_config_path: The path of the test config
-        save: Whether to save the test config to ``test_config_path``.
-
-    Returns:
-        The test configuration as a typed TestConfig.
-    """
-    # Validate the model config against the PoseConfig pydantic model
-    model_config = PoseConfig.from_any(model_config)
-
-    bodyparts = model_config["metadata"]["bodyparts"]
-    unique_bodyparts = model_config["metadata"]["unique_bodyparts"]
-    all_joint_names = bodyparts + unique_bodyparts
-
-    test_config = TestConfig(
-        dataset=model_config["metadata"]["project_path"],
-        dataset_type="multi-animal-imgaug",  # required for downstream tracking
-        num_joints=len(all_joint_names),
-        all_joints=[[i] for i in range(len(all_joint_names))],
-        all_joints_names=all_joint_names,
-        net_type=model_config["net_type"],
-        global_scale=1,
-        scoremap_dir="test",
-    )
-    if save:
-        test_config.to_yaml(test_config_path, overwrite=True)
-
-    return test_config
-
-
-def make_basic_project_config(
-    dataset_path: Path | str,
-    bodyparts: list[str],
-    max_individuals: int,
-    multi_animal: bool = True,
-) -> dict:
-    """Creates a basic configuration dict that can be used to create model configs.
-
-    This should be used to create the `project_config` given to
-    `make_pytorch_pose_config` for non-DeepLabCut projects (e.g. when creating a
-    configuration file for a model that will be trained on a COCO dataset).
-
-    Args:
-        dataset_path: The path to the dataset for which the config will be created.
-        bodyparts: The bodyparts labeled for individuals in the dataset.
-        max_individuals: The maximum number of individuals to detect in a single image.
-        multi_animal: Whether multiple animals can be present in an image.
-
-    Returns:
-        The created project configuration dict that can be given to
-        `make_pytorch_pose_config`.
-
-    Examples:
-        Creating a `pytorch_config` for a ResNet50 backbone with a part-affinity head (
-        as multi_animal=True and top_down=False)
-
-        >>> import deeplabcut.pose_estimation_pytorch as pep
-        >>> project_config = pep.config.make_basic_project_config(
-        >>>     dataset_path="/path/coco",
-        >>>     bodyparts=["nose", "left_eye", "right_eye"],
-        >>>     max_individuals=12,
-        >>>     multi_animal=True,
-        >>> )
-        >>> model_config = pep.config.make_pytorch_pose_config(
-        >>>     project_config=project_config,
-        >>>     pose_config_path="/path/coco/models/resnet50/pytorch_config.yaml",
-        >>>     net_type="resnet_50",
-        >>>     top_down=False,
-        >>>     save=True,
-        >>> )
-
-        Creating a `pytorch_config` for a ResNet50 backbone with a simple heatmap head
-        (as the project is single-animal):
-
-        >>> import deeplabcut.pose_estimation_pytorch as pep
-        >>> project_config = pep.config.make_basic_project_config(
-        >>>     dataset_path="/path/coco",
-        >>>     bodyparts=["nose", "left_eye", "right_eye"],
-        >>>     max_individuals=1,
-        >>>     multi_animal=False,
-        >>> )
-        >>> model_config = pep.config.make_pytorch_pose_config(
-        >>>     project_config=project_config,
-        >>>     pose_config_path="/path/coco/models/resnet50/pytorch_config.yaml",
-        >>>     net_type="resnet_50",
-        >>>     top_down=False,
-        >>>     save=True,
-        >>> )
-    """
-    return dict(
-        project_path=str(dataset_path),
-        multianimalproject=multi_animal,
-        bodyparts=bodyparts,
-        multianimalbodyparts=bodyparts,
-        uniquebodyparts=[],
-        individuals=[f"individual{i:03d}" for i in range(max_individuals)],
-    )
-
-
-@ensure_plain_config
-def add_metadata(project_config: dict, config: dict, pose_config_path: str | Path) -> dict:
-    """Adds metadata to a pytorch pose configuration
-
-    Args:
-        project_config: the project configuration
-        config: the pytorch pose configuration
-        pose_config_path: the path where the pytorch pose configuration will be saved
-
-    Returns:
-        the configuration with a `meta` key added
-    """
-    config = copy.deepcopy(config)
-    config["metadata"] = {
-        "project_path": project_config["project_path"],
-        "pose_config_path": str(pose_config_path),
-        "bodyparts": auxiliaryfunctions.get_bodyparts(project_config),
-        "unique_bodyparts": auxiliaryfunctions.get_unique_bodyparts(project_config),
-        "individuals": project_config.get("individuals", ["animal"]),
-        "with_identity": project_config.get("identity", False),
-    }
-    return config
-
-
-def create_backbone_with_heatmap_model(
+def _create_backbone_with_heatmap_model(
     configs_dir: Path,
     net_type: str,
     multianimal_project: bool,
@@ -467,8 +354,7 @@ def create_backbone_with_heatmap_model(
             "A pose model formed of a backbone and simple heatmap + location refinement"
             " head can only be used for single animal projects. As you're working with"
             " a multi-animal project, please select a multi-individual model instead of"
-            f" {net_type} or use a detector to create a top-down model (create your"
-            f" configuration with `make_pytorch_pose_config(..., top_down=True)`)."
+            f" {net_type} or use a detector to create a top-down model."
         )
 
     # add the backbone to the config
@@ -493,7 +379,7 @@ def create_backbone_with_heatmap_model(
     return model_config
 
 
-def create_backbone_with_paf_model(
+def _create_backbone_with_paf_model(
     configs_dir: Path,
     net_type: str,
     num_individuals: int,
@@ -532,41 +418,7 @@ def create_backbone_with_paf_model(
     return model_config
 
 
-def add_detector(
-    configs_dir: Path,
-    config: dict,
-    num_individuals: int,
-    detector_type: str | None = None,
-) -> dict:
-    """Adds a detector to a model.
-
-    Args:
-        configs_dir: path to the DeepLabCut "configs" directory
-        config: model configuration to update
-        num_individuals: the maximum number of individuals the model should detect
-        detector_type: the type of detector to use (if None, uses ``ssdlite``)
-
-    Returns:
-        the model configuration with an added detector config
-    """
-    if detector_type is None:
-        detector_type = "ssdlite"  # default detector
-
-    detector_type = detector_type.lower()
-    config = copy.deepcopy(config)
-    detector_config = update_config(
-        read_config_as_dict(configs_dir / "base" / "base_detector.yaml"),
-        read_config_as_dict(configs_dir / "detectors" / f"{detector_type}.yaml"),
-    )
-    detector_config = replace_default_values(
-        detector_config,
-        num_individuals=num_individuals,
-    )
-    config["detector"] = dict(sorted(detector_config.items()))
-    return config
-
-
-def add_unique_bodypart_head(
+def _add_unique_bodypart_head(
     configs_dir: Path,
     config: dict,
     num_unique_bodyparts: int,
@@ -594,7 +446,7 @@ def add_unique_bodypart_head(
     return config
 
 
-def add_identity_head(
+def _add_identity_head(
     configs_dir: Path,
     config: dict,
     num_individuals: int,
@@ -619,28 +471,3 @@ def add_identity_head(
         backbone_output_channels=backbone_output_channels,
     )
     return config
-
-
-def _get_paf_parameters(
-    project_config: dict,
-    bodyparts: list[str],
-    num_limbs_threshold: int = 105,
-    paf_graph_degree: int = 6,
-) -> dict:
-    """Gets values for PAF parameters from the project configuration."""
-    paf_graph = [[i, j] for i in range(len(bodyparts)) for j in range(i + 1, len(bodyparts))]
-    num_limbs = len(paf_graph)
-    # If the graph is unnecessarily large (with 15+ keypoints by default),
-    # we randomly prune it to a size guaranteeing an average node degree of 6;
-    # see Suppl. Fig S9c in Lauer et al., 2022.
-    if num_limbs >= num_limbs_threshold:
-        paf_graph = auxfun_multianimal.prune_paf_graph(
-            paf_graph,
-            average_degree=paf_graph_degree,
-        )
-        num_limbs = len(paf_graph)
-    return {
-        "paf_graph": paf_graph,
-        "num_limbs": num_limbs,
-        "paf_edges_to_keep": project_config.get("paf_best", list(range(num_limbs))),
-    }

--- a/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
+++ b/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
@@ -147,12 +147,14 @@ def build_pose_config_defaults(
 
     if net_type in backbones:
         if task == Task.BOTTOM_UP and multi_animal:
+            if paf_parameters is None:
+                raise ValueError("PAF parameters are required for multi-animal bottom-up models.")
             model_cfg = _create_backbone_with_paf_model(
                 configs_dir=configs_dir,
                 net_type=net_type,
                 num_individuals=metadata.num_individuals,
                 bodyparts=metadata.bodyparts,
-                paf_parameters=paf_parameters,
+                paf_parameters=paf_parameters.to_dict(),
             )
         else:
             model_cfg = _create_backbone_with_heatmap_model(
@@ -166,7 +168,9 @@ def build_pose_config_defaults(
         architecture = net_type.split("_")[0]
         default_value_kwargs = {}
         if architecture == "dlcrnet":
-            default_value_kwargs.update(paf_parameters)
+            if paf_parameters is None:
+                raise ValueError("PAF parameters are required for DLCRNet models.")
+            default_value_kwargs.update(paf_parameters.to_dict())
 
         cfg_path = configs_dir / architecture / f"{net_type}.yaml"
         model_cfg = read_config_as_dict(cfg_path)
@@ -179,6 +183,8 @@ def build_pose_config_defaults(
     model_cfg["net_type"] = net_type
 
     if task == Task.TOP_DOWN:
+        if detector_config is None:
+            raise ValueError("detector_config is required for top-down pose configs.")
         model_cfg["detector"] = detector_config.to_dict()
 
     # add the default augmentations to the config
@@ -232,7 +238,7 @@ def build_pose_config_defaults(
     # Add metadata and weight init to the model config
     model_cfg["metadata"] = metadata.to_dict()
     if weight_init is not None:
-        model_cfg["train_settings"]["weight_init"] = weight_init
+        model_cfg["train_settings"]["weight_init"] = weight_init.to_dict()
     return model_cfg
 
 

--- a/deeplabcut/pose_estimation_pytorch/config/metadata.py
+++ b/deeplabcut/pose_estimation_pytorch/config/metadata.py
@@ -66,9 +66,11 @@ class PoseMetadata(DLCBaseConfig):
         from deeplabcut.pose_estimation_pytorch.modelzoo.config import build_superanimal_metadata
 
         metadata = build_superanimal_metadata(
-            super_animal=super_animal, model_name=model_name, max_individuals=max_individuals
+            super_animal=super_animal,
+            model_name=model_name,
+            max_individuals=max_individuals,
         )
-        return cls.build(metadata)
+        return cls.from_dict(metadata)
 
     # NOTE @deruyter92 2026-06-12
     # This serves as a replacement for pose_estimation_pytorch.config.make_basic_project_config.

--- a/deeplabcut/pose_estimation_pytorch/config/metadata.py
+++ b/deeplabcut/pose_estimation_pytorch/config/metadata.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+from pydantic import Field
+from typing_extensions import Self
+
+from deeplabcut.core.config import DLCBaseConfig
+from deeplabcut.core.config.project_config import ProjectConfig
+from deeplabcut.core.config.validation import UniqueStrList
+
+
+# TODO @deruyter92 2026-06-08: This is duplicated from ProjectConfig. Note that field names are misaligned!
+# Once field names are aligned (in v1), we should merge these ProjectConfig subsets.
+class PoseMetadata(DLCBaseConfig):
+    project_path: Path | None = None
+    pose_config_path: Path = Field(default_factory=Path)
+    bodyparts: UniqueStrList = Field(default_factory=list)
+    unique_bodyparts: UniqueStrList = Field(default_factory=list, json_schema_extra={"aliases": ["uniquebodyparts"]})
+    individuals: UniqueStrList = Field(default_factory=lambda: ["individual_1"])
+
+    # TODO @deruyter92 2026-06-09: Nullable field to support old configs with empty identity field -> fix in v1.
+    with_identity: bool | None = Field(default=None, json_schema_extra={"aliases": ["identity"]})
+
+    @property
+    def num_individuals(self) -> int:
+        return len(self.individuals)
+
+    @property
+    def num_bodyparts(self) -> int:
+        return len(self.bodyparts)
+
+    @property
+    def num_unique_bodyparts(self) -> int:
+        return len(self.unique_bodyparts) if self.unique_bodyparts is not None else 0
+
+    @classmethod
+    def build(
+        cls,
+        project_config: ProjectConfig | dict | Path | str,
+        *,
+        project_path: Path | str | None = None,
+        pose_config_path: Path | str | None = None,
+        bodyparts: list[str] | None = None,
+        unique_bodyparts: list[str] | None = None,
+        individuals: list[str] | None = None,
+        with_identity: bool | None = None,
+    ) -> Self:
+        """Get metadata from a project configuration with optional overrides"""
+        cfg = ProjectConfig.from_any(project_config)
+
+        # Conversions for diverging fields in ProjectConfig
+        cfg_bodyparts = cfg.bodyparts_list
+        cfg_unique_bodyparts = cfg.uniquebodyparts
+        cfg_with_identity = cfg.identity
+
+        return cls(
+            project_path=project_path if project_path is not None else cfg.project_path,
+            pose_config_path=pose_config_path if pose_config_path is not None else cfg.pose_config_path,
+            bodyparts=bodyparts if bodyparts is not None else cfg_bodyparts,
+            unique_bodyparts=unique_bodyparts if unique_bodyparts is not None else cfg_unique_bodyparts,
+            individuals=individuals if individuals is not None else cfg.individuals,
+            with_identity=with_identity if with_identity is not None else cfg_with_identity,
+        )
+
+    @classmethod
+    def build_for_superanimal(cls, super_animal: str, model_name: str, max_individuals: int) -> Self:
+        from deeplabcut.pose_estimation_pytorch.modelzoo.config import build_superanimal_metadata
+
+        metadata = build_superanimal_metadata(
+            super_animal=super_animal, model_name=model_name, max_individuals=max_individuals
+        )
+        return cls.build(metadata)
+
+    # NOTE @deruyter92 2026-06-12
+    # This serves as a replacement for pose_estimation_pytorch.config.make_basic_project_config.
+    # It can safely be removed when we stop supporting that API. Prefer PoseMetadata(..) instead.
+    def to_dict_legacy(self) -> dict:
+        return dict(
+            project_path=self.project_path,
+            multianimalproject=self.num_individuals > 1,
+            bodyparts=self.bodyparts if self.num_individuals <= 1 else "MULTI!",
+            multianimalbodyparts=self.bodyparts if self.num_individuals > 1 else None,
+            uniquebodyparts=[],
+            individuals=self.individuals,
+        )

--- a/deeplabcut/pose_estimation_pytorch/config/metadata.py
+++ b/deeplabcut/pose_estimation_pytorch/config/metadata.py
@@ -12,7 +12,7 @@ from deeplabcut.core.config.validation import UniqueStrList
 # Once field names are aligned (in v1), we should merge these ProjectConfig subsets.
 class PoseMetadata(DLCBaseConfig):
     project_path: Path | None = None
-    pose_config_path: Path = Field(default_factory=Path)
+    pose_config_path: Path | None = None
     bodyparts: UniqueStrList = Field(default_factory=list)
     unique_bodyparts: UniqueStrList = Field(default_factory=list, json_schema_extra={"aliases": ["uniquebodyparts"]})
     individuals: UniqueStrList = Field(default_factory=lambda: ["individual_1"])

--- a/deeplabcut/pose_estimation_pytorch/config/paf_parameters.py
+++ b/deeplabcut/pose_estimation_pytorch/config/paf_parameters.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+from pydantic import Field
+from typing_extensions import Self
+
+from deeplabcut.core.config import DLCBaseConfig, ProjectConfig
+from deeplabcut.core.config.validation import NonNegativeInt
+
+
+class PAFParameters(DLCBaseConfig):
+    paf_graph: list[list[NonNegativeInt]] = Field(default_factory=list)
+    num_limbs: NonNegativeInt = 0
+    paf_edges_to_keep: list[NonNegativeInt] = Field(default_factory=list)
+
+    @classmethod
+    def build(
+        cls,
+        project_config: ProjectConfig | dict | Path | str,
+        *,
+        bodyparts: list[str] | None = None,
+        num_limbs_threshold: int = 105,
+        paf_graph_degree: int = 6,
+    ) -> Self:
+
+        # Normalize ProjectConfig + set defaults if not provided
+        project_config = ProjectConfig.from_any(project_config)
+        if bodyparts is None:
+            bodyparts = project_config.bodyparts_list
+
+        # Build the PAF parameters
+        return cls.from_dict(get_paf_parameters(project_config, bodyparts, num_limbs_threshold, paf_graph_degree))
+
+
+def get_paf_parameters(
+    project_config: dict,
+    bodyparts: list[str],
+    num_limbs_threshold: int = 105,
+    paf_graph_degree: int = 6,
+) -> dict:
+    """Gets values for PAF parameters from the project configuration."""
+    from deeplabcut.utils import auxfun_multianimal
+
+    paf_graph = [[i, j] for i in range(len(bodyparts)) for j in range(i + 1, len(bodyparts))]
+    num_limbs = len(paf_graph)
+    # If the graph is unnecessarily large (with 15+ keypoints by default),
+    # we randomly prune it to a size guaranteeing an average node degree of 6;
+    # see Suppl. Fig S9c in Lauer et al., 2022.
+    if num_limbs >= num_limbs_threshold:
+        paf_graph = auxfun_multianimal.prune_paf_graph(
+            paf_graph,
+            average_degree=paf_graph_degree,
+        )
+        num_limbs = len(paf_graph)
+    return {
+        "paf_graph": paf_graph,
+        "num_limbs": num_limbs,
+        "paf_edges_to_keep": project_config.get("paf_best", list(range(num_limbs))),
+    }

--- a/deeplabcut/pose_estimation_pytorch/config/pose.py
+++ b/deeplabcut/pose_estimation_pytorch/config/pose.py
@@ -54,6 +54,7 @@ class DetectorConfig(DLCBaseConfig):
     runner: RunnerConfig | None = None
     train_settings: TrainSettingsConfig | None = None
     inference: InferenceConfig = Field(default_factory=InferenceConfig)
+    resume_training_from: str | None = None
 
     @classmethod
     def build(
@@ -104,6 +105,7 @@ class PoseConfig(DLCVersionedConfig):
     runner: RunnerConfig | None = None
     train_settings: TrainSettingsConfig | None = None
     detector: DetectorConfig | None = None
+    resume_training_from: str | None = None
 
     @field_validator("net_type", mode="before")
     @classmethod

--- a/deeplabcut/pose_estimation_pytorch/config/pose.py
+++ b/deeplabcut/pose_estimation_pytorch/config/pose.py
@@ -10,8 +10,13 @@
 #
 """Main pose configuration class for DeepLabCut pose estimation models."""
 
-from enum import Enum
+from __future__ import annotations
+
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from deeplabcut.core.weight_init import WeightInitialization
 
 from pydantic import Field
 from typing_extensions import Self
@@ -20,92 +25,26 @@ from deeplabcut.core.config import DLCBaseConfig, DLCVersionedConfig
 from deeplabcut.core.config.project_config import ProjectConfig
 from deeplabcut.core.config.validation import Fraction, NonNegativeInt, UniqueStrList
 from deeplabcut.pose_estimation_pytorch.config.data import DataConfig
+from deeplabcut.pose_estimation_pytorch.config.enums import DatasetType, DetectorType, MethodType, NetType
 from deeplabcut.pose_estimation_pytorch.config.inference import InferenceConfig
 from deeplabcut.pose_estimation_pytorch.config.logger import (
     CSVLoggerConfig,
     WandbLoggerConfig,
 )
+from deeplabcut.pose_estimation_pytorch.config.make_pose_config import (
+    build_detector_config_defaults,
+    build_pose_config_defaults,
+    resolve_task,
+)
+from deeplabcut.pose_estimation_pytorch.config.metadata import PoseMetadata
 from deeplabcut.pose_estimation_pytorch.config.model import (
     DetectorModelConfig,
     ModelConfig,
 )
+from deeplabcut.pose_estimation_pytorch.config.paf_parameters import PAFParameters
 from deeplabcut.pose_estimation_pytorch.config.runner import RunnerConfig
 from deeplabcut.pose_estimation_pytorch.config.training import TrainSettingsConfig
-
-
-class MethodType(str, Enum):
-    """Enumeration of pose estimation method types."""
-
-    BOTTOM_UP = "bu"
-    TOP_DOWN = "td"
-    CONDITIONAL_TOP_DOWN = "ctd"
-
-
-class NetType(str, Enum):
-    """Enumeration of network architecture types."""
-
-    # ResNet variants (bottom-up)
-    RESNET_50 = "resnet_50"
-    RESNET_101 = "resnet_101"
-
-    # ResNet variants (top-down)
-    TOP_DOWN_RESNET_50 = "top_down_resnet_50"
-    TOP_DOWN_RESNET_101 = "top_down_resnet_101"
-
-    # HRNet variants (bottom-up)
-    HRNET_W18 = "hrnet_w18"
-    HRNET_W32 = "hrnet_w32"
-    HRNET_W48 = "hrnet_w48"
-
-    # HRNet variants (top-down)
-    TOP_DOWN_HRNET_W18 = "top_down_hrnet_w18"
-    TOP_DOWN_HRNET_W32 = "top_down_hrnet_w32"
-    TOP_DOWN_HRNET_W48 = "top_down_hrnet_w48"
-
-    # CSPNeXt variants (bottom-up)
-    CSPNEXT_S = "cspnext_s"
-    CSPNEXT_M = "cspnext_m"
-    CSPNEXT_X = "cspnext_x"
-
-    # CSPNeXt variants (top-down)
-    TOP_DOWN_CSPNEXT_S = "top_down_cspnext_s"
-    TOP_DOWN_CSPNEXT_M = "top_down_cspnext_m"
-    TOP_DOWN_CSPNEXT_X = "top_down_cspnext_x"
-
-    # DEKR variants (bottom-up with HRNet backbone)
-    DEKR_W18 = "dekr_w18"
-    DEKR_W32 = "dekr_w32"
-    DEKR_W48 = "dekr_w48"
-
-    # BUCTD variants (Conditional Top-Down)
-    CTD_COAM_W32 = "ctd_coam_w32"
-    CTD_COAM_W48 = "ctd_coam_w48"
-    CTD_COAM_W48_HUMAN = "ctd_coam_w48_human"
-    CTD_PRENET_HRNET_W32 = "ctd_prenet_hrnet_w32"
-    CTD_PRENET_HRNET_W48 = "ctd_prenet_hrnet_w48"
-    CTD_PRENET_RTMPOSE_S = "ctd_prenet_rtmpose_s"
-    CTD_PRENET_RTMPOSE_M = "ctd_prenet_rtmpose_m"
-    CTD_PRENET_RTMPOSE_X = "ctd_prenet_rtmpose_x"
-    CTD_PRENET_RTMPOSE_X_HUMAN = "ctd_prenet_rtmpose_x_human"
-
-    # DLCRNet variants
-    DLCRNET_STRIDE16_MS5 = "dlcrnet_stride16_ms5"
-    DLCRNET_STRIDE32_MS5 = "dlcrnet_stride32_ms5"
-
-    # RTMPose variants (top-down)
-    RTMPOSE_S = "rtmpose_s"
-    RTMPOSE_M = "rtmpose_m"
-    RTMPOSE_X = "rtmpose_x"
-
-    # AnimalTokenPose variant (inference only)
-    ANIMALTOKENPOSE_BASE = "animaltokenpose_base"
-
-
-class DatasetType(str, Enum):
-    """Enumeration of dataset types."""
-
-    # TODO @deruyter92 2026-02-05: Add other dataset types as needed.
-    MULTIANIMAL_IMGAUG = "multi-animal-imgaug"
+from deeplabcut.pose_estimation_pytorch.task import Task
 
 
 class DetectorConfig(DLCBaseConfig):
@@ -116,29 +55,20 @@ class DetectorConfig(DLCBaseConfig):
     train_settings: TrainSettingsConfig | None = None
     inference: InferenceConfig = Field(default_factory=InferenceConfig)
 
-
-# TODO @deruyter92 2026-06-08: This is duplicated from ProjectConfig. Note that field names are misaligned!
-# Once field names are aligned (in v1), we should merge these ProjectConfig subsets.
-class PoseMetadata(DLCBaseConfig):
-    project_path: Path | None = None
-    pose_config_path: Path | None = None
-    bodyparts: UniqueStrList = Field(default_factory=list)
-    unique_bodyparts: UniqueStrList = Field(default_factory=list, json_schema_extra={"aliases": ["uniquebodyparts"]})
-    individuals: UniqueStrList = Field(default_factory=lambda: ["individual_1"])
-
-    # TODO @deruyter92 2026-06-09: Nullable field to support old configs with empty identity field -> fix in v1.
-    with_identity: bool | None = Field(default=None, json_schema_extra={"aliases": ["identity"]})
-
     @classmethod
-    def from_project_config(cls, project_config: ProjectConfig | dict | Path | str) -> Self:
-        cfg = ProjectConfig.from_any(project_config)
-        return cls(
-            project_path=cfg.project_path,
-            pose_config_path=cfg.pose_config_path,
-            bodyparts=cfg.multianimalbodyparts if cfg.multianimalproject else cfg.bodyparts,
-            unique_bodyparts=cfg.uniquebodyparts,
-            individuals=cfg.individuals,
-            with_identity=cfg.identity,
+    def build(
+        cls,
+        num_individuals: int,
+        detector_type: DetectorType | None = None,
+    ) -> Self:
+        if detector_type is None:
+            detector_type = DetectorType.SSDLITE
+
+        return cls.from_dict(
+            build_detector_config_defaults(
+                num_individuals=num_individuals,
+                detector_type=detector_type,
+            )
         )
 
 
@@ -175,6 +105,149 @@ class PoseConfig(DLCVersionedConfig):
     train_settings: TrainSettingsConfig | None = None
     detector: DetectorConfig | None = None
 
+    @classmethod
+    def build(
+        cls,
+        project_config: ProjectConfig | dict | Path | str,
+        pose_config_path: str | Path,
+        *,
+        top_down: bool,
+        multi_animal: bool | None = None,
+        net_type: NetType | str | None = None,
+        detector_type: DetectorType | None = None,
+        weight_init: WeightInitialization | None = None,
+        ctd_conditions: int | str | Path | tuple[int, str] | tuple[int, int] | None = None,
+        save: bool = False,
+    ) -> Self:
+        """Build a typed PoseConfig for a project
+
+        Args:
+            project_config (ProjectConfig | dict | Path | str): The project configuration.
+            pose_config_path (str | Path): The path to the pose configuration.
+            top_down (bool): Whether to use a top-down backbone.
+            net_type (NetType | str | None, optional): The network architecture type.
+                If None, the default net type from the project config will be used.
+            detector_type (str | None, optional): The detector architecture type. Required for top-down models.
+            weight_init (WeightInitialization | None, optional): The weight initialization object or path.
+            ctd_conditions (int | str | Path | tuple[int, str] | tuple[int, int] | None, optional):
+                The conditional top-down conditions. Only required for CTD models.
+            save (bool, optional): Whether to save the pose configuration.
+
+        Note:
+            For generic backbone models, ``method`` is resolved from ``top_down``. For non-backbone models,
+            the ``top_down`` is ignored and ``method`` is resolved from the default config.
+        """
+        from deeplabcut.core.weight_init import WeightInitialization
+
+        # Normalize input parameters + set defaults if not provided
+        project_config = ProjectConfig.from_any(project_config)
+        task: Task = resolve_task(net_type, top_down=top_down)
+        if net_type is None:
+            net_type = project_config.default_net_type
+        if multi_animal is None:
+            multi_animal = project_config.multianimalproject
+
+        # Build related configurations (PoseMetadata, PAFParameters, DetectorConfig)
+        metadata = PoseMetadata.build(project_config, pose_config_path=pose_config_path)
+        paf_parameters = None
+        detector_config = None
+        if task == Task.BOTTOM_UP and multi_animal:
+            paf_parameters = PAFParameters.build(project_config)
+        elif task == Task.TOP_DOWN:
+            detector_config = DetectorConfig.build(metadata.num_individuals, detector_type)
+        if weight_init is not None:
+            weight_init = WeightInitialization.from_any(weight_init)
+
+        # Build the pose model config
+        defaults: dict = build_pose_config_defaults(
+            net_type=net_type,
+            metadata=metadata,
+            paf_parameters=paf_parameters,
+            weight_init=weight_init,
+            task=task,
+            multi_animal=multi_animal,
+            detector_config=detector_config,
+            ctd_conditions=ctd_conditions,
+        )
+        pose_config = cls.from_dict(defaults)
+
+        # Save if needed
+        if save:
+            pose_config.to_yaml(pose_config_path, overwrite=True)
+
+        return pose_config
+
+    @classmethod
+    def build_for_superanimal_inference(
+        cls,
+        super_animal: str,
+        model_name: str,
+        detector_name: str | None = None,
+        max_individuals: int = 30,
+        device: str | None = None,
+    ) -> Self:
+        from deeplabcut.pose_estimation_pytorch.modelzoo.config import build_superanimal_inference_config
+
+        metadata = PoseMetadata.build_for_superanimal(
+            super_animal=super_animal, model_name=model_name, max_individuals=max_individuals
+        )
+        return cls.from_dict(
+            build_superanimal_inference_config(
+                super_animal=super_animal,
+                model_name=model_name,
+                detector_name=detector_name,
+                max_individuals=max_individuals,
+                metadata=metadata,
+                device=device,
+            )
+        )
+
+    @classmethod
+    def build_for_superanimal_finetune(
+        cls,
+        project_config: ProjectConfig | dict | Path | str,
+        *model_name: str,
+        detector_name: str | None,
+        pose_config_path: str | Path,
+        weight_init: WeightInitialization,
+        inference_config: InferenceConfig | dict | Path | str | None = None,
+        save: bool = False,
+    ) -> Self:
+        from deeplabcut.pose_estimation_pytorch.modelzoo.config import build_superanimal_finetune_config
+
+        # Normalize input parameters + build related configurations
+        project_config = ProjectConfig.from_any(project_config)
+        if inference_config is None:
+            inference_config = InferenceConfig()
+        else:
+            inference_config = InferenceConfig.from_any(inference_config)
+        metadata = PoseMetadata.build(project_config, pose_config_path=pose_config_path)
+
+        # Input validation
+        if weight_init.dataset is None:
+            raise ValueError("`WeightInitialization.dataset` is required for fine-tuning SuperAnimal models.")
+
+        if not weight_init.with_decoder:
+            raise ValueError(
+                "`weight_init.with_decoder=True` is required for fine-tuning SuperAnimal models."
+                "Please set `with_decoder=True` to fine-tune a model, or create a transfer learning config instead."
+            )
+
+        # Build the pose configuration
+        pose_config = cls.from_dict(
+            build_superanimal_finetune_config(
+                weight_init,
+                metadata,
+                model_name,
+                detector_name,
+                inference_config=inference_config,
+            )
+        )
+
+        if save:
+            pose_config.to_yaml(metadata.pose_config_path, overwrite=True)
+        return
+
 
 class TestConfig(DLCBaseConfig):
     """Configuration class for DeepLabCut test/inference settings.
@@ -203,3 +276,39 @@ class TestConfig(DLCBaseConfig):
     dataset_type: DatasetType = DatasetType.MULTIANIMAL_IMGAUG
     global_scale: Fraction = 1.0
     scoremap_dir: Path = Path()
+
+    @classmethod
+    def build(
+        cls,
+        pose_config: PoseConfig | dict | Path | str,
+        *,
+        dataset_type: DatasetType = DatasetType.MULTIANIMAL_IMGAUG,
+        scoremap_dir: Path | str = "test",
+        test_config_path: Path | str | None = None,
+        global_scale: Fraction = 1.0,
+        save: bool = False,
+    ) -> Self:
+
+        # Needs a validated PoseConfig
+        cfg = PoseConfig.from_any(pose_config)
+        metadata = cfg.metadata
+
+        # Build the test config
+        test_config = cls(
+            dataset=cfg.metadata.project_path,
+            dataset_type=dataset_type,  # required for downstream tracking
+            num_joints=metadata.num_bodyparts + metadata.num_unique_bodyparts,
+            all_joints=[[i] for i in range(metadata.num_bodyparts + metadata.num_unique_bodyparts)],
+            all_joints_names=metadata.bodyparts + metadata.unique_bodyparts,
+            net_type=cfg.net_type,
+            global_scale=global_scale,
+            scoremap_dir=scoremap_dir,
+        )
+
+        # Save if needed
+        if save:
+            if test_config_path is None:
+                raise ValueError("test_config_path is required to save the test config.")
+            test_config.to_yaml(test_config_path, overwrite=True)
+
+        return test_config

--- a/deeplabcut/pose_estimation_pytorch/config/pose.py
+++ b/deeplabcut/pose_estimation_pytorch/config/pose.py
@@ -230,6 +230,7 @@ class PoseConfig(DLCVersionedConfig):
 
         # Normalize input parameters + build related configurations
         project_config = ProjectConfig.from_any(project_config)
+        weight_init = WeightInitialization.from_any(weight_init)
         if inference_config is None:
             inference_config = InferenceConfig()
         else:

--- a/deeplabcut/pose_estimation_pytorch/config/pose.py
+++ b/deeplabcut/pose_estimation_pytorch/config/pose.py
@@ -196,7 +196,6 @@ class PoseConfig(DLCVersionedConfig):
                 super_animal=super_animal,
                 model_name=model_name,
                 detector_name=detector_name,
-                max_individuals=max_individuals,
                 metadata=metadata,
                 device=device,
             )

--- a/deeplabcut/pose_estimation_pytorch/config/pose.py
+++ b/deeplabcut/pose_estimation_pytorch/config/pose.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from deeplabcut.core.weight_init import WeightInitialization
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from typing_extensions import Self
 
 from deeplabcut.core.config import DLCBaseConfig, DLCVersionedConfig
@@ -34,7 +34,7 @@ from deeplabcut.pose_estimation_pytorch.config.logger import (
 from deeplabcut.pose_estimation_pytorch.config.make_pose_config import (
     build_detector_config_defaults,
     build_pose_config_defaults,
-    resolve_task,
+    resolve_net_type_and_task,
 )
 from deeplabcut.pose_estimation_pytorch.config.metadata import PoseMetadata
 from deeplabcut.pose_estimation_pytorch.config.model import (
@@ -105,6 +105,14 @@ class PoseConfig(DLCVersionedConfig):
     train_settings: TrainSettingsConfig | None = None
     detector: DetectorConfig | None = None
 
+    @field_validator("net_type", mode="before")
+    @classmethod
+    def _coerce_net_type(cls, v: object) -> NetType:
+        if isinstance(v, NetType):
+            return v
+        net_type, _ = NetType.from_alias(str(v))
+        return net_type
+
     @classmethod
     def build(
         cls,
@@ -114,8 +122,8 @@ class PoseConfig(DLCVersionedConfig):
         top_down: bool,
         multi_animal: bool | None = None,
         net_type: NetType | str | None = None,
-        detector_type: DetectorType | None = None,
-        weight_init: WeightInitialization | None = None,
+        detector_type: DetectorType | str | None = None,
+        weight_init: WeightInitialization | dict | Path | str | None = None,
         ctd_conditions: int | str | Path | tuple[int, str] | tuple[int, int] | None = None,
         save: bool = False,
     ) -> Self:
@@ -125,9 +133,9 @@ class PoseConfig(DLCVersionedConfig):
             project_config (ProjectConfig | dict | Path | str): The project configuration.
             pose_config_path (str | Path): The path to the pose configuration.
             top_down (bool): Whether to use a top-down backbone.
-            net_type (NetType | str | None, optional): The network architecture type.
+            net_type (NetType | str | None, optional): The network architecture type (without 'top_down_' prefix).
                 If None, the default net type from the project config will be used.
-            detector_type (str | None, optional): The detector architecture type. Required for top-down models.
+            detector_type (DetectorType | str | None, optional): The detector architecture. Required for td models.
             weight_init (WeightInitialization | None, optional): The weight initialization object or path.
             ctd_conditions (int | str | Path | tuple[int, str] | tuple[int, int] | None, optional):
                 The conditional top-down conditions. Only required for CTD models.
@@ -141,11 +149,17 @@ class PoseConfig(DLCVersionedConfig):
 
         # Normalize input parameters + set defaults if not provided
         project_config = ProjectConfig.from_any(project_config)
-        task: Task = resolve_task(net_type, top_down=top_down)
-        if net_type is None:
-            net_type = project_config.default_net_type
         if multi_animal is None:
             multi_animal = project_config.multianimalproject
+        net_type, task = resolve_net_type_and_task(
+            net_type,
+            default=project_config.default_net_type,
+            top_down=top_down,
+        )
+        if detector_type is not None:
+            detector_type = DetectorType(detector_type)
+        if weight_init is not None:
+            weight_init = WeightInitialization.from_any(weight_init)
 
         # Build related configurations (PoseMetadata, PAFParameters, DetectorConfig)
         metadata = PoseMetadata.build(project_config, pose_config_path=pose_config_path)
@@ -155,8 +169,6 @@ class PoseConfig(DLCVersionedConfig):
             paf_parameters = PAFParameters.build(project_config)
         elif task == Task.TOP_DOWN:
             detector_config = DetectorConfig.build(metadata.num_individuals, detector_type)
-        if weight_init is not None:
-            weight_init = WeightInitialization.from_any(weight_init)
 
         # Build the pose model config
         defaults: dict = build_pose_config_defaults(

--- a/deeplabcut/pose_estimation_pytorch/config/pose.py
+++ b/deeplabcut/pose_estimation_pytorch/config/pose.py
@@ -193,6 +193,7 @@ class PoseConfig(DLCVersionedConfig):
     def build_for_superanimal_inference(
         cls,
         super_animal: str,
+        *,
         model_name: str,
         detector_name: str | None = None,
         max_individuals: int = 30,
@@ -217,7 +218,8 @@ class PoseConfig(DLCVersionedConfig):
     def build_for_superanimal_finetune(
         cls,
         project_config: ProjectConfig | dict | Path | str,
-        *model_name: str,
+        *,
+        model_name: str,
         detector_name: str | None,
         pose_config_path: str | Path,
         weight_init: WeightInitialization,
@@ -257,7 +259,7 @@ class PoseConfig(DLCVersionedConfig):
 
         if save:
             pose_config.to_yaml(metadata.pose_config_path, overwrite=True)
-        return
+        return pose_config
 
 
 class TestConfig(DLCBaseConfig):

--- a/deeplabcut/pose_estimation_pytorch/config/runner.py
+++ b/deeplabcut/pose_estimation_pytorch/config/runner.py
@@ -65,7 +65,6 @@ class RunnerConfig(DLCBaseConfig):
         optimizer: Optimizer configuration
         scheduler: Scheduler configuration
         snapshots: Snapshot configuration
-        resume_training_from: Path to resume training from
         load_weights_only: Value for torch.load() weights_only parameter
     """
 
@@ -82,5 +81,4 @@ class RunnerConfig(DLCBaseConfig):
     scheduler: SchedulerConfig | None = None
     snapshots: SnapshotCheckpointConfig | None = None
     snapshot_prefix: str | None = None
-    resume_training_from: str | None = None
     load_weights_only: bool | None = None

--- a/deeplabcut/pose_estimation_pytorch/config/runner.py
+++ b/deeplabcut/pose_estimation_pytorch/config/runner.py
@@ -81,5 +81,6 @@ class RunnerConfig(DLCBaseConfig):
     optimizer: OptimizerConfig | None = None
     scheduler: SchedulerConfig | None = None
     snapshots: SnapshotCheckpointConfig | None = None
+    snapshot_prefix: str | None = None
     resume_training_from: str | None = None
     load_weights_only: bool | None = None

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/config.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/config.py
@@ -68,18 +68,20 @@ def build_superanimal_inference_config(
     model_config = read_config_as_dict(model_cfg_path)
     model_config = config_utils.replace_default_values(
         model_config,
-        num_bodyparts=len(model_config["metadata"]["bodyparts"]),
+        num_bodyparts=metadata.num_bodyparts,
         num_individuals=max_individuals,
         backbone_output_channels=model_config["model"]["backbone_output_channels"],
     )
     if detector_name is None and super_animal != "superanimal_humanbody":
-        model_config["method"] = "BU"
+        model_config["method"] = Task.BOTTOM_UP.aliases[0].lower()
     else:
-        model_config["method"] = "TD"
+        model_config["method"] = Task.TOP_DOWN.aliases[0].lower()
         if super_animal != "superanimal_humanbody":
             detector_cfg_path = get_super_animal_model_config_path(model_name=detector_name)
             detector_cfg = read_config_as_dict(detector_cfg_path)
             model_config["detector"] = detector_cfg
+        else:
+            model_config.pop("detector", None)
 
     model_config["metadata"] = metadata.to_dict()
     if device is not None:

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/config.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/config.py
@@ -42,9 +42,8 @@ def build_superanimal_metadata(super_animal: str, model_name: str, max_individua
     project_cfg_path = get_super_animal_project_config_path(super_animal=super_animal)
     project_config = read_config_as_dict(project_cfg_path)
     model_cfg_path = get_super_animal_model_config_path(model_name=model_name)
-    read_config_as_dict(model_cfg_path)
     metadata = {
-        "project_path": project_config.get("project_path") or Path(),
+        "project_path": project_config.get("project_path"),
         "pose_config_path": model_cfg_path,
         "bodyparts": af.get_bodyparts(project_config),
         "unique_bodyparts": af.get_unique_bodyparts(project_config),

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/config.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/config.py
@@ -14,73 +14,98 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from deeplabcut.pose_estimation_pytorch.config.pose import PoseConfig
+    from deeplabcut.pose_estimation_pytorch.runners.inference import InferenceConfig
+
+from ruamel.yaml import YAML
 
 import deeplabcut.pose_estimation_pytorch.config.utils as config_utils
 import deeplabcut.utils.auxiliaryfunctions as af
-from deeplabcut.core.config import read_config_as_dict
-from deeplabcut.core.config.project_config import ProjectConfig
-from deeplabcut.core.config.utils import get_yaml_loader
+from deeplabcut.core.config import (
+    read_config_as_dict,
+)
 from deeplabcut.core.engine import Engine
 from deeplabcut.core.weight_init import WeightInitialization
-from deeplabcut.pose_estimation_pytorch.config.pose import PoseConfig
+from deeplabcut.pose_estimation_pytorch.config.metadata import PoseMetadata
 from deeplabcut.pose_estimation_pytorch.modelzoo.utils import (
     get_super_animal_model_config_path,
     get_super_animal_project_config_path,
 )
-from deeplabcut.pose_estimation_pytorch.runners.inference import InferenceConfig
 from deeplabcut.pose_estimation_pytorch.task import Task
+from deeplabcut.utils.deprecation import deprecated
 
 
-def make_super_animal_finetune_config(
-    weight_init: WeightInitialization,
-    project_config: ProjectConfig | dict | Path | str,
-    pose_config_path: str | Path,
+def build_superanimal_metadata(super_animal: str, model_name: str, max_individuals: int) -> dict:
+    project_cfg_path = get_super_animal_project_config_path(super_animal=super_animal)
+    project_config = read_config_as_dict(project_cfg_path)
+    model_cfg_path = get_super_animal_model_config_path(model_name=model_name)
+    read_config_as_dict(model_cfg_path)
+    metadata = {
+        "project_path": project_config.get("project_path") or Path(),
+        "pose_config_path": model_cfg_path,
+        "bodyparts": af.get_bodyparts(project_config),
+        "unique_bodyparts": af.get_unique_bodyparts(project_config),
+        "individuals": [f"animal{i}" for i in range(max_individuals)],
+        "with_identity": project_config.get("identity", False),
+    }
+    return metadata
+
+
+def build_superanimal_inference_config(
+    super_animal: str,
     model_name: str,
     detector_name: str | None,
-    save: bool = False,
-) -> PoseConfig:
-    """Creates a PyTorch pose configuration file to finetune a SuperAnimal model on a
-    downstream project.
+    metadata: PoseMetadata,
+    device: str | None = None,
+) -> dict:
 
-    Args:
-        weight_init: The weight initialization configuration.
-        project_config (ProjectConfig | dict | Path | str): The project configuration.
-        pose_config_path: The path where the pose configuration file will be saved
-        model_name: The type of neural net to finetune.
-        detector_name: The type of detector to use for the SuperAnimal model. If None is
-            given, the model will be set to a Bottom-Up framework.
-        save: Whether to save the model configuration file to the ``pose_config_path``.
+    max_individuals = metadata.num_individuals
 
-    Returns:
-        PoseConfig: The generated pose configuration.
+    model_cfg_path = get_super_animal_model_config_path(model_name=model_name)
+    model_config = read_config_as_dict(model_cfg_path)
+    model_config = config_utils.replace_default_values(
+        model_config,
+        num_bodyparts=len(model_config["metadata"]["bodyparts"]),
+        num_individuals=max_individuals,
+        backbone_output_channels=model_config["model"]["backbone_output_channels"],
+    )
+    if detector_name is None and super_animal != "superanimal_humanbody":
+        model_config["method"] = "BU"
+    else:
+        model_config["method"] = "TD"
+        if super_animal != "superanimal_humanbody":
+            detector_cfg_path = get_super_animal_model_config_path(model_name=detector_name)
+            detector_cfg = read_config_as_dict(detector_cfg_path)
+            model_config["detector"] = detector_cfg
 
-    Raises:
-        ValueError: If `weight_init.with_decoder = False`. This method only creates
-            configs to fine-tune SuperAnimal models. Call `make_pytorch_pose_config`
-            to create configuration files for transfer learning.
-    """
-    project_config = ProjectConfig.from_any(project_config)
-    bodyparts = af.get_bodyparts(project_config)
-    if weight_init.dataset is None:
-        raise ValueError("You must set the ``WeightInitialization.dataset`` when fine-tuning SuperAnimal models.")
+    model_config["metadata"] = metadata.to_dict()
+    if device is not None:
+        model_config["device"] = device
+        if model_config.get("detector", None) is not None:
+            model_config["detector"]["device"] = device
+    return model_config
 
-    if not weight_init.with_decoder:
-        raise ValueError(
-            "Can only call ``make_super_animal_finetune_config`` when "
-            f" `with_decoder=True`, but you had {weight_init}. Please set "
-            "`with_decoder=True` to fine-tune a model or call "
-            "`make_pytorch_pose_config` to create a transfer learning "
-            "pose configuration file."
-        )
 
-    converted_bodyparts = bodyparts
+def build_superanimal_finetune_config(
+    weight_init: WeightInitialization,
+    metadata: PoseMetadata,
+    model_name: str,
+    detector_name: str | None,
+    inference_config: InferenceConfig,
+) -> dict:
+
+    # Bodyparts mapping
+    converted_bodyparts = metadata.bodyparts
     if weight_init.bodyparts is not None:
         assert len(weight_init.bodyparts) == len(weight_init.conversion_array)
         converted_bodyparts = weight_init.bodyparts
-    elif len(bodyparts) != len(weight_init.conversion_array):
+    elif len(metadata.bodyparts) != len(weight_init.conversion_array):
         raise ValueError(
             "You don't have the same number of bodyparts in your project config as "
-            f"number of entries your conversion array ({bodyparts} vs "
+            f"number of entries your conversion array ({metadata.bodyparts} vs "
             f"{weight_init.conversion_array}). If you're fine-tuning from "
             "SuperAnimal on a subset of your bodyparts, you must specify which "
             "ones in `WeightInitialization.bodyparts`. This should be done "
@@ -88,50 +113,8 @@ def make_super_animal_finetune_config(
             "`WeightInitialization.build`."
         )
 
-    # Load the exact pose configuration file for the model to fine-tune
-    pose_config = create_config_from_modelzoo(
-        super_animal=weight_init.dataset,
-        model_name=model_name,
-        detector_name=detector_name,
-        converted_bodyparts=converted_bodyparts,
-        weight_init=weight_init,
-        project_config=project_config,
-        pose_config_path=pose_config_path,
-    )
-    if save:
-        pose_config.to_yaml(pose_config_path, overwrite=True)
-
-    return pose_config
-
-
-def create_config_from_modelzoo(
-    super_animal: str,
-    model_name: str,
-    detector_name: str | None,
-    converted_bodyparts: list[str],
-    weight_init: WeightInitialization,
-    project_config: ProjectConfig | dict | Path | str,
-    pose_config_path: str | Path,
-) -> PoseConfig:
-    """Creates a model configuration file to fine-tune a SuperAnimal model.
-
-    Args:
-        super_animal: The SuperAnimal dataset on which the model was trained.
-        model_name: The type of neural net to finetune.
-        detector_name: The type of detector to use for the SuperAnimal model. If None is
-            given, the model will be set to a Bottom-Up framework.
-        converted_bodyparts: The project bodyparts that the model will learn.
-        weight_init: The weight initialization to use.
-        project_config (ProjectConfig | dict | Path | str): The project configuration.
-        pose_config_path: The path where the pose configuration file will be saved.
-
-    Returns:
-        PoseConfig: The generated pose configuration.
-    """
-    project_config = ProjectConfig.from_any(project_config)
-
     # load the model configuration
-    model_cfg = PoseConfig.from_yaml(get_super_animal_model_config_path(model_name))
+    model_cfg = read_config_as_dict(get_super_animal_model_config_path(model_name))
     if detector_name is None:
         model_cfg["method"] = Task.BOTTOM_UP.aliases[0].lower()
         # Use default bottom-up image augmentation if no detector is given (the collate
@@ -145,25 +128,36 @@ def create_config_from_modelzoo(
 
     # use SuperAnimal bodyparts
     if weight_init.memory_replay:
-        super_animal_project_config = read_config_as_dict(get_super_animal_project_config_path(super_animal))
+        super_animal_project_config = read_config_as_dict(get_super_animal_project_config_path(weight_init.dataset))
         converted_bodyparts = super_animal_project_config["bodyparts"]
 
     model_cfg["net_type"] = model_name
-    model_cfg["metadata"] = {
-        "project_path": project_config["project_path"],
-        "pose_config_path": str(pose_config_path),
-        "bodyparts": converted_bodyparts,
-        "unique_bodyparts": [],
-        "individuals": project_config.get("individuals", ["animal"]),
-        "with_identity": False,
-    }
-
+    model_cfg["metadata"] = metadata.to_dict()
     model_cfg["model"] = config_utils.replace_default_values(model_cfg["model"], num_bodyparts=len(converted_bodyparts))
     model_cfg["train_settings"]["weight_init"] = weight_init.to_dict()
-
-    model_cfg["inference"] = InferenceConfig().to_dict()
-
+    model_cfg["inference"] = inference_config.to_dict()
     return model_cfg
+
+
+@deprecated(replacement="PoseConfig.build_for_superanimal_finetune", since="3.1")
+def make_super_animal_finetune_config(
+    weight_init: WeightInitialization,
+    project_config: dict,
+    pose_config_path: str | Path,
+    model_name: str,
+    detector_name: str | None,
+    save: bool = False,
+) -> PoseConfig:
+    from deeplabcut.pose_estimation_pytorch.config.pose import PoseConfig
+
+    return PoseConfig.build_for_superanimal_finetune(
+        weight_init=weight_init,
+        project_config=project_config,
+        pose_config_path=pose_config_path,
+        model_name=model_name,
+        detector_name=detector_name,
+        save=save,
+    )
 
 
 def write_pytorch_config_for_memory_replay(config_path, shuffle, pytorch_config):
@@ -176,5 +170,5 @@ def write_pytorch_config_for_memory_replay(config_path, shuffle, pytorch_config)
     os.makedirs(model_folder / "train", exist_ok=True)
     out_path = model_folder / "train" / "pytorch_config.yaml"
     with open(str(out_path), "w") as f:
-        yaml = get_yaml_loader()
+        yaml = YAML()
         yaml.dump(pytorch_config, f)

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/inference_helpers.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/inference_helpers.py
@@ -26,7 +26,6 @@ from deeplabcut.pose_estimation_pytorch.modelzoo.utils import (
     COCO_PERSON_CATEGORY_ID,
     get_super_animal_snapshot_path,
     load_super_animal_config,
-    update_config,
 )
 from deeplabcut.pose_estimation_pytorch.runners import InferenceRunner
 from deeplabcut.pose_estimation_pytorch.task import Task
@@ -163,8 +162,9 @@ def create_superanimal_inference_runners(
             super_animal=superanimal_name,
             model_name=model_name,
             detector_name=detector_name,
+            max_individuals=max_individuals,
+            device=device,
         )
-    model_cfg = update_config(model_cfg, max_individuals=max_individuals, device=device)
 
     if superanimal_name == "superanimal_humanbody":
         return _build_humanbody_inference_runners(

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/utils.py
@@ -12,15 +12,20 @@ import inspect
 import subprocess
 import warnings
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from deeplabcut.pose_estimation_pytorch.config.pose import PoseConfig
 
 import torch
 from dlclibrary import download_huggingface_model
 
 import deeplabcut.pose_estimation_pytorch.config.utils as config_utils
-from deeplabcut.core.config import read_config_as_dict
-from deeplabcut.core.config.project_config import ProjectConfig
-from deeplabcut.pose_estimation_pytorch.config.pose import PoseConfig, PoseMetadata
+
+# from deeplabcut.core.config import read_config_as_dict
+# from deeplabcut.pose_estimation_pytorch.config.make_pose_config import add_metadata
 from deeplabcut.utils import auxiliaryfunctions
+from deeplabcut.utils.deprecation import deprecated
 
 # COCO category ID for the "person" class.
 COCO_PERSON_CATEGORY_ID = 1
@@ -87,45 +92,61 @@ def get_super_animal_snapshot_path(
     return model_path
 
 
+@deprecated(replacement="PoseConfig.build_for_superanimal_inference", since="3.1")
 def load_super_animal_config(
     super_animal: str,
     model_name: str,
     detector_name: str | None = None,
     max_individuals: int = 30,
     device: str | None = None,
-) -> PoseConfig:
-    """Loads the model configuration file for a model, detector and SuperAnimal.
+) -> "PoseConfig":
+    from deeplabcut.pose_estimation_pytorch.config.pose import PoseConfig
 
-    Args:
-        super_animal: The name of the SuperAnimal for which to create the model config.
-        model_name: The name of the model for which to create the model config.
-        detector_name: The name of the detector for which to create the model config.
-        max_individuals: The maximum number of detections to make in an image
-        device: The device to use to train/run inference on the model
+    return PoseConfig.build_for_superanimal_inference(
+        super_animal=super_animal,
+        model_name=model_name,
+        detector_name=detector_name,
+        max_individuals=max_individuals,
+        device=device,
+    )
 
-    Returns:
-        PoseConfig: The model configuration for a SuperAnimal-pretrained model.
-    """
-    project_cfg_path = get_super_animal_project_config_path(super_animal=super_animal)
-    project_config = ProjectConfig.from_yaml(project_cfg_path)
 
-    model_cfg_path = get_super_animal_model_config_path(model_name=model_name)
-    model_config = PoseConfig.from_yaml(model_cfg_path)
-    metadata = PoseMetadata.from_project_config(project_config)
-    metadata.pose_config_path = model_cfg_path
-    model_config.metadata = PoseMetadata.from_project_config(project_config)
-    model_config.metadata = metadata
-    model_config = update_config(model_config, max_individuals, device)
+# def load_super_animal_config(
+#     super_animal: str,
+#     model_name: str,
+#     detector_name: str | None = None,
+#     max_individuals: int = 30,
+#     device: str | None = None,
+# ) -> dict:
+#     """Loads the model configuration file for a model, detector and SuperAnimal.
 
-    if detector_name is None and super_animal != "superanimal_humanbody":
-        model_config["method"] = "bu"
-    else:
-        model_config["method"] = "td"
-        if super_animal != "superanimal_humanbody":
-            detector_cfg_path = get_super_animal_model_config_path(model_name=detector_name)
-            detector_cfg = read_config_as_dict(detector_cfg_path)
-            model_config["detector"] = detector_cfg
-    return PoseConfig.from_any(model_config)
+#     Args:
+#         super_animal: The name of the SuperAnimal for which to create the model config.
+#         model_name: The name of the model for which to create the model config.
+#         detector_name: The name of the detector for which to create the model config.
+#         max_individuals: The maximum number of detections to make in an image
+#         device: The device to use to train/run inference on the model
+
+#     Returns:
+#         The model configuration for a SuperAnimal-pretrained model.
+#     """
+#     project_cfg_path = get_super_animal_project_config_path(super_animal=super_animal)
+#     project_config = read_config_as_dict(project_cfg_path)
+
+#     model_cfg_path = get_super_animal_model_config_path(model_name=model_name)
+#     model_config = read_config_as_dict(model_cfg_path)
+#     model_config = add_metadata(project_config, model_config, model_cfg_path)
+#     model_config = update_config(model_config, max_individuals, device)
+
+#     if detector_name is None and super_animal != "superanimal_humanbody":
+#         model_config["method"] = "BU"
+#     else:
+#         model_config["method"] = "TD"
+#         if super_animal != "superanimal_humanbody":
+#             detector_cfg_path = get_super_animal_model_config_path(model_name=detector_name)
+#             detector_cfg = read_config_as_dict(detector_cfg_path)
+#             model_config["detector"] = detector_cfg
+#     return model_config
 
 
 def download_super_animal_snapshot(dataset: str, model_name: str) -> Path:
@@ -189,24 +210,17 @@ def raise_warning_if_called_directly():
         )
 
 
-# TODO @deruyter92: This logic is currently completely separated from
-# the PoseConfig logic elsewhere. We should put this in line with the rest of the codebase.
-def update_config(
-    config: PoseConfig | dict | str | Path,
-    max_individuals: int,
-    device: str | None,
-) -> PoseConfig:
-    """Update placeholder values in a SuperAnimal pose configuration.
+def update_config(config: dict, max_individuals: int, device: str):
+    """Loads the model configuration file for a model, detector and SuperAnimal.
 
     Args:
-        config (PoseConfig | dict | str | Path): The pose configuration to update.
+        config: The default model configuration file.
         max_individuals: The maximum number of detections to make in an image
         device: The device to use to train/run inference on the model
 
     Returns:
-        PoseConfig: The updated pose configuration.
+        The model configuration for a SuperAnimal-pretrained model.
     """
-    config = PoseConfig.from_any(config).to_dict()
     config = config_utils.replace_default_values(
         config,
         num_bodyparts=len(config["metadata"]["bodyparts"]),
@@ -215,9 +229,8 @@ def update_config(
     )
     config["metadata"]["individuals"] = [f"animal{i}" for i in range(max_individuals)]
 
-    resolved_device = device if device is not None else "auto"
-    config["device"] = resolved_device
-    if config.get("detector") is not None:
-        config["detector"]["device"] = resolved_device
+    config["device"] = device
+    if config.get("detector", None) is not None:
+        config["detector"]["device"] = device
 
-    return PoseConfig.from_dict(config)
+    return config

--- a/deeplabcut/pose_estimation_pytorch/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/utils.py
@@ -12,12 +12,11 @@ from __future__ import annotations
 
 import os
 import random
-from pathlib import Path
 
 import numpy as np
 import torch
 
-from deeplabcut.pose_estimation_pytorch.config.pose import PoseConfig
+from deeplabcut.pose_estimation_pytorch.config.pose import DetectorConfig, PoseConfig
 
 
 def create_folder(path_to_folder):
@@ -43,7 +42,7 @@ def fix_seeds(seed: int) -> None:
     torch.backends.cudnn.benchmark = False
 
 
-def resolve_device(model_config: PoseConfig | dict | str | Path) -> str:
+def resolve_device(model_config: PoseConfig | DetectorConfig) -> str:
     """Determines which device should be used from the model config.
 
     When the device is set to 'auto':
@@ -58,9 +57,12 @@ def resolve_device(model_config: PoseConfig | dict | str | Path) -> str:
     Returns:
         the device on which training should be run
     """
-    model_config = PoseConfig.from_any(model_config)
-    device = model_config["device"]
-    supports_mps = "resnet" in model_config.get("net_type", "resnet")
+    device = model_config.device
+
+    if isinstance(model_config, DetectorConfig):
+        supports_mps = False
+    else:
+        supports_mps = "resnet" in model_config.get("net_type", "")
 
     if device == "auto":
         if torch.cuda.is_available():

--- a/deeplabcut/utils/pseudo_label.py
+++ b/deeplabcut/utils/pseudo_label.py
@@ -32,7 +32,6 @@ from deeplabcut.modelzoo.generalized_data_converter.datasets import (
 from deeplabcut.pose_estimation_pytorch.apis.utils import get_inference_runners
 from deeplabcut.pose_estimation_pytorch.modelzoo.utils import (
     select_device,
-    update_config,
 )
 
 
@@ -187,6 +186,8 @@ def keypoint_matching(
         super_animal=superanimal_name,
         model_name=model_name,
         detector_name=detector_name,
+        max_individuals=max_individuals,
+        device=device,
     )
     if device is None:
         device = select_device()
@@ -201,9 +202,6 @@ def keypoint_matching(
         model_name=detector_name,
     )
 
-    # TODO @deruyter92: midway config updates are not ideal.
-    # We should validate this against the pydantic schema.
-    config = update_config(config, max_individuals, device)
     individuals = [f"animal{i}" for i in range(max_individuals)]
     config["metadata"]["individuals"] = individuals
     train_file_path = os.path.join(memory_replay_folder, "annotations", train_file)

--- a/examples/testscript_pytorch_multi_animal.py
+++ b/examples/testscript_pytorch_multi_animal.py
@@ -84,11 +84,6 @@ def main(
                         }
                     )
 
-                # Only add conditional top-down config updates for conditional top-down models
-                if is_model_cond_top_down(net_type):
-                    pytorch_cfg_updates["inference.conditions.shuffle"] = conditions_shuffle
-                    pytorch_cfg_updates["inference.conditions.snapshot_index"] = -1
-
                 run(
                     config_path=config_path,
                     train_fraction=train_frac,
@@ -99,6 +94,7 @@ def main(
                     engine=engine,
                     pytorch_cfg_updates=pytorch_cfg_updates,
                     create_labeled_videos=create_labeled_videos,
+                    ctd_conditions=(conditions_shuffle, -1) if is_model_cond_top_down(net_type) else None,
                 )
             except Exception as err:
                 log_step(f"FAILED TO RUN {net_type}")

--- a/examples/testscript_superanimal_transfer_learning.py
+++ b/examples/testscript_superanimal_transfer_learning.py
@@ -30,7 +30,11 @@ if __name__ == "__main__":
         detector_name=detector_name,
         with_decoder=False,
     )
-    deeplabcut.create_training_dataset(config_path, weight_init=weight_init)
+    deeplabcut.create_training_dataset(
+        config_path,
+        weight_init=weight_init,
+        net_type=model_name,
+    )
 
     deeplabcut.train_network(
         config_path,

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -349,11 +349,12 @@ def run(
     engine: Engine = Engine.PYTORCH,
     pytorch_cfg_updates: dict | None = None,
     create_labeled_videos: bool = False,
+    ctd_conditions: tuple[int, int] | None = None,
 ) -> None:
     times = [time.time()]
     log_step(f"Testing with net type {net_type}")
     log_step("Creating the training dataset")
-    deeplabcut.create_training_dataset(str(config_path), net_type=net_type, engine=engine)
+    deeplabcut.create_training_dataset(config_path, net_type=net_type, engine=engine, ctd_conditions=ctd_conditions)
     existing_shuffles = get_existing_shuffle_indices(config_path, train_fraction=train_fraction, engine=engine)
     shuffle_index = existing_shuffles[-1]
 

--- a/tests/pose_estimation_pytorch/apis/test_apis_export.py
+++ b/tests/pose_estimation_pytorch/apis/test_apis_export.py
@@ -22,6 +22,8 @@ from ruamel.yaml.scalarstring import SingleQuotedScalarString as SQS
 import deeplabcut.pose_estimation_pytorch.apis.export as export
 import deeplabcut.utils.auxiliaryfunctions as af
 from deeplabcut.pose_estimation_pytorch import Task
+from deeplabcut.pose_estimation_pytorch.config.metadata import PoseMetadata
+from deeplabcut.pose_estimation_pytorch.config.pose import PoseConfig
 from deeplabcut.pose_estimation_pytorch.runners.snapshots import Snapshot
 
 
@@ -93,6 +95,18 @@ def _make_mock_loader(
         loader.model_cfg["detector"] = dict(resume_training_from=None)
 
     return loader
+
+
+def test_wipe_paths_clears_resume_training_from() -> None:
+    cfg = PoseConfig(
+        resume_training_from="/abs/snapshot.pt",
+        metadata=PoseMetadata(project_path=Path("/proj"), pose_config_path=Path("/proj/cfg.yaml")),
+    ).to_dict()
+
+    export.wipe_paths_from_model_config(cfg)
+
+    assert cfg["resume_training_from"] is None
+    assert cfg["metadata"]["project_path"] == ""
 
 
 def _get_export_model_data(

--- a/tests/pose_estimation_pytorch/apis/test_apis_training.py
+++ b/tests/pose_estimation_pytorch/apis/test_apis_training.py
@@ -1,0 +1,57 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Tests for the training API."""
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from deeplabcut.pose_estimation_pytorch.apis.training import train
+from deeplabcut.pose_estimation_pytorch.config import make_pytorch_pose_config
+from deeplabcut.pose_estimation_pytorch.config.pose import PoseConfig
+from deeplabcut.pose_estimation_pytorch.task import Task
+
+
+def _minimal_run_config(tmp_path: Path, *, resume_from: str | None = None) -> PoseConfig:
+    project_cfg = {
+        "multianimalproject": False,
+        "project_path": str(tmp_path),
+        "bodyparts": ["nose"],
+        "uniquebodyparts": [],
+        "individuals": ["mouse"],
+    }
+    cfg_path = tmp_path / "pytorch_config.yaml"
+    defaults = make_pytorch_pose_config(project_cfg, str(cfg_path), net_type="resnet_50")
+    if resume_from is not None:
+        defaults["resume_training_from"] = resume_from
+    return PoseConfig.from_dict(defaults)
+
+
+@patch("deeplabcut.pose_estimation_pytorch.apis.training.build_transforms", return_value=Mock())
+@patch("deeplabcut.pose_estimation_pytorch.apis.training.PoseModel.build", return_value=Mock())
+@patch("deeplabcut.pose_estimation_pytorch.apis.training.build_training_runner", return_value=Mock())
+def test_train_uses_resume_training_from_config(
+    mock_build_runner: Mock,
+    mock_build_model: Mock,
+    mock_build_transforms: Mock,
+    tmp_path: Path,
+) -> None:
+    run_config = _minimal_run_config(tmp_path, resume_from="/train/snapshot-010.pt")
+
+    loader = Mock()
+    loader.model_folder = tmp_path
+    loader.model_cfg = run_config
+    train_dataset = Mock(__len__=Mock(return_value=1))
+    valid_dataset = Mock(__len__=Mock(return_value=1))
+    loader.create_dataset = Mock(side_effect=[train_dataset, valid_dataset])
+
+    train(loader=loader, run_config=run_config, task=Task.BOTTOM_UP, device="cpu", snapshot_path=None)
+
+    assert mock_build_runner.call_args.kwargs["snapshot_path"] == "/train/snapshot-010.pt"

--- a/tests/pose_estimation_pytorch/modelzoo/test_inference_helpers.py
+++ b/tests/pose_estimation_pytorch/modelzoo/test_inference_helpers.py
@@ -33,7 +33,6 @@ def test_create_superanimal_inference_runners_uses_custom_config_path(monkeypatc
         return cfg
 
     monkeypatch.setattr(helpers.PoseConfig, "from_any", fake_from_any)
-    monkeypatch.setattr(helpers, "update_config", lambda config, max_individuals, device: config)
     monkeypatch.setattr(
         helpers,
         "get_inference_runners",
@@ -64,16 +63,15 @@ def test_create_superanimal_inference_runners_uses_custom_config_path(monkeypatc
     assert model_cfg is cfg
 
 
-def test_create_superanimal_inference_runners_uses_deepcopy_for_custom_dict(monkeypatch):
+def test_create_superanimal_inference_runners_does_not_mutate_custom_dict(monkeypatch):
     custom_cfg = _dummy_cfg("TD")
-    monkeypatch.setattr(helpers.PoseConfig, "from_any", copy.deepcopy)
+    original_bodyparts = list(custom_cfg["metadata"]["bodyparts"])
 
-    def fake_update_config(config, max_individuals, device):
-        # Mutate nested structure; caller-owned dict should stay unchanged.
-        config["metadata"]["bodyparts"].append("tail")
-        return config
-
-    monkeypatch.setattr(helpers, "update_config", fake_update_config)
+    monkeypatch.setattr(
+        helpers.PoseConfig,
+        "from_any",
+        lambda config: copy.deepcopy(config),
+    )
     monkeypatch.setattr(
         helpers,
         "get_inference_runners",
@@ -98,22 +96,31 @@ def test_create_superanimal_inference_runners_uses_deepcopy_for_custom_dict(monk
         customized_model_config=custom_cfg,
     )
 
-    assert custom_cfg["metadata"]["bodyparts"] == ["nose"]
-    assert model_cfg["metadata"]["bodyparts"] == ["nose", "tail"]
+    assert custom_cfg["metadata"]["bodyparts"] == original_bodyparts
+    assert model_cfg is not custom_cfg
 
 
 @pytest.mark.parametrize("input_device", ["auto", None])
 def test_create_superanimal_inference_runners_auto_device_selection(monkeypatch, input_device):
-    cfg = _dummy_cfg("TD")
     captured = {}
 
-    monkeypatch.setattr(helpers.PoseConfig, "from_any", lambda config: cfg)
-
-    def fake_update_config(config, max_individuals, device):
+    def fake_build_for_superanimal_inference(
+        cls,
+        super_animal,
+        *,
+        model_name,
+        detector_name=None,
+        max_individuals=30,
+        device=None,
+    ):
         captured["device"] = device
-        return config
+        return _dummy_cfg("TD")
 
-    monkeypatch.setattr(helpers, "update_config", fake_update_config)
+    monkeypatch.setattr(
+        helpers.PoseConfig,
+        "build_for_superanimal_inference",
+        classmethod(fake_build_for_superanimal_inference),
+    )
     monkeypatch.setattr(
         helpers,
         "get_inference_runners",
@@ -135,7 +142,7 @@ def test_create_superanimal_inference_runners_auto_device_selection(monkeypatch,
         superanimal_name="superanimal_quadruped",
         model_name="hrnet_w32",
         detector_name="fasterrcnn_resnet50_fpn_v2",
-        customized_model_config="/tmp/custom_model_cfg.yaml",
+        customized_model_config=None,
         device=input_device,
     )
     assert captured["device"] == "auto"
@@ -154,10 +161,13 @@ def test_create_superanimal_inference_runners_raises_for_fmpose3d():
 def test_create_superanimal_inference_runners_propagates_unsupported_dataset_error(
     monkeypatch,
 ):
+    def fake_build_for_superanimal_inference(cls, *args, **kwargs):
+        raise ValueError("Unsupported dataset for model zoo config")
+
     monkeypatch.setattr(
-        helpers,
-        "load_super_animal_config",
-        lambda **kwargs: (_ for _ in ()).throw(ValueError("Unsupported dataset for model zoo config")),
+        helpers.PoseConfig,
+        "build_for_superanimal_inference",
+        classmethod(fake_build_for_superanimal_inference),
     )
 
     with pytest.raises(ValueError, match="Unsupported dataset"):


### PR DESCRIPTION
The construction of configs used to be a bit of a spaghetti of loading yamls, adjusting fields midway, and then updating them once more in the API calls, such as train_network. 

The structured configs refactor improved this a bit, but there was a mixed state with validation halfway construction, requiring the need for nullable fields and moving a lot back and forth between dicts and types.


This PR aims to move construction of configs for a specific deeplabcut project or deeplabcut net type to a canonical `build()` method on the structured configs themselves. 

The construction is now always split in two steps. E.g. for PoseConfig:
1. build the defaults _dictionary_ from the yaml (given a `net_type`, derived from ProjectConfig + build args) 
2. construct a validated PoseConfig from the defaults

API calls can still update the PoseConfig with overrides (e.g. `train_network`), but these overrides are never _required_: the validated PoseConfig is always considered a fully initialized model that can be used downstream. 