### PR TITLE
CI: Introduce functional scripts dependencies in CI test selection

### DIFF
--- a/tests/tools/test_selector/test_selector_decision.py
+++ b/tests/tools/test_selector/test_selector_decision.py
@@ -387,3 +387,8 @@ def test_3d_changes_select_scripts_in_dependency_order():
         "examples/testscript_tensorflow_single_animal.py",
         "examples/testscript_3d.py",
     ]
+    assert (
+        "dependency:examples/testscript_3d.py"
+        in result.provenance.scripts["examples/testscript_tensorflow_single_animal.py"]
+    )
+    assert "3d_pose_estimation" in result.provenance.scripts["examples/testscript_3d.py"]

--- a/tests/tools/test_selector/test_selector_decision.py
+++ b/tests/tools/test_selector/test_selector_decision.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
+from tools import test_selector
+from tools.test_selector import decide, order_functional_scripts
 from tools.test_selector_config import (
     CATEGORY_RULES,
     CategoryRule,
@@ -339,3 +341,49 @@ def test_current_selected_paths_exist():
                 missing.append((rule.name, "script", path))
 
     assert missing == []
+
+
+def test_3d_script_includes_tensorflow_prerequisite():
+    scripts = order_functional_scripts({"examples/testscript_3d.py"})
+
+    assert scripts == [
+        "examples/testscript_tensorflow_single_animal.py",
+        "examples/testscript_3d.py",
+    ]
+
+
+def test_explicit_dependency_is_not_duplicated():
+    scripts = order_functional_scripts(
+        {
+            "examples/testscript_tensorflow_single_animal.py",
+            "examples/testscript_3d.py",
+        }
+    )
+
+    assert scripts == [
+        "examples/testscript_tensorflow_single_animal.py",
+        "examples/testscript_3d.py",
+    ]
+
+
+def test_functional_script_dependency_cycle(monkeypatch):
+    monkeypatch.setattr(
+        test_selector,
+        "FUNC_SCRIPT_DEPENDENCIES",
+        {
+            "a.py": ("b.py",),
+            "b.py": ("a.py",),
+        },
+    )
+
+    with pytest.raises(ValueError, match="Cyclic"):
+        order_functional_scripts({"a.py"})
+
+
+def test_3d_changes_select_scripts_in_dependency_order():
+    result = decide(["deeplabcut/pose_estimation_3d/plotting3D.py"])
+
+    assert result.functional_scripts == [
+        "examples/testscript_tensorflow_single_animal.py",
+        "examples/testscript_3d.py",
+    ]

--- a/tools/test_selector.py
+++ b/tools/test_selector.py
@@ -334,6 +334,49 @@ def _matches_any(path: str, preds: Sequence[Callable[[str], bool]]) -> bool:
     return False
 
 
+def resolve_functional_scripts(
+    selected: set[str],
+) -> tuple[list[str], dict[str, set[str]]]:
+    """Expand and dependency-order functional scripts.
+
+    Returns:
+        ordered
+            Selected scripts and their transitive dependencies, with each
+            dependency appearing before scripts that depend on it.
+        dependency_sources
+            Provenance entries for every dependency added during expansion.
+    """
+    ordered: list[str] = []
+    dependency_sources: dict[str, set[str]] = defaultdict(set)
+    visited: set[str] = set()
+    visiting: set[str] = set()
+
+    def visit(script: str) -> None:
+        if script in visited:
+            return
+
+        if script in visiting:
+            raise ValueError(f"Cyclic functional-script dependency involving {script!r}")
+
+        visiting.add(script)
+
+        for dependency in FUNC_SCRIPT_DEPENDENCIES.get(
+            script,
+            (),
+        ):
+            dependency_sources[dependency].add(f"dependency:{script}")
+            visit(dependency)
+
+        visiting.remove(script)
+        visited.add(script)
+        ordered.append(script)
+
+    for script in sorted(selected):
+        visit(script)
+
+    return ordered, dependency_sources
+
+
 def order_functional_scripts(
     selected: set[str],
 ) -> list[str]:
@@ -534,22 +577,17 @@ def decide(files: list[str]) -> SelectorResult:
         fast_reasons.append("fallback_minimal_pytest")
     lane_reasons["fast"] = fast_reasons
 
-    ordered_functional_scripts = order_functional_scripts(functional_set)
-
-    for dependent in functional_set:
-        for dependency in FUNC_SCRIPT_DEPENDENCIES.get(
-            dependent,
-            (),
-        ):
-            script_sources[dependency].add(f"dependency:{dependent}")
+    ordered_functional_scripts, dependency_sources = resolve_functional_scripts(functional_set)
+    for scrpt, srcs in dependency_sources.items():
+        script_sources[scrpt].update(srcs)
 
     return SelectorResult(
         lanes=lanes,
         pytest_paths=sorted(pytest_paths_set),
         functional_scripts=ordered_functional_scripts,
         provenance=SelectionProvenance(
-            pytest={k: sorted(v) for k, v in sorted(pytest_sources.items())},
-            scripts={k: sorted(v) for k, v in sorted(script_sources.items())},
+            pytest={path: sorted(sources) for path, sources in sorted(pytest_sources.items())},
+            scripts={path: sorted(sources) for path, sources in sorted(script_sources.items())},
         ),
         reasons=reasons,
         changed_files=files,

--- a/tools/test_selector.py
+++ b/tools/test_selector.py
@@ -65,6 +65,7 @@ try:
         CATEGORY_RULE_BY_NAME,
         CATEGORY_RULES,
         FULL_SUITE_TRIGGERS,
+        FUNC_SCRIPT_DEPENDENCIES,
         LINT_ONLY_FILES,
         MINIMAL_PYTEST,
     )
@@ -75,6 +76,7 @@ except ImportError:  # pragma: no cover
         CATEGORY_RULE_BY_NAME,
         CATEGORY_RULES,
         FULL_SUITE_TRIGGERS,
+        FUNC_SCRIPT_DEPENDENCIES,
         LINT_ONLY_FILES,
         MINIMAL_PYTEST,
     )
