### PR TITLE
GUI: use importlib.resources instead of manual path construction

### DIFF
--- a/deeplabcut/gui/__init__.py
+++ b/deeplabcut/gui/__init__.py
@@ -15,8 +15,7 @@ from importlib.resources import files
 os.environ["QT_API"] = "pyside6"
 import qtpy  # Necessary unused import to properly store the env variable
 
-BASE_DIR = os.path.dirname(__file__)
-
+STYLE_PATH = files("deeplabcut.gui") / "style.qss"
 ASSETS = files("deeplabcut.gui.assets")
 LOGO_PATH = ASSETS / "logo.png"
 LOGO_TRANSPARENT_PATH = ASSETS / "logo_transparent.png"

--- a/deeplabcut/gui/__init__.py
+++ b/deeplabcut/gui/__init__.py
@@ -17,6 +17,7 @@ import qtpy  # Necessary unused import to properly store the env variable
 
 STYLE_PATH = files("deeplabcut.gui") / "style.qss"
 ASSETS = files("deeplabcut.gui.assets")
+MEDIA = files("deeplabcut.gui.media")
 LOGO_PATH = ASSETS / "logo.png"
 LOGO_TRANSPARENT_PATH = ASSETS / "logo_transparent.png"
 WELCOME_PATH = ASSETS / "welcome.png"

--- a/deeplabcut/gui/__init__.py
+++ b/deeplabcut/gui/__init__.py
@@ -10,8 +10,14 @@
 #
 
 import os
+from importlib.resources import files
 
 os.environ["QT_API"] = "pyside6"
 import qtpy  # Necessary unused import to properly store the env variable
 
 BASE_DIR = os.path.dirname(__file__)
+
+ASSETS = files("deeplabcut.gui.assets")
+LOGO_PATH = ASSETS / "logo.png"
+LOGO_TRANSPARENT_PATH = ASSETS / "logo_transparent.png"
+WELCOME_PATH = ASSETS / "welcome.png"

--- a/deeplabcut/gui/assets/__init__.py
+++ b/deeplabcut/gui/assets/__init__.py
@@ -1,0 +1,10 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/master/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#

--- a/deeplabcut/gui/components.py
+++ b/deeplabcut/gui/components.py
@@ -18,6 +18,7 @@ from PySide6.QtCore import Qt, Slot
 from PySide6.QtGui import QIcon
 
 from deeplabcut.core.config import read_config_as_dict
+from deeplabcut.gui import LOGO_PATH
 from deeplabcut.gui.dlc_params import DLCParams
 from deeplabcut.gui.widgets import ConfigEditor
 
@@ -672,9 +673,7 @@ def _create_message_box(text, info_text):
 
     msg.setWindowTitle("Info")
     msg.setMinimumWidth(900)
-    logo_dir = os.path.dirname(os.path.realpath("logo.png")) + os.path.sep
-    logo = logo_dir + "/assets/logo.png"
-    msg.setWindowIcon(QIcon(logo))
+    msg.setWindowIcon(QIcon(str(LOGO_PATH)))
     msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
     return msg
 
@@ -687,9 +686,7 @@ def _create_confirmation_box(title, description):
 
     msg.setWindowTitle("Confirmation")
     msg.setMinimumWidth(900)
-    logo_dir = os.path.dirname(os.path.realpath("logo.png")) + os.path.sep
-    logo = logo_dir + "/assets/logo.png"
-    msg.setWindowIcon(QIcon(logo))
+    msg.setWindowIcon(QIcon(str(LOGO_PATH)))
     msg.setStandardButtons(QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No)
     return msg
 

