### PR TITLE
Fix NaN handling in PredictKeypointIdentities postprocessor

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/data/postprocessor.py
+++ b/deeplabcut/pose_estimation_pytorch/data/postprocessor.py
@@ -504,13 +504,17 @@ class PredictKeypointIdentities(Postprocessor):
 
         id_score_matrix = np.zeros((num_preds, num_keypoints, num_ids))
         for pred_idx, individual_keypoints in enumerate(pose):
-            heatmap_indices = np.rint(individual_keypoints).astype(int)
+            xy = individual_keypoints[:, :2]
+            valid = np.all(np.isfinite(xy), axis=1)
+
+            heatmap_indices = np.zeros((num_keypoints, 2), dtype=int)
+            if np.any(valid):
+                heatmap_indices[valid] = np.rint(xy[valid]).astype(int)
             xs = np.clip(heatmap_indices[:, 0], 0, w - 1)
             ys = np.clip(heatmap_indices[:, 1], 0, h - 1)
-
-            # get the score from each identity heatmap at each predicted keypoint
             for kpt_idx, (x, y) in enumerate(zip(xs, ys, strict=False)):
-                id_score_matrix[pred_idx, kpt_idx] = identity_heatmap[y, x, :]
+                if valid[kpt_idx]:
+                    id_score_matrix[pred_idx, kpt_idx] = identity_heatmap[y, x, :]
 
         predictions[self.identity_key] = id_score_matrix
         if not self.keep_id_maps:

--- a/deeplabcut/pose_estimation_pytorch/data/postprocessor.py
+++ b/deeplabcut/pose_estimation_pytorch/data/postprocessor.py
@@ -508,8 +508,7 @@ class PredictKeypointIdentities(Postprocessor):
             valid = np.all(np.isfinite(xy), axis=1)
 
             heatmap_indices = np.zeros((num_keypoints, 2), dtype=int)
-            if np.any(valid):
-                heatmap_indices[valid] = np.rint(xy[valid]).astype(int)
+            heatmap_indices[valid] = np.rint(xy[valid]).astype(int)
             xs = np.clip(heatmap_indices[:, 0], 0, w - 1)
             ys = np.clip(heatmap_indices[:, 1], 0, h - 1)
             for kpt_idx, (x, y) in enumerate(zip(xs, ys, strict=False)):

--- a/tests/pose_estimation_pytorch/data/test_postprocessor.py
+++ b/tests/pose_estimation_pytorch/data/test_postprocessor.py
@@ -379,3 +379,45 @@ def test_remove_low_confidence_boxes(data):
 
     np.testing.assert_array_equal(predictions["bboxes"], expected_bboxes)
     np.testing.assert_array_equal(predictions["bbox_scores"], expected_scores)
+
+
+def test_predict_keypoint_identities_handles_nan_keypoints():
+    import warnings
+
+    p = PredictKeypointIdentities(
+        identity_key="keypoint_identity",
+        identity_map_key="identity_map",
+        pose_key="bodyparts",
+        keep_id_maps=True,
+    )
+
+    # PAF-style output: (num_individuals, num_bodyparts, 5); missing joint is all-NaN
+    bodyparts = np.array(
+        [
+            [
+                [3.1, 1.0, 0.8, 0.0, 0.5],  # valid
+                [np.nan, np.nan, np.nan, np.nan, np.nan],  # missing (assembler default)
+                [1.0, 0.0, 0.9, 1.0, 0.5],  # valid
+            ],
+        ]
+    )
+    id_heatmap = np.array(
+        [
+            [[0.1, 0.1], [0.2, 0.1], [0.3, 0.1], [0.4, 0.1]],
+            [[0.1, 0.2], [0.2, 0.2], [0.3, 0.2], [0.4, 0.2]],
+            [[0.1, 0.3], [0.2, 0.3], [0.3, 0.3], [0.4, 0.3]],
+            [[0.1, 0.4], [0.2, 0.4], [0.3, 0.4], [0.4, 0.4]],
+        ]
+    )
+    predictions_in = {"bodyparts": bodyparts, "identity_map": id_heatmap}
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        predictions, _ = p(predictions_in, {})
+
+    expected = np.zeros((1, 3, 2))
+    expected[0, 0] = id_heatmap[1, 3]  # rint(3.1, 1.0) -> (3, 1)
+    expected[0, 1] = 0.0  # NaN keypoint: leave identity scores at zero
+    expected[0, 2] = id_heatmap[0, 1]  # rint(1.0, 0.0) -> (1, 0)
+
+    np.testing.assert_array_equal(predictions["keypoint_identity"], expected)


### PR DESCRIPTION
**Summary**
Fixes #3376 - RuntimeWarning: invalid value encountered in cast during analyze_videos on multi-animal models with identity enabled. PAF assembly leaves missing bodyparts as NaN; PredictKeypointIdentities now indexes the identity heatmap using only finite x/y coordinates and skips invalid keypoints.

Added a new test that reproduces the original issue, which is now fixed: tests/pose_estimation_pytorch/data/test_postprocessor.py::test_predict_keypoint_identities_handles_nan_keypoints