@@ -332,6 +334,39 @@ def _matches_any(path: str, preds: Sequence[Callable[[str], bool]]) -> bool:
     return False
 
 
+def order_functional_scripts(
+    selected: set[str],
+) -> list[str]:
+    """Expand and order functional scripts after their dependencies."""
+    ordered: list[str] = []
+    visited: set[str] = set()
+    visiting: set[str] = set()
+
+    def visit(script: str) -> None:
+        if script in visited:
+            return
+
+        if script in visiting:
+            raise ValueError(f"Cyclic functional-script dependency involving {script!r}")
+
+        visiting.add(script)
+
+        for dependency in FUNC_SCRIPT_DEPENDENCIES.get(
+            script,
+            (),
+        ):
+            visit(dependency)
+
+        visiting.remove(script)
+        visited.add(script)
+        ordered.append(script)
+
+    for script in sorted(selected):
+        visit(script)
+
+    return ordered
+
+
 def decide(files: list[str]) -> SelectorResult:
     reasons: list[str] = []
     lane_reasons: dict[str, list[str]] = {}
@@ -499,10 +534,19 @@ def decide(files: list[str]) -> SelectorResult:
         fast_reasons.append("fallback_minimal_pytest")
     lane_reasons["fast"] = fast_reasons
 
+    ordered_functional_scripts = order_functional_scripts(functional_set)
+
+    for dependent in functional_set:
+        for dependency in FUNC_SCRIPT_DEPENDENCIES.get(
+            dependent,
+            (),
+        ):
+            script_sources[dependency].add(f"dependency:{dependent}")
+
     return SelectorResult(
         lanes=lanes,
         pytest_paths=sorted(pytest_paths_set),
-        functional_scripts=sorted(functional_set),
+        functional_scripts=ordered_functional_scripts,
         provenance=SelectionProvenance(
             pytest={k: sorted(v) for k, v in sorted(pytest_sources.items())},
             scripts={k: sorted(v) for k, v in sorted(script_sources.items())},

--- a/tools/test_selector.py
+++ b/tools/test_selector.py
@@ -578,8 +578,8 @@ def decide(files: list[str]) -> SelectorResult:
     lane_reasons["fast"] = fast_reasons
 
     ordered_functional_scripts, dependency_sources = resolve_functional_scripts(functional_set)
-    for scrpt, srcs in dependency_sources.items():
-        script_sources[scrpt].update(srcs)
+    for script, srcs in dependency_sources.items():
+        script_sources[script].update(srcs)
 
     return SelectorResult(
         lanes=lanes,

--- a/tools/test_selector_config.py
+++ b/tools/test_selector_config.py
@@ -10,6 +10,10 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 PathPred = Callable[[str], bool]
 
+FUNC_SCRIPT_DEPENDENCIES: dict[str, tuple[str, ...]] = {
+    "examples/testscript_3d.py": ("examples/testscript_tensorflow_single_animal.py",),
+}
+
 
 def prefix(*values: str) -> PathPred:
     """Match if path starts with any of the given prefixes."""


### PR DESCRIPTION
Add functional script dependency support to the test selector so prerequisite scripts run first. 

- Introduce `FUNC_SCRIPT_DEPENDENCIES` (including the 3D -> tensorflow single animal prerequisite)
- Apply dependency-aware ordering with cycle detection, and keep provenance by tagging dependency-driven selections. 
- Expand selector tests to cover ordering, deduplication, cycle errors, and 3D change-driven script selection.

Fixes the current fast lane failures related to the 3D script running too early.