--- a/deeplabcut/gui/launch_script.py
+++ b/deeplabcut/gui/launch_script.py
@@ -19,7 +19,6 @@ Licensed under GNU Lesser General Public License v3.0
 
 """
 
-import os
 import sys
 
 import PySide6.QtWidgets as QtWidgets
@@ -27,7 +26,7 @@ import qdarkstyle
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon, QPixmap
 
-from deeplabcut.gui import BASE_DIR, LOGO_PATH, WELCOME_PATH
+from deeplabcut.gui import LOGO_PATH, STYLE_PATH, WELCOME_PATH
 
 
 def launch_dlc():
@@ -38,9 +37,7 @@ def launch_dlc():
     splash = QtWidgets.QSplashScreen(pixmap)
     splash.show()
 
-    stylefile = os.path.join(BASE_DIR, "style.qss")
-    with open(stylefile) as f:
-        app.setStyleSheet(f.read())
+    app.setStyleSheet(STYLE_PATH.read_text(encoding="utf-8"))
 
     dark_stylesheet = qdarkstyle.load_stylesheet_pyside2()
     app.setStyleSheet(dark_stylesheet)

--- a/deeplabcut/gui/launch_script.py
+++ b/deeplabcut/gui/launch_script.py
@@ -27,16 +27,14 @@ import qdarkstyle
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon, QPixmap
 
-from deeplabcut.gui import BASE_DIR
+from deeplabcut.gui import BASE_DIR, LOGO_PATH, WELCOME_PATH
 
 
 def launch_dlc():
     app = QtWidgets.QApplication(sys.argv)
-    app.setWindowIcon(QIcon(os.path.join(BASE_DIR, "assets", "logo.png")))
+    app.setWindowIcon(QIcon(str(LOGO_PATH)))
     screen_size = app.screens()[0].size()
-    pixmap = QPixmap(os.path.join(BASE_DIR, "assets", "welcome.png")).scaledToWidth(
-        int(0.7 * screen_size.width()), Qt.SmoothTransformation
-    )
+    pixmap = QPixmap(str(WELCOME_PATH)).scaledToWidth(int(0.7 * screen_size.width()), Qt.SmoothTransformation)
     splash = QtWidgets.QSplashScreen(pixmap)
     splash.show()
 

--- a/deeplabcut/gui/tabs/create_project.py
+++ b/deeplabcut/gui/tabs/create_project.py
@@ -15,7 +15,7 @@ from PySide6 import QtCore, QtWidgets
 from PySide6.QtGui import QBrush, QColor, QDesktopServices, QIcon, QPainter, QPen
 
 from deeplabcut.create_project import create_new_project, create_new_project_3d
-from deeplabcut.gui import BASE_DIR
+from deeplabcut.gui import ASSETS
 from deeplabcut.gui.dlc_params import DLCParams
 from deeplabcut.gui.tabs.docs import (
     URL_3D,
@@ -235,7 +235,7 @@ class ProjectCreator(QtWidgets.QDialog):
         self.loc_line = QtWidgets.QLineEdit(self.loc_default, user_frame)
         self.loc_line.setReadOnly(True)
         action = self.loc_line.addAction(
-            QIcon(os.path.join(BASE_DIR, "assets", "icons", "open2.png")),
+            QIcon(str(ASSETS / "icons" / "open2.png")),
             QtWidgets.QLineEdit.TrailingPosition,
         )
         action.triggered.connect(self.on_click)

--- a/deeplabcut/gui/tabs/modelzoo.py
+++ b/deeplabcut/gui/tabs/modelzoo.py
@@ -8,7 +8,6 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
-import os
 import webbrowser
 from functools import partial
 from pathlib import Path
@@ -20,7 +19,7 @@ from PySide6.QtGui import QIcon, QPixmap, QRegularExpressionValidator
 
 import deeplabcut
 from deeplabcut.core.engine import Engine
-from deeplabcut.gui import BASE_DIR
+from deeplabcut.gui import ASSETS
 from deeplabcut.gui.components import (
     DefaultTab,
     VideoSelectionWidget,
@@ -213,7 +212,7 @@ class ModelZoo(DefaultTab):
         )
         self.loc_line.setReadOnly(True)
         action = self.loc_line.addAction(
-            QIcon(os.path.join(BASE_DIR, "assets", "icons", "open2.png")),
+            QIcon(str(ASSETS / "icons" / "open2.png")),
             QtWidgets.QLineEdit.TrailingPosition,
         )
         action.triggered.connect(self.select_folder)
@@ -251,7 +250,7 @@ class ModelZoo(DefaultTab):
         validator.validationChanged.connect(self._handle_validation_change)
         self.scales_line.setValidator(validator)
         tooltip_label = QtWidgets.QLabel()
-        tooltip_label.setPixmap(QPixmap(os.path.join(BASE_DIR, "assets", "icons", "help2.png")).scaledToWidth(30))
+        tooltip_label.setPixmap(QPixmap(str(ASSETS / "icons" / "help2.png")).scaledToWidth(30))
         tooltip_label.setToolTip(
             "Approximate animal sizes in pixels, for spatial pyramid search. If left "
             "blank, defaults to video height +/- 50 pixels"
@@ -269,7 +268,7 @@ class ModelZoo(DefaultTab):
         self.adapt_checkbox.setStyleSheet("font-weight: bold; font-size: 16px; padding: 6px 12px;")
         # Add help button
         adapt_help_btn = QtWidgets.QToolButton()
-        adapt_help_btn.setIcon(QIcon(os.path.join(BASE_DIR, "assets", "icons", "help2.png")))
+        adapt_help_btn.setIcon(QIcon(str(ASSETS / "icons" / "help2.png")))
         adapt_help_btn.setIconSize(QSize(24, 24))
         adapt_help_btn.setToolTip("What is video adaptation?")
 

--- a/deeplabcut/gui/tabs/open_project.py
+++ b/deeplabcut/gui/tabs/open_project.py
@@ -13,6 +13,8 @@ import os
 from PySide6 import QtCore, QtWidgets
 from PySide6.QtGui import QIcon
 
+from deeplabcut.gui import LOGO_PATH
+
 
 class OpenProject(QtWidgets.QDialog):
     def __init__(self, parent):
@@ -76,17 +78,12 @@ class OpenProject(QtWidgets.QDialog):
 
             msg.setWindowTitle("Error")
             msg.setMinimumWidth(400)
-            self.logo_dir = os.path.dirname(os.path.realpath("logo.png")) + os.path.sep
-            self.logo = self.logo_dir + "/assets/logo.png"
-            msg.setWindowIcon(QIcon(self.logo))
+            msg.setWindowIcon(QIcon(str(LOGO_PATH)))
             msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
             msg.exec_()
 
             self.loaded = False
         else:
-            self.logo_dir = os.path.dirname(os.path.realpath("logo.png")) + os.path.sep
-            self.logo = self.logo_dir + "/assets/logo.png"
-
             self.loaded = True
             self.accept()
             self.close()

--- a/deeplabcut/gui/tabs/train_network.py
+++ b/deeplabcut/gui/tabs/train_network.py
@@ -10,7 +10,6 @@
 #
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 
 from PySide6 import QtWidgets
@@ -19,6 +18,7 @@ from PySide6.QtGui import QIcon
 
 import deeplabcut.compat as compat
 from deeplabcut.core.engine import Engine
+from deeplabcut.gui import LOGO_PATH
 from deeplabcut.gui.components import (
     DefaultTab,
     ShuffleSpinBox,
@@ -244,9 +244,7 @@ class TrainNetwork(DefaultTab):
 
         msg.setWindowTitle("Info")
         msg.setMinimumWidth(900)
-        self.logo_dir = os.path.dirname(os.path.realpath("logo.png")) + os.path.sep
-        self.logo = self.logo_dir + "/assets/logo.png"
-        msg.setWindowIcon(QIcon(self.logo))
+        msg.setWindowIcon(QIcon(str(LOGO_PATH)))
         msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
         msg.exec_()
 

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -37,7 +37,7 @@ from deeplabcut import __version__ as DLC_VERSION
 from deeplabcut import auxiliaryfunctions, compat
 from deeplabcut.core.debug import install_debug_recorder
 from deeplabcut.core.engine import Engine
-from deeplabcut.gui import BASE_DIR, components
+from deeplabcut.gui import ASSETS, LOGO_PATH, LOGO_TRANSPARENT_PATH, components
 from deeplabcut.gui.dialogs import create_generate_debug_log_action
 from deeplabcut.gui.tabs import (
     AnalyzeVideos,
@@ -217,9 +217,7 @@ class MainWindow(QMainWindow):
 
                 msg.setWindowTitle("Info")
                 msg.setMinimumWidth(900)
-                logo_dir = os.path.dirname(os.path.realpath("logo.png")) + os.path.sep
-                logo = logo_dir + "/assets/logo.png"
-                msg.setWindowIcon(QIcon(logo))
+                msg.setWindowIcon(QIcon(str(LOGO_PATH)))
                 msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
                 msg.exec_()
 
@@ -609,8 +607,7 @@ class MainWindow(QMainWindow):
         palette.setColor(QtGui.QPalette.Window, QtGui.QColor("#ffffff"))
         self.setPalette(palette)
 
-        icon = os.path.join(BASE_DIR, "assets", "logo.png")
-        self.setWindowIcon(QIcon(icon))
+        self.setWindowIcon(QIcon(str(LOGO_PATH)))
 
         # Set default window size and allow resizing
         self.resize(
@@ -643,8 +640,7 @@ class MainWindow(QMainWindow):
         image_widget = QtWidgets.QLabel(self)
         image_widget.setAlignment(Qt.AlignCenter)
         image_widget.setContentsMargins(0, 0, 0, 0)
-        logo = os.path.join(BASE_DIR, "assets", "logo_transparent.png")
-        pixmap = QtGui.QPixmap(logo)
+        pixmap = QtGui.QPixmap(str(LOGO_TRANSPARENT_PATH))
         image_widget.setPixmap(pixmap.scaledToHeight(400, QtCore.Qt.SmoothTransformation))
         self.layout.addWidget(image_widget)
         description = (
@@ -700,7 +696,7 @@ class MainWindow(QMainWindow):
         self.newAction = QAction(self)
         self.newAction.setText("&New Project...")
 
-        self.newAction.setIcon(QIcon(os.path.join(BASE_DIR, "assets", "icons", names[0])))
+        self.newAction.setIcon(QIcon(str(ASSETS / "icons" / names[0])))
         self.newAction.setShortcut("Ctrl+N")
         self.newAction.setStatusTip("Create a new project...")
 
@@ -708,7 +704,7 @@ class MainWindow(QMainWindow):
 
         # Creating actions using the second constructor
         self.openAction = QAction("&Open...", self)
-        self.openAction.setIcon(QIcon(os.path.join(BASE_DIR, "assets", "icons", names[1])))
+        self.openAction.setIcon(QIcon(str(ASSETS / "icons" / names[1])))
         self.openAction.setShortcut("Ctrl+O")
         self.openAction.setStatusTip("Open a project...")
         self.openAction.triggered.connect(self._open_project)
@@ -722,7 +718,7 @@ class MainWindow(QMainWindow):
         self.darkmodeAction.triggered.connect(self.darkmode)
 
         self.helpAction = QAction("&Help", self)
-        self.helpAction.setIcon(QIcon(os.path.join(BASE_DIR, "assets", "icons", names[2])))
+        self.helpAction.setIcon(QIcon(str(ASSETS / "icons" / names[2])))
         self.helpAction.setStatusTip("Ask for help...")
         self.helpAction.triggered.connect(self._ask_for_help)
 

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -13,7 +13,6 @@ import os
 import sys
 import warnings
 from functools import cached_property
-from importlib.resources import files
 from importlib.util import find_spec
 from pathlib import Path
 
@@ -37,7 +36,7 @@ from deeplabcut import __version__ as DLC_VERSION
 from deeplabcut import auxiliaryfunctions, compat
 from deeplabcut.core.debug import install_debug_recorder
 from deeplabcut.core.engine import Engine
-from deeplabcut.gui import ASSETS, LOGO_PATH, LOGO_TRANSPARENT_PATH, components
+from deeplabcut.gui import ASSETS, LOGO_PATH, LOGO_TRANSPARENT_PATH, MEDIA, components
 from deeplabcut.gui.dialogs import create_generate_debug_log_action
 from deeplabcut.gui.tabs import (
     AnalyzeVideos,
@@ -794,7 +793,7 @@ class MainWindow(QMainWindow):
         engine_icon.setStyleSheet("background: transparent;")
 
         def _update_icon(engine: str):
-            file = files("deeplabcut.gui.media") / f"dlc-{engine}.png"
+            file = MEDIA / f"dlc-{engine}.png"
             pixmap = QPixmap(str(file))
             if not pixmap.isNull():
                 engine_icon.setPixmap(pixmap.scaled(56, 56, Qt.AspectRatioMode.KeepAspectRatio))


### PR DESCRIPTION
This PR builds on top of #3349 and is related to #3350. Together these PRs enforce more robust path resolution across the codebase. 

**Summary**
This PR replaces all manual path constructions in the GUI (for accessing the assets, like the logo, etc) with `importlib.resources`. This loads correctly regardless of the process working directory, editable installs, or where the user launched the GUI from and should be the canonical way to load GUI assets. It was already implemented in some places, but now made more consistent.