### PR TITLE
Re-enable mdformat for dev-docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,15 +90,7 @@ repos:
       - id: mdformat
         additional_dependencies:
           - mdformat-myst
-        files: ^docs/.*\.md$
-        stages: [pre-commit]
-
-  - repo: https://github.com/hukkin/mdformat
-    rev: 1.0.0
-    hooks:
-      - id: mdformat
-        additional_dependencies:
-          - mdformat-mkdocs==5.2.0
+          - mdformat-mkdocs==5.2.1
         args: [--ignore-missing-references]
         files: ^dev-docs/.*\.md$
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -84,13 +84,24 @@ repos:
         args: [--check, --diff]
         stages: [manual]
 
+  # docs/ and dev-docs/ use different MkDocs/Markdown dialects, so each tree gets its
+  # own mdformat hook with the matching plugin (see https://github.com/hukkin/mdformat/issues/546).
   - repo: https://github.com/hukkin/mdformat
     rev: 1.0.0
     hooks:
       - id: mdformat
+        name: mdformat (docs — myst)
         additional_dependencies:
           - mdformat-myst
+        files: ^docs/.*\.md$
+        stages: [pre-commit]
+
+      - id: mdformat
+        name: mdformat (dev-docs — mkdocs)
+        additional_dependencies:
           - mdformat-mkdocs==5.2.1
+        # Autoref targets may not resolve in the formatter env; without this flag,
+        # mdformat-mkdocs can rewrite links incorrectly (see KyleKing/mdformat-mkdocs#80).
         args: [--ignore-missing-references]
         files: ^dev-docs/.*\.md$
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,17 +93,15 @@ repos:
         files: ^docs/.*\.md$
         stages: [pre-commit]
 
-  # - repo: https://github.com/hukkin/mdformat
-  # Broken currently, replaces all autorefs with broken escaped links.
-  # See https://github.com/KyleKing/mdformat-mkdocs/issues/80
-  #   rev: 1.0.0
-  #   hooks:
-  #     - id: mdformat
-  #       additional_dependencies:
-  #         - mdformat-mkdocs==5.2.0b2
-  #       files: ^dev-docs/.*\.md$
-  #       stages: [pre-commit]
-
+  - repo: https://github.com/hukkin/mdformat
+    rev: 1.0.0
+    hooks:
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-mkdocs==5.2.0
+        args: [--ignore-missing-references]
+        files: ^dev-docs/.*\.md$
+        stages: [pre-commit]
 
   # check only, no modifications
   - repo: local

--- a/dev-docs/docs/developer-guides/dataprep.md
+++ b/dev-docs/docs/developer-guides/dataprep.md
@@ -121,11 +121,13 @@ train_dataset = loader.create_dataset(
 COCO JSON files can specify image paths in two ways:
 
 1. **Relative paths**: Resolved to the `images/` folder
-   - `"file_name": "img0000.png"` → `/path/to/COCOProject/images/img0000.png`
-   - `"file_name": "subfolder/img0000.png"` → `/path/to/COCOProject/images/subfolder/img0000.png`
 
-2. **Absolute paths**: Used directly without resolution
-   - `"file_name": "/data/disk2/images/img0000.png"` → `/data/disk2/images/img0000.png`
+    - `"file_name": "img0000.png"` → `/path/to/COCOProject/images/img0000.png`
+    - `"file_name": "subfolder/img0000.png"` → `/path/to/COCOProject/images/subfolder/img0000.png`
+
+1. **Absolute paths**: Used directly without resolution
+
+    - `"file_name": "/data/disk2/images/img0000.png"` → `/data/disk2/images/img0000.png`
 
 This allows you to keep images on different disks or reuse images across projects without duplication.
 

--- a/dev-docs/docs/developer-guides/inference.md
+++ b/dev-docs/docs/developer-guides/inference.md
@@ -59,8 +59,6 @@ When `deeplabcut.pose_estimation_pytorch.apis.videos.video_inference` is called 
 
 You can easily do so by writing a bit of custom code, as shown in the example below:
 
-
-
 ```python
 from deeplabcut.core.config import read_config_as_dict
 from pathlib import Path

--- a/dev-docs/docs/developer-guides/models.md
+++ b/dev-docs/docs/developer-guides/models.md
@@ -19,6 +19,7 @@ Backbones are feature extraction networks that process input images and produce 
 All backbones inherit from [`BaseBackbone`][deeplabcut.pose_estimation_pytorch.models.backbones.BaseBackbone] and must define a stride property indicating the downsampling factor.
 
 **Example:**
+
 ```python
 from deeplabcut.pose_estimation_pytorch.models.backbones import BACKBONES
 
@@ -38,6 +39,7 @@ All necks inherit from [`BaseNeck`][deeplabcut.pose_estimation_pytorch.models.ne
 Heads are task-specific output layers that produce the final predictions. The [`deeplabcut.pose_estimation_pytorch.models.heads`][] module contains various head architectures for different pose estimation approaches.
 
 Each head contains:
+
 - A **predictor** to convert model outputs to keypoint locations
 - A **target generator** to create training targets from annotations
 - A **criterion** to compute the loss
@@ -46,6 +48,7 @@ Each head contains:
 All heads inherit from [`BaseHead`][deeplabcut.pose_estimation_pytorch.models.heads.BaseHead] and output a dictionary mapping output names to tensors.
 
 **Example:**
+
 ```python
 from deeplabcut.pose_estimation_pytorch.models.heads import HEADS
 


### PR DESCRIPTION
## Re-enable mdformat for dev-docs

### Problem

`dev-docs/` markdown formatting was disabled in pre-commit after [mdformat-mkdocs#80](https://github.com/KyleKing/mdformat-mkdocs/issues/80): the plugin could rewrite MkDocs autoref links into broken escaped links. This came from [#3353](https://github.com/DeepLabCut/DeepLabCut/pull/3353), which added `dev-docs/` to mdformat and then commented the hook out again because of the aforementioned issue. 

### Fix

Thanks to [@KyleKing](https://github.com/KyleKing) for `df7394f6` and `79e245b8` (see https://github.com/deruyter92/DeepLabCut/pull/4):

- Re-enable `mdformat-mkdocs` for `dev-docs/**/*.md` (pinned to `5.2.1`)
- Use `--ignore-missing-references` so unresolved autoref targets are left alone ([mdformat-mkdocs#80](https://github.com/KyleKing/mdformat-mkdocs/issues/80))
- Run an initial formatting pass on a few dev-docs pages

`b5fb4519` restores **two separate hooks** — `mdformat-myst` for `docs/`, `mdformat-mkdocs` for `dev-docs/` — per [hukkin/mdformat#546](https://github.com/hukkin/mdformat/issues/546), with brief comments explaining the split and the `--ignore-missing-references` flag.

### Related

- DeepLabCut [#3353](https://github.com/DeepLabCut/DeepLabCut/pull/3353)
- [KyleKing/mdformat-mkdocs#80](https://github.com/KyleKing/mdformat-mkdocs/issues/80)
- [hukkin/mdformat#546](https://github.com/hukkin/mdformat/issues/546)