### PR TITLE
minor follow-up adjustments for config GUI validation

### DIFF
--- a/deeplabcut/compat.py
+++ b/deeplabcut/compat.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import numpy as np
 
 import deeplabcut.core.visualization as visualization
-from deeplabcut.core.config import read_config_as_dict
+from deeplabcut.core.config import read_config
 from deeplabcut.core.deprecation import renamed_parameter
 from deeplabcut.core.engine import Engine
 from deeplabcut.generate_training_dataset.metadata import get_shuffle_engine
@@ -211,7 +211,7 @@ def train_network(
     config = Path(config)
     if engine is None:
         engine = get_shuffle_engine(
-            _load_config(config),
+            read_config(config),
             trainingsetindex=trainingsetindex,
             shuffle=shuffle,
         )
@@ -292,7 +292,7 @@ def return_train_network_path(
     config = Path(config)
     if engine is None:
         engine = get_shuffle_engine(
-            _load_config(config),
+            read_config(config),
             trainingsetindex=trainingsetindex,
             shuffle=shuffle,
             modelprefix=modelprefix,
@@ -431,7 +431,7 @@ def evaluate_network(
     """
     config = Path(config)
     if engine is None:
-        cfg = _load_config(config)
+        cfg = read_config(config)
         engines = set()
         for shuffle in shuffles:
             engines.add(
@@ -551,7 +551,7 @@ def return_evaluate_network_data(
     config = Path(config)
     if engine is None:
         engine = get_shuffle_engine(
-            _load_config(config),
+            read_config(config),
             trainingsetindex=trainingsetindex,
             shuffle=shuffle,
             modelprefix=modelprefix,
@@ -779,7 +779,7 @@ def analyze_videos(
     destfolder = _coerce_optional_path(destfolder)
     if engine is None:
         engine = get_shuffle_engine(
-            _load_config(config),
+            read_config(config),
             trainingsetindex=trainingsetindex,
             shuffle=shuffle,
             modelprefix=modelprefix,
@@ -924,7 +924,7 @@ def create_tracking_dataset(
     destfolder = _coerce_optional_path(destfolder)
     if engine is None:
         engine = get_shuffle_engine(
-            _load_config(config),
+            read_config(config),
             trainingsetindex=trainingsetindex,
             shuffle=shuffle,
             modelprefix=modelprefix,
@@ -1074,7 +1074,7 @@ def analyze_images(
             )
     """
     engine = get_shuffle_engine(
-        _load_config(config),
+        read_config(config),
         trainingsetindex=trainingsetindex,
         shuffle=shuffle,
         modelprefix=modelprefix,
@@ -1168,7 +1168,7 @@ def analyze_time_lapse_frames(
     directory = Path(directory)
     if engine is None:
         engine = get_shuffle_engine(
-            _load_config(config),
+            read_config(config),
             trainingsetindex=trainingsetindex,
             shuffle=shuffle,
             modelprefix=modelprefix,
@@ -1286,7 +1286,7 @@ def convert_detections2tracklets(
     destfolder = _coerce_optional_path(destfolder)
     if engine is None:
         engine = get_shuffle_engine(
-            _load_config(config),
+            read_config(config),
             trainingsetindex=trainingsetindex,
             shuffle=shuffle,
             modelprefix=modelprefix,
@@ -1385,7 +1385,7 @@ def extract_maps(
     config = Path(config)
     if engine is None:
         engine = get_shuffle_engine(
-            _load_config(config),
+            read_config(config),
             trainingsetindex=trainingsetindex,
             shuffle=shuffle,
             modelprefix=modelprefix,
@@ -1538,7 +1538,7 @@ def extract_save_all_maps(
     dest_folder = _coerce_optional_path(dest_folder)
     if engine is None:
         engine = get_shuffle_engine(
-            _load_config(config),
+            read_config(config),
             trainingsetindex=trainingsetindex,
             shuffle=shuffle,
             modelprefix=modelprefix,
@@ -1631,7 +1631,7 @@ def export_model(
     cfg_path = Path(cfg_path)
     if engine is None:
         engine = get_shuffle_engine(
-            _load_config(cfg_path),
+            read_config(cfg_path),
             trainingsetindex=trainingsetindex,
             shuffle=shuffle,
             modelprefix=modelprefix,
@@ -1685,7 +1685,3 @@ def _gpu_to_use_to_device(gpu_to_use: int | None, device: str | None) -> str | N
             device = gpu_to_use
 
     return device
-
-
-def _load_config(config: str) -> dict:
-    return read_config_as_dict(config)

--- a/deeplabcut/gui/config_file_monitor.py
+++ b/deeplabcut/gui/config_file_monitor.py
@@ -1,0 +1,93 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Watch the active project configuration file for external edits."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from PySide6 import QtCore, QtWidgets
+
+
+class ConfigFileMonitor(QtCore.QObject):
+    """Offer an explicit reload when the active config file changes on disk."""
+
+    def __init__(
+        self,
+        status_bar: QtWidgets.QStatusBar,
+        on_reload: Callable[[], bool],
+        parent: QtCore.QObject | None = None,
+        debounce_ms: int = 300,
+    ) -> None:
+        super().__init__(parent)
+        self._path: str | None = None
+        self._loaded_signature: tuple[int, int] | None = None
+
+        self._watcher = QtCore.QFileSystemWatcher(self)
+        self._watcher.fileChanged.connect(self._on_file_changed)
+
+        self._debounce = QtCore.QTimer(self)
+        self._debounce.setSingleShot(True)
+        self._debounce.setInterval(debounce_ms)
+        self._debounce.timeout.connect(self._check_for_change)
+
+        self._reload_button = QtWidgets.QPushButton("Reload configuration")
+        self._reload_button.clicked.connect(on_reload)
+        self._reload_button.hide()
+        status_bar.addPermanentWidget(self._reload_button)
+        self._status_bar = status_bar
+
+    def set_path(self, path: str | None) -> None:
+        """Watch ``path``, clearing any previous watch and pending notification."""
+        watched = self._watcher.files()
+        if watched:
+            self._watcher.removePaths(watched)
+
+        self._path = path
+        self._loaded_signature = None
+        self._debounce.stop()
+        self._reload_button.hide()
+
+        if path is not None and Path(path).is_file():
+            self._watcher.addPath(path)
+
+    def mark_current(self) -> None:
+        """Record that the in-memory config matches the file currently on disk."""
+        self._loaded_signature = self._signature()
+        if self._path is not None and Path(self._path).is_file():
+            if self._path not in self._watcher.files():
+                self._watcher.addPath(self._path)
+        self._reload_button.hide()
+
+    def _signature(self) -> tuple[int, int] | None:
+        if self._path is None:
+            return None
+        try:
+            stat = Path(self._path).stat()
+        except OSError:
+            return None
+        return stat.st_mtime_ns, stat.st_size
+
+    def _on_file_changed(self, _path: str) -> None:
+        self._debounce.start()
+
+    def _check_for_change(self) -> None:
+        if self._path is None or self._loaded_signature is None:
+            return
+
+        current = self._signature()
+        if current == self._loaded_signature:
+            return
+
+        # Some editors replace the file, which drops the watch path.
+        if current is not None and self._path not in self._watcher.files():
+            self._watcher.addPath(self._path)
+
+        self._status_bar.showMessage("Project configuration changed on disk.")
+        self._reload_button.show()

--- a/deeplabcut/gui/config_file_monitor.py
+++ b/deeplabcut/gui/config_file_monitor.py
@@ -31,6 +31,7 @@ class ConfigFileMonitor(QtCore.QObject):
 
         self._watcher = QtCore.QFileSystemWatcher(self)
         self._watcher.fileChanged.connect(self._on_file_changed)
+        self._watcher.directoryChanged.connect(self._on_file_changed)
 
         self._debounce = QtCore.QTimer(self)
         self._debounce.setSingleShot(True)
@@ -44,18 +45,28 @@ class ConfigFileMonitor(QtCore.QObject):
         self._status_bar = status_bar
 
     def set_path(self, path: str | None) -> None:
-        """Watch ``path``, clearing any previous watch and pending notification."""
-        watched = self._watcher.files()
-        if watched:
-            self._watcher.removePaths(watched)
+        """Watch ``path`` and its parent directory, clearing any previous watches."""
+        watched_files = self._watcher.files()
+        if watched_files:
+            self._watcher.removePaths(watched_files)
+        watched_dirs = self._watcher.directories()
+        if watched_dirs:
+            self._watcher.removePaths(watched_dirs)
 
         self._path = path
         self._loaded_signature = None
         self._debounce.stop()
         self._reload_button.hide()
 
-        if path is not None and Path(path).is_file():
-            self._watcher.addPath(path)
+        if path is not None:
+            config_path = Path(path)
+            if config_path.is_file():
+                self._watcher.addPath(path)
+            # Watch the parent directory so atomic file replacements
+            # (delete + rename) are also detected.
+            parent = str(config_path.parent)
+            if parent and Path(parent).is_dir():
+                self._watcher.addPath(parent)
 
     def mark_current(self) -> None:
         """Record that the in-memory config matches the file currently on disk."""
@@ -86,6 +97,7 @@ class ConfigFileMonitor(QtCore.QObject):
             return
 
         # Some editors replace the file, which drops the watch path.
+        # Watching the parent directory helps detect such replacements.
         if current is not None and self._path not in self._watcher.files():
             self._watcher.addPath(self._path)
 

--- a/deeplabcut/gui/dialogs/config_errors.py
+++ b/deeplabcut/gui/dialogs/config_errors.py
@@ -16,13 +16,13 @@ from typing import Any
 from pydantic import ValidationError
 
 #: Exceptions that indicate a configuration could not be read or validated.
-#: Kept deliberately narrow — TypeError and ValueError are excluded to avoid
-#: catching errors unrelated to configuration (e.g. from arbitrary GUI callbacks).
 CONFIG_LOAD_ERRORS = (
     ValidationError,
     FileNotFoundError,
     PermissionError,
     OSError,
+    TypeError,
+    ValueError,
 )
 
 _CUSTOM_MESSAGES: dict[str, str] = {

--- a/deeplabcut/gui/dialogs/config_errors.py
+++ b/deeplabcut/gui/dialogs/config_errors.py
@@ -16,13 +16,13 @@ from typing import Any
 from pydantic import ValidationError
 
 #: Exceptions that indicate a configuration could not be read or validated.
+#: Kept deliberately narrow — TypeError and ValueError are excluded to avoid
+#: catching errors unrelated to configuration (e.g. from arbitrary GUI callbacks).
 CONFIG_LOAD_ERRORS = (
     ValidationError,
     FileNotFoundError,
     PermissionError,
     OSError,
-    TypeError,
-    ValueError,
 )
 
 _CUSTOM_MESSAGES: dict[str, str] = {

--- a/deeplabcut/gui/dialogs/config_errors.py
+++ b/deeplabcut/gui/dialogs/config_errors.py
@@ -15,6 +15,21 @@ from typing import Any
 
 from pydantic import ValidationError
 
+#: Exceptions that indicate a configuration could not be read or validated.
+CONFIG_LOAD_ERRORS = (
+    ValidationError,
+    FileNotFoundError,
+    PermissionError,
+    OSError,
+    TypeError,
+    ValueError,
+)
+
+_CUSTOM_MESSAGES: dict[str, str] = {
+    "extra_forbidden": "This setting is not supported by the installed DeepLabCut version.",
+    "missing": "This required setting is missing.",
+}
+
 
 @dataclass(frozen=True)
 class ConfigErrorReport:
@@ -71,15 +86,10 @@ def format_config_error(
         for detail in error.errors(include_url=False):
             location = _format_location(tuple(detail.get("loc", ())))
             error_type = detail.get("type")
-            message = detail.get(
-                "msg",
-                "Invalid value",
+            message = _CUSTOM_MESSAGES.get(
+                error_type,
+                detail.get("msg", "Invalid value"),
             )
-
-            if error_type == "extra_forbidden":
-                message = "This setting is not supported by the installed DeepLabCut version."
-            elif error_type == "missing":
-                message = "This required setting is missing."
 
             entry = f"• {location}: {message}"
 

--- a/deeplabcut/gui/displays/selected_shuffle_display.py
+++ b/deeplabcut/gui/displays/selected_shuffle_display.py
@@ -26,7 +26,7 @@ from deeplabcut.utils import auxiliaryfunctions
 class SelectedShuffleDisplay(QtWidgets.QWidget):
     """A widget displaying information about the selected shuffle."""
 
-    pose_cfg_signal = QtCore.Signal(dict)
+    pose_cfg_signal = QtCore.Signal(object)
 
     def __init__(self, root, row_margin: int = 25):
         super().__init__()
@@ -132,5 +132,5 @@ class SelectedShuffleDisplay(QtWidgets.QWidget):
 
         self._engine = Engine.PYTORCH if "pytorch" in pose_cfg_path.stem.lower() else Engine.TF
         self._net_type = pose_cfg.get("net_type", "UNKNOWN")
-        self._is_top_down = self._engine == Engine.PYTORCH and pose_cfg.get("method").lower() == "td"
+        self._is_top_down = self._engine == Engine.PYTORCH and pose_cfg.get("method", "").lower() == "td"
         self.pose_cfg = pose_cfg

--- a/deeplabcut/gui/displays/selected_shuffle_display.py
+++ b/deeplabcut/gui/displays/selected_shuffle_display.py
@@ -132,5 +132,8 @@ class SelectedShuffleDisplay(QtWidgets.QWidget):
 
         self._engine = Engine.PYTORCH if "pytorch" in pose_cfg_path.stem.lower() else Engine.TF
         self._net_type = pose_cfg.get("net_type", "UNKNOWN")
-        self._is_top_down = self._engine == Engine.PYTORCH and pose_cfg.get("method", "").lower() == "td"
+
+        method = pose_cfg.get("method")
+        self._is_top_down = self._engine == Engine.PYTORCH and isinstance(method, str) and method.lower() == "td"
+
         self.pose_cfg = pose_cfg

--- a/deeplabcut/gui/tabs/analyze_videos.py
+++ b/deeplabcut/gui/tabs/analyze_videos.py
@@ -54,6 +54,11 @@ class AnalyzeVideos(DefaultTab):
     def __init__(self, root, parent, h1_description):
         super().__init__(root, parent, h1_description)
 
+        self._reload_timer = QTimer(self)
+        self._reload_timer.setSingleShot(True)
+        self._reload_timer.setInterval(0)
+        self._reload_timer.timeout.connect(self.root.reload_project_config)
+
         self._set_page()
 
     @property
@@ -267,12 +272,7 @@ class AnalyzeVideos(DefaultTab):
             return
         config = self.root.config_path
         editor = ConfigEditor(config, parent=self.root)
-        editor.accepted.connect(
-            lambda: QTimer.singleShot(
-                0,
-                self.root.reload_project_config,
-            )
-        )
+        editor.accepted.connect(self._reload_timer.start)
         editor.show()
 
     def _collect_options(self) -> AnalyzeVideosOptions:

--- a/deeplabcut/gui/tabs/analyze_videos.py
+++ b/deeplabcut/gui/tabs/analyze_videos.py
@@ -13,7 +13,7 @@ from functools import partial
 from pathlib import Path
 
 from PySide6 import QtWidgets
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QTimer
 
 import deeplabcut
 from deeplabcut.core.config import ProjectConfig
@@ -265,7 +265,14 @@ class AnalyzeVideos(DefaultTab):
     def edit_config_file(self):
         if not self.root.config_path:
             return
-        editor = ConfigEditor(self.root.config_path)
+        config = self.root.config_path
+        editor = ConfigEditor(config, parent=self.root)
+        editor.accepted.connect(
+            lambda: QTimer.singleShot(
+                0,
+                self.root.reload_project_config,
+            )
+        )
         editor.show()
 
     def _collect_options(self) -> AnalyzeVideosOptions:
@@ -441,6 +448,7 @@ class AnalyzeVideos(DefaultTab):
         func = partial(self._run_pipeline, options, batches)
 
         self.worker, self.thread = move_to_separate_thread(func)
+        self.worker.error.connect(self.root.show_task_error)
         self.worker.finished.connect(lambda: self.analyze_videos_btn.setEnabled(True))
         self.worker.finished.connect(lambda: self.root._progress_bar.hide())
         self.thread.start()

--- a/deeplabcut/gui/tabs/evaluate_network.py
+++ b/deeplabcut/gui/tabs/evaluate_network.py
@@ -30,7 +30,6 @@ from deeplabcut.gui.components import (
     _create_label_widget,
     _create_vertical_layout,
 )
-from deeplabcut.gui.dialogs.config_errors import CONFIG_LOAD_ERRORS
 from deeplabcut.gui.displays.selected_shuffle_display import SelectedShuffleDisplay
 from deeplabcut.gui.widgets import ConfigEditor, launch_napari
 from deeplabcut.utils import auxiliaryfunctions
@@ -182,17 +181,17 @@ class EvaluateNetwork(DefaultTab):
             self.root.logger.info(f"Use selected bodyparts only: {self.bodyparts_list_widget.selected_bodyparts}")
 
     def evaluate_network(self):
-        config_path = self.root.config_path
-        shuffle = self.root.shuffle_value
-        plotting = self.plot_predictions.isChecked()
-
-        bodyparts_to_use = "all"
-        if (
-            len(self.root.all_bodyparts) != len(self.bodyparts_list_widget.selected_bodyparts)
-        ) and not self.use_all_bodyparts.isChecked():
-            bodyparts_to_use = self.bodyparts_list_widget.selected_bodyparts
-
         try:
+            config_path = self.root.config_path
+            shuffle = self.root.shuffle_value
+            plotting = self.plot_predictions.isChecked()
+
+            bodyparts_to_use = "all"
+            if (
+                len(self.root.all_bodyparts) != len(self.bodyparts_list_widget.selected_bodyparts)
+            ) and not self.use_all_bodyparts.isChecked():
+                bodyparts_to_use = self.bodyparts_list_widget.selected_bodyparts
+
             deeplabcut.evaluate_network(
                 config_path,
                 Shuffles=[shuffle],
@@ -200,27 +199,26 @@ class EvaluateNetwork(DefaultTab):
                 show_errors=True,
                 comparisonbodyparts=bodyparts_to_use,
             )
-        except CONFIG_LOAD_ERRORS as error:
+
+            if plotting:
+                project_cfg = self.root.cfg
+                eval_folder = auxiliaryfunctions.get_evaluation_folder(
+                    trainFraction=project_cfg["TrainingFraction"][0],
+                    shuffle=shuffle,
+                    cfg=project_cfg,
+                )
+                scorer, _ = auxiliaryfunctions.get_scorer_name(
+                    cfg=project_cfg,
+                    shuffle=shuffle,
+                    trainFraction=project_cfg["TrainingFraction"][0],
+                )
+
+                image_dir = Path(self.root.project_folder) / eval_folder / f"LabeledImages_{scorer}"
+                labeled_images = [str(p) for p in image_dir.rglob("*.png")]
+                if len(labeled_images) > 0:
+                    _ = launch_napari(labeled_images)
+        except Exception as error:
             self.root.show_task_error(error, self.root.pose_cfg_path)
-            return
-
-        if plotting:
-            project_cfg = self.root.cfg
-            eval_folder = auxiliaryfunctions.get_evaluation_folder(
-                trainFraction=project_cfg["TrainingFraction"][0],
-                shuffle=shuffle,
-                cfg=project_cfg,
-            )
-            scorer, _ = auxiliaryfunctions.get_scorer_name(
-                cfg=project_cfg,
-                shuffle=shuffle,
-                trainFraction=project_cfg["TrainingFraction"][0],
-            )
-
-            image_dir = Path(self.root.project_folder) / eval_folder / f"LabeledImages_{scorer}"
-            labeled_images = [str(p) for p in image_dir.rglob("*.png")]
-            if len(labeled_images) > 0:
-                _ = launch_napari(labeled_images)
 
     @Slot(Engine)
     def _on_engine_change(self, engine: Engine) -> None:

--- a/deeplabcut/gui/tabs/evaluate_network.py
+++ b/deeplabcut/gui/tabs/evaluate_network.py
@@ -30,6 +30,7 @@ from deeplabcut.gui.components import (
     _create_label_widget,
     _create_vertical_layout,
 )
+from deeplabcut.gui.dialogs.config_errors import CONFIG_LOAD_ERRORS
 from deeplabcut.gui.displays.selected_shuffle_display import SelectedShuffleDisplay
 from deeplabcut.gui.widgets import ConfigEditor, launch_napari
 from deeplabcut.utils import auxiliaryfunctions
@@ -191,13 +192,17 @@ class EvaluateNetwork(DefaultTab):
         ) and not self.use_all_bodyparts.isChecked():
             bodyparts_to_use = self.bodyparts_list_widget.selected_bodyparts
 
-        deeplabcut.evaluate_network(
-            config_path,
-            Shuffles=[shuffle],
-            plotting=plotting,
-            show_errors=True,
-            comparisonbodyparts=bodyparts_to_use,
-        )
+        try:
+            deeplabcut.evaluate_network(
+                config_path,
+                Shuffles=[shuffle],
+                plotting=plotting,
+                show_errors=True,
+                comparisonbodyparts=bodyparts_to_use,
+            )
+        except CONFIG_LOAD_ERRORS as error:
+            self.root.show_task_error(error, self.root.pose_cfg_path)
+            return
 
         if plotting:
             project_cfg = self.root.cfg

--- a/deeplabcut/gui/tabs/extract_frames.py
+++ b/deeplabcut/gui/tabs/extract_frames.py
@@ -226,6 +226,7 @@ class ExtractFrames(DefaultTab):
         )
 
         self.worker, self.thread = move_to_separate_thread(func, capture_outputs=True)
+        self.worker.error.connect(self.root.show_task_error)
         self.worker.finished.connect(lambda: self.ok_button.setEnabled(True))
         self.worker.finished.connect(lambda: self.root._progress_bar.hide())
         self.thread.finished.connect(self._show_success_message)

--- a/deeplabcut/gui/tabs/extract_frames.py
+++ b/deeplabcut/gui/tabs/extract_frames.py
@@ -226,7 +226,9 @@ class ExtractFrames(DefaultTab):
         )
 
         self.worker, self.thread = move_to_separate_thread(func, capture_outputs=True)
+        self._extract_error = False
         self.worker.error.connect(self.root.show_task_error)
+        self.worker.error.connect(lambda _err: setattr(self, "_extract_error", True))
         self.worker.finished.connect(lambda: self.ok_button.setEnabled(True))
         self.worker.finished.connect(lambda: self.root._progress_bar.hide())
         self.thread.finished.connect(self._show_success_message)
@@ -235,6 +237,9 @@ class ExtractFrames(DefaultTab):
         self.root._progress_bar.show()
 
     def _show_success_message(self):
+        if getattr(self, "_extract_error", False):
+            return
+
         message = "Failed to create worker: it is None"
         root_message = "failed to extract frames: worker is None"
         if self.worker is not None:

--- a/deeplabcut/gui/tabs/manage_project.py
+++ b/deeplabcut/gui/tabs/manage_project.py
@@ -11,7 +11,7 @@
 import os
 from pathlib import Path
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QTimer
 from PySide6.QtWidgets import (
     QFileDialog,
     QLabel,
@@ -62,7 +62,14 @@ class ManageProject(DefaultTab):
         self.main_layout.addWidget(self.add_videos_btn, alignment=Qt.AlignRight)
 
     def open_config_editor(self):
-        editor = ConfigEditor(self.root.config_path)
+        config = self.root.config_path
+        editor = ConfigEditor(config, parent=self.root)
+        editor.accepted.connect(
+            lambda: QTimer.singleShot(
+                0,
+                self.root.reload_project_config,
+            )
+        )
         editor.show()
 
     def add_new_videos(self):

--- a/deeplabcut/gui/tabs/manage_project.py
+++ b/deeplabcut/gui/tabs/manage_project.py
@@ -28,6 +28,12 @@ from deeplabcut.gui.widgets import ConfigEditor
 class ManageProject(DefaultTab):
     def __init__(self, root, parent, h1_description):
         super().__init__(root, parent, h1_description)
+
+        self._reload_timer = QTimer(self)
+        self._reload_timer.setSingleShot(True)
+        self._reload_timer.setInterval(0)
+        self._reload_timer.timeout.connect(self.root.reload_project_config)
+
         self._set_page()
         self._videos = []
 
@@ -64,12 +70,7 @@ class ManageProject(DefaultTab):
     def open_config_editor(self):
         config = self.root.config_path
         editor = ConfigEditor(config, parent=self.root)
-        editor.accepted.connect(
-            lambda: QTimer.singleShot(
-                0,
-                self.root.reload_project_config,
-            )
-        )
+        editor.accepted.connect(self._reload_timer.start)
         editor.show()
 
     def add_new_videos(self):

--- a/deeplabcut/gui/tabs/modelzoo.py
+++ b/deeplabcut/gui/tabs/modelzoo.py
@@ -456,6 +456,7 @@ class ModelZoo(DefaultTab):
                     **kwargs,
                 )
                 self.worker, self.thread = move_to_separate_thread(func)
+                self.worker.error.connect(self.root.show_task_error)
                 self.worker.finished.connect(self.signal_analysis_complete)
                 self.thread.start()
             else:

--- a/deeplabcut/gui/tabs/train_network.py
+++ b/deeplabcut/gui/tabs/train_network.py
@@ -75,7 +75,8 @@ class TrainNetwork(DefaultTab):
             self.snapshot_selection_widget.show()
             # Display detector snapshot selection widget only if in Top-Down mode
             pose_cfg = self._shuffle_display.pose_cfg
-            if pose_cfg is not None and pose_cfg.get("method", "").lower() == "td":
+            method = pose_cfg.get("method") if pose_cfg is not None else None
+            if isinstance(method, str) and method.lower() == "td":
                 self.detector_snapshot_selection_widget.show()
             else:
                 self.detector_snapshot_selection_widget.hide()

--- a/deeplabcut/gui/tabs/train_network.py
+++ b/deeplabcut/gui/tabs/train_network.py
@@ -24,7 +24,6 @@ from deeplabcut.gui.components import (
     _create_grid_layout,
     _create_label_widget,
 )
-from deeplabcut.gui.dialogs.config_errors import CONFIG_LOAD_ERRORS
 from deeplabcut.gui.displays.selected_shuffle_display import SelectedShuffleDisplay
 from deeplabcut.gui.gui_assets import icon_from_resource
 from deeplabcut.gui.widgets import ConfigEditor
@@ -223,36 +222,35 @@ class TrainNetwork(DefaultTab):
         editor.show()
 
     def train_network(self):
-        config_path = self.root.config_path
-        shuffle = int(self._shuffle.value())
-
-        kwargs = dict(gputouse=None, autotune=False)
-        for k, spin_box in self._attribute_kwargs[self.root.engine].items():
-            kwargs[k] = int(spin_box.value())
-        if self.root.engine == Engine.PYTORCH:
-            snapshot_to_start_training_from = self.snapshot_selection_widget.selected_snapshot
-            if snapshot_to_start_training_from is not None:
-                kwargs["snapshot_path"] = snapshot_to_start_training_from
-            detector_to_start_training_from = self.detector_snapshot_selection_widget.selected_snapshot
-            if detector_to_start_training_from is not None:
-                kwargs["detector_path"] = detector_to_start_training_from
-
         try:
+            config_path = self.root.config_path
+            shuffle = int(self._shuffle.value())
+
+            kwargs = dict(gputouse=None, autotune=False)
+            for k, spin_box in self._attribute_kwargs[self.root.engine].items():
+                kwargs[k] = int(spin_box.value())
+            if self.root.engine == Engine.PYTORCH:
+                snapshot_to_start_training_from = self.snapshot_selection_widget.selected_snapshot
+                if snapshot_to_start_training_from is not None:
+                    kwargs["snapshot_path"] = snapshot_to_start_training_from
+                detector_to_start_training_from = self.detector_snapshot_selection_widget.selected_snapshot
+                if detector_to_start_training_from is not None:
+                    kwargs["detector_path"] = detector_to_start_training_from
+
             compat.train_network(config_path, shuffle, **kwargs)
-        except CONFIG_LOAD_ERRORS as error:
+
+            msg = QtWidgets.QMessageBox()
+            msg.setIcon(QtWidgets.QMessageBox.Information)
+            msg.setText("The network is now trained and ready to evaluate.")
+            msg.setInformativeText("Use the function 'evaluate_network' to evaluate the network.")
+
+            msg.setWindowTitle("Info")
+            msg.setMinimumWidth(900)
+            msg.setWindowIcon(icon_from_resource("logo.png"))
+            msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
+            msg.exec_()
+        except Exception as error:
             self.root.show_task_error(error, self.root.pose_cfg_path)
-            return
-
-        msg = QtWidgets.QMessageBox()
-        msg.setIcon(QtWidgets.QMessageBox.Information)
-        msg.setText("The network is now trained and ready to evaluate.")
-        msg.setInformativeText("Use the function 'evaluate_network' to evaluate the network.")
-
-        msg.setWindowTitle("Info")
-        msg.setMinimumWidth(900)
-        msg.setWindowIcon(icon_from_resource("logo.png"))
-        msg.setStandardButtons(QtWidgets.QMessageBox.Ok)
-        msg.exec_()
 
     @Slot(dict)
     def _pose_cfg_change(self, pose_cfg: dict | None) -> None:

--- a/deeplabcut/gui/tabs/train_network.py
+++ b/deeplabcut/gui/tabs/train_network.py
@@ -24,6 +24,7 @@ from deeplabcut.gui.components import (
     _create_grid_layout,
     _create_label_widget,
 )
+from deeplabcut.gui.dialogs.config_errors import CONFIG_LOAD_ERRORS
 from deeplabcut.gui.displays.selected_shuffle_display import SelectedShuffleDisplay
 from deeplabcut.gui.gui_assets import icon_from_resource
 from deeplabcut.gui.widgets import ConfigEditor
@@ -74,7 +75,8 @@ class TrainNetwork(DefaultTab):
             self.resume_from_snapshot_label.show()
             self.snapshot_selection_widget.show()
             # Display detector snapshot selection widget only if in Top-Down mode
-            if self._shuffle_display.pose_cfg.get("method", "").lower() == "td":
+            pose_cfg = self._shuffle_display.pose_cfg
+            if pose_cfg is not None and pose_cfg.get("method", "").lower() == "td":
                 self.detector_snapshot_selection_widget.show()
             else:
                 self.detector_snapshot_selection_widget.hide()
@@ -235,7 +237,12 @@ class TrainNetwork(DefaultTab):
             if detector_to_start_training_from is not None:
                 kwargs["detector_path"] = detector_to_start_training_from
 
-        compat.train_network(config_path, shuffle, **kwargs)
+        try:
+            compat.train_network(config_path, shuffle, **kwargs)
+        except CONFIG_LOAD_ERRORS as error:
+            self.root.show_task_error(error, self.root.pose_cfg_path)
+            return
+
         msg = QtWidgets.QMessageBox()
         msg.setIcon(QtWidgets.QMessageBox.Information)
         msg.setText("The network is now trained and ready to evaluate.")

--- a/deeplabcut/gui/tabs/unsupervised_id_tracking.py
+++ b/deeplabcut/gui/tabs/unsupervised_id_tracking.py
@@ -128,6 +128,7 @@ class UnsupervizedIdTracking(DefaultTab):
             track_method=track_method,
         )
         self.worker, self.thread = move_to_separate_thread(func)
+        self.worker.error.connect(self.root.show_task_error)
         self.worker.finished.connect(lambda: self.run_transformer_button.setEnabled(True))
         self.worker.finished.connect(lambda: self.root._progress_bar.hide())
         self.thread.start()

--- a/deeplabcut/gui/utils.py
+++ b/deeplabcut/gui/utils.py
@@ -40,7 +40,7 @@ class Worker(QtCore.QObject):
     def run(self):
         try:
             self._execute()
-        except Exception as exc:
+        except BaseException as exc:
             # Marshal the exception to the GUI thread instead of crashing or
             # silently killing the worker thread.
             self.error.emit(exc)

--- a/deeplabcut/gui/utils.py
+++ b/deeplabcut/gui/utils.py
@@ -31,14 +31,24 @@ def absolute_path(path: str | Path) -> Path:
 
 class Worker(QtCore.QObject):
     finished = QtCore.Signal()
+    error = QtCore.Signal(object)
 
     def __init__(self, func):
         super().__init__()
         self.func = func
 
     def run(self):
+        try:
+            self._execute()
+        except Exception as exc:
+            # Marshal the exception to the GUI thread instead of crashing or
+            # silently killing the worker thread.
+            self.error.emit(exc)
+        finally:
+            self.finished.emit()
+
+    def _execute(self):
         self.func()
-        self.finished.emit()
 
 
 class CaptureWorker(Worker):
@@ -48,9 +58,8 @@ class CaptureWorker(Worker):
         super().__init__(func)
         self.outputs = None
 
-    def run(self):
+    def _execute(self):
         self.outputs = self.func()
-        self.finished.emit()
 
 
 def move_to_separate_thread(func: Callable, capture_outputs: bool = False):

--- a/deeplabcut/gui/widgets.py
+++ b/deeplabcut/gui/widgets.py
@@ -432,7 +432,7 @@ class ConfigEditor(QtWidgets.QDialog):
         self.config_path = Path(config_path).absolute()
         config_name = self.config_path.name
         if config_name == "config.yaml":
-            self.read_func = auxiliaryfunctions.read_config
+            self.read_func = auxiliaryfunctions.read_plainconfig
             self.write_func = auxiliaryfunctions.write_config
         else:
             self.read_func = auxiliaryfunctions.read_plainconfig

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -109,6 +109,7 @@ class MainWindow(QMainWindow):
         self.logger = logging.getLogger("deeplabcut.gui")
         self.console_logger = logging.getLogger("deeplabcut.gui.console")
 
+        self._config_monitor = None
         self.config_path: Path | None = None
         self.loaded = False
 
@@ -118,7 +119,6 @@ class MainWindow(QMainWindow):
         self.files: set[Path] = set()
 
         self._engine = Engine.PYTORCH
-        self._config_monitor = None
 
         # Update checks
         self._update_process = None

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -36,12 +36,16 @@ from PySide6.QtWidgets import (
 
 import deeplabcut
 from deeplabcut import __version__ as DLC_VERSION
-from deeplabcut import auxiliaryfunctions, compat
+from deeplabcut import auxiliaryfunctions
+from deeplabcut.core.config import ProjectConfig
 from deeplabcut.core.debug import install_debug_recorder
 from deeplabcut.core.engine import Engine
+from deeplabcut.generate_training_dataset.metadata import get_shuffle_engine
 from deeplabcut.gui import components
+from deeplabcut.gui.config_file_monitor import ConfigFileMonitor
 from deeplabcut.gui.dialogs import create_generate_debug_log_action
 from deeplabcut.gui.dialogs.config_errors import (
+    CONFIG_LOAD_ERRORS,
     ConfigErrorReport,
     format_config_error,
 )
@@ -167,6 +171,12 @@ class MainWindow(QMainWindow):
         self._progress_bar.hide()
         self.status_bar.addPermanentWidget(self._progress_bar)
 
+        self._config_monitor = ConfigFileMonitor(
+            status_bar=self.status_bar,
+            on_reload=self.reload_project_config,
+            parent=self,
+        )
+
     def print_to_status_bar(self, text):
         self.status_bar.showMessage(text)
         self.status_bar.repaint()
@@ -203,10 +213,29 @@ class MainWindow(QMainWindow):
         self.recentfiles_menu.insertAction(before_action, action)
 
     @property
-    def cfg(self):
+    def config_path(self) -> Path | None:
+        return self._config_path
+
+    @config_path.setter
+    def config_path(self, value: Path | None) -> None:
+        self._config_path = value
+        self._cfg = None
+        monitor = getattr(self, "_config_monitor", None)
+        if monitor is not None:
+            monitor.set_path(str(value) if value is not None else None)
+
+    @property
+    def cfg(self) -> ProjectConfig | None:
+        """The loaded project configuration, read from disk and cached.
+
+        The cache is invalidated whenever ``config_path`` is assigned; retry
+        loops reset it explicitly to force a fresh read from disk.
+        """
         if self.config_path is None:
-            return {}
-        return auxiliaryfunctions.read_config(self.config_path)
+            return None
+        if self._cfg is None:
+            self._cfg = auxiliaryfunctions.read_config(self.config_path)
+        return self._cfg
 
     @property
     def engine(self) -> Engine:
@@ -244,70 +273,88 @@ class MainWindow(QMainWindow):
         self.engine_change.emit(e)
 
     @property
+    @property
     def project_folder(self) -> Path:
-        path = self.cfg.get("project_path")
-        if path is not None:
-            return Path(path).absolute()
-        return Path("~/Desktop").expanduser().absolute()
+        cfg = self.cfg
+        if cfg is None:
+            return Path("~/Desktop").expanduser().absolute()
+        return cfg.project_path
 
     @property
     def is_multianimal(self) -> bool:
-        return bool(self.cfg.get("multianimalproject"))
+        cfg = self.cfg
+        return cfg is not None and cfg.multianimalproject
 
     @property
     def all_bodyparts(self) -> list:
-        if self.is_multianimal:
-            return self.cfg.get("multianimalbodyparts")
-        else:
-            return self.cfg["bodyparts"]
+        cfg = self.cfg
+        if cfg is None:
+            return []
+        if cfg.multianimalproject:
+            return cfg.multianimalbodyparts
+        return cfg.bodyparts
 
     @property
     def all_individuals(self) -> list:
-        if self.is_multianimal:
-            return self.cfg.get("individuals")
-        else:
-            return [""]
+        cfg = self.cfg
+        if cfg is not None and cfg.multianimalproject:
+            return cfg.individuals
+        return [""]
+
+    @property
+    def _selected_model_train_folder(self) -> tuple[Path, Engine]:
+        """Resolve model paths from the validated project-config snapshot."""
+        cfg = self.cfg
+        if cfg is None:
+            raise RuntimeError("No project configuration is loaded.")
+
+        shuffle = int(self.shuffle_value)
+        trainingset_index = int(self.trainingset_index)
+        engine = get_shuffle_engine(
+            cfg,
+            trainingsetindex=trainingset_index,
+            shuffle=shuffle,
+        )
+        model_folder = auxiliaryfunctions.get_model_folder(
+            cfg.TrainingFraction[trainingset_index],
+            shuffle,
+            cfg,
+            engine=engine,
+        )
+        return Path(cfg.project_path) / model_folder / "train", engine
 
     @property
     def pose_cfg_path(self) -> Path:
         try:
-            return Path(
-                compat.return_train_network_path(
-                    self.config_path,
-                    shuffle=int(self.shuffle_value),
-                    trainingsetindex=int(self.trainingset_index),
-                    modelprefix="",
-                )[0]
-            ).absolute()
+            train_folder, engine = self._selected_model_train_folder
+            filename = "pytorch_config.yaml" if engine == Engine.PYTORCH else "pose_cfg.yaml"
+            return train_folder / filename
         except FileNotFoundError:
             return (Path(deeplabcut.__file__).parent / "pose_cfg.yaml").absolute()
 
     @property
     def models_folder(self) -> Path:
         try:
-            return Path(
-                compat.return_train_network_path(
-                    self.config_path,
-                    shuffle=int(self.shuffle_value),
-                    trainingsetindex=int(self.trainingset_index),
-                    modelprefix="",
-                )[2]
-            ).absolute()
+            train_folder, _ = self._selected_model_train_folder
+            return train_folder
         except FileNotFoundError:
             return self.project_folder
 
     @property
     def inference_cfg_path(self) -> Path:
+        cfg = self.cfg
+        if cfg is None:
+            raise RuntimeError("No project configuration is loaded.")
         return (
-            Path(self.cfg["project_path"])
+            cfg.project_path
             / auxiliaryfunctions.get_model_folder(
-                self.cfg["TrainingFraction"][int(self.trainingset_index)],
+                cfg.TrainingFraction[int(self.trainingset_index)],
                 int(self.shuffle_value),
-                self.cfg,
+                cfg,
             )
             / "test"
             / "inference_cfg.yaml"
-        ).absolute()
+        )
 
     def update_cfg(self, text):
         self.config_path = Path(text).absolute() if text else None
@@ -866,8 +913,15 @@ class MainWindow(QMainWindow):
             return False
 
         self.loaded = True
+        self._config_monitor.mark_current()
         self.add_recent_filename(str(self.config_path))
         return True
+
+    def reload_project_config(self) -> bool:
+        """Reload the active project configuration and rebuild its UI."""
+        if self.config_path is None:
+            return False
+        return self._update_project_state(self.config_path, loaded=True)
 
     def _ask_for_help(self):
         dlg = QMessageBox(self)
@@ -889,26 +943,30 @@ class MainWindow(QMainWindow):
         dlg = ProjectCreator(self)
         dlg.show()
 
-    def _open_config_with_system_application(self) -> bool:
-        """Open the current config with the operating system's default app."""
-        if self.config_path is None:
+    def _open_config_with_system_application(
+        self,
+        config_path: str | Path | None = None,
+    ) -> bool:
+        """Open a config (default: the project config) with the OS default app."""
+        path = Path(config_path) if config_path is not None else self.config_path
+        if path is None:
             return False
 
-        if not self.config_path.is_file():
+        if not path.is_file():
             QMessageBox.warning(
                 self,
                 "Configuration not found",
-                (f"The project configuration no longer exists:\n\n{self.config_path}"),
+                (f"The project configuration no longer exists:\n\n{path}"),
             )
             return False
 
-        config_url = QtCore.QUrl.fromLocalFile(str(self.config_path))
+        config_url = QtCore.QUrl.fromLocalFile(str(path))
         opened = QDesktopServices.openUrl(config_url)
 
         if not opened:
             self.logger.warning(
                 "The operating system could not open configuration %s",
-                self.config_path,
+                path,
             )
 
         return opened
@@ -972,65 +1030,108 @@ class MainWindow(QMainWindow):
                         ),
                     )
 
+    def show_task_error(
+        self,
+        error: Exception,
+        config_path: str | Path | None = None,
+    ) -> None:
+        """Show an error raised by a GUI-launched task (e.g. training, analysis).
+
+        Unlike the project-config recovery loop, this only reports the failure;
+        the user fixes the file and re-runs the action.
+        """
+        if config_path is None:
+            if isinstance(error, ValidationError) and error.title == "PoseConfig":
+                config_path = self.pose_cfg_path
+            else:
+                config_path = self.config_path
+
+        self.logger.error("Task failed: %s", error, exc_info=error)
+
+        if isinstance(error, CONFIG_LOAD_ERRORS):
+            report = format_config_error(config_path or "<unknown>", error)
+        else:
+            report = ConfigErrorReport(
+                title="Task failed",
+                summary="DeepLabCut could not complete the task.",
+                details=str(error),
+                technical_details=repr(error),
+            )
+
+        message = QMessageBox(self)
+        message.setIcon(QMessageBox.Critical)
+        message.setWindowTitle(report.title)
+        message.setText(report.summary)
+        message.setInformativeText(report.details)
+        message.setDetailedText(report.technical_details)
+
+        open_button = None
+        if config_path is not None and isinstance(error, CONFIG_LOAD_ERRORS):
+            open_button = message.addButton(
+                "Open configuration",
+                QMessageBox.ActionRole,
+            )
+        message.addButton(QMessageBox.Close)
+
+        message.exec()
+
+        if open_button is not None and message.clickedButton() is open_button:
+            self._open_config_with_system_application(config_path)
+
+    def _handle_config_error(self, error: Exception) -> ConfigErrorAction:
+        """Log and present a recoverable project configuration error."""
+        if isinstance(error, ValidationError):
+            self.logger.warning(
+                "Invalid project configuration %s (%d validation error%s)",
+                self.config_path,
+                error.error_count(),
+                "" if error.error_count() == 1 else "s",
+            )
+        else:
+            self.logger.warning(
+                "Could not read project configuration %s: %s",
+                self.config_path,
+                error,
+            )
+
+        self.logger.debug(
+            "Project configuration error details",
+            exc_info=(
+                type(error),
+                error,
+                error.__traceback__,
+            ),
+        )
+
+        report = format_config_error(
+            self.config_path,
+            error,
+        )
+        return self._show_config_error(report)
+
     def _build_project_ui_from_current_config(self) -> bool:
         """Build project tabs using the current config file on disk.
 
-        The configuration is reread for every attempt. No validated
-        configuration state is cached between attempts.
+        Every attempt starts by invalidating the cached configuration, so
+        each retry performs a fresh read and validation from disk.
         """
         if self.config_path is None:
             return False
 
         while True:
             self._discard_partial_project_tabs()
+            self._cfg = None
 
             try:
-                # Preflight validation only. The result is not cached.
+                # Read and validate; tabs reuse the cached snapshot via self.cfg.
                 self._read_current_config_for_ui()
-
-                # Tabs may access self.cfg, which rereads the file.
                 self.add_tabs()
                 return True
 
-            except (
-                ValidationError,
-                FileNotFoundError,
-                PermissionError,
-                OSError,
-                TypeError,
-                ValueError,
-            ) as error:
+            except CONFIG_LOAD_ERRORS as error:
                 self._discard_partial_project_tabs()
                 self._generate_welcome_page()
-
-                if isinstance(error, ValidationError):
-                    self.logger.warning(
-                        "Invalid project configuration %s (%d validation error%s)",
-                        self.config_path,
-                        error.error_count(),
-                        "" if error.error_count() == 1 else "s",
-                    )
-                else:
-                    self.logger.warning(
-                        "Could not read project configuration %s: %s",
-                        self.config_path,
-                        error,
-                    )
-
-                self.logger.debug(
-                    "Project configuration error details",
-                    exc_info=(
-                        type(error),
-                        error,
-                        error.__traceback__,
-                    ),
-                )
-
-                report = format_config_error(
-                    self.config_path,
-                    error,
-                )
-                action = self._show_config_error(report)
+                action = self._handle_config_error(error)
 
             except Exception:
                 self._discard_partial_project_tabs()
@@ -1082,12 +1183,12 @@ class MainWindow(QMainWindow):
         self.tab_widget.addTab(self.modelzoo, "Model Zoo")
         self.setCentralWidget(self.tab_widget)
 
-    def _read_current_config_for_ui(self) -> dict:
+    def _read_current_config_for_ui(self) -> ProjectConfig:
         """Read the current config from disk for a UI-building attempt."""
-        if self.config_path is None:
+        cfg = self.cfg
+        if cfg is None:
             raise FileNotFoundError("No project configuration is selected.")
-
-        return auxiliaryfunctions.read_config(self.config_path)
+        return cfg
 
     def load_config(
         self,
@@ -1097,44 +1198,12 @@ class MainWindow(QMainWindow):
         self.config_path = absolute_path(config)
 
         while True:
+            self._cfg = None
+
             try:
-                cfg = self.cfg
-            except (
-                ValidationError,
-                FileNotFoundError,
-                PermissionError,
-                OSError,
-                TypeError,
-                ValueError,
-            ) as error:
-                if isinstance(error, ValidationError):
-                    self.logger.warning(
-                        "Invalid project configuration %s (%d validation error%s)",
-                        self.config_path,
-                        error.error_count(),
-                        "" if error.error_count() == 1 else "s",
-                    )
-                else:
-                    self.logger.warning(
-                        "Could not read project configuration %s: %s",
-                        self.config_path,
-                        error,
-                    )
-
-                self.logger.debug(
-                    "Project configuration error details",
-                    exc_info=(
-                        type(error),
-                        error,
-                        error.__traceback__,
-                    ),
-                )
-
-                report = format_config_error(
-                    self.config_path,
-                    error,
-                )
-                action = self._show_config_error(report)
+                cfg = self._read_current_config_for_ui()
+            except CONFIG_LOAD_ERRORS as error:
+                action = self._handle_config_error(error)
 
                 if action is ConfigErrorAction.RETRY:
                     continue
@@ -1143,14 +1212,12 @@ class MainWindow(QMainWindow):
 
             self.config_loaded.emit()
 
-            task = cfg.get(
-                "Task",
-                self.config_path.parent.name,
-            )
+            task = cfg.Task or self.config_path.parent.name
             self.logger.info(
                 'Project "%s" successfully loaded.',
                 task,
             )
+            self._config_monitor.mark_current()
             return True
 
     def darkmode(self):

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -1052,7 +1052,7 @@ class MainWindow(QMainWindow):
 
         self.logger.error("Task failed: %s", error, exc_info=error)
 
-        if isinstance(error, CONFIG_LOAD_ERRORS):
+        if isinstance(error, ValidationError):
             report = format_config_error(config_path or "<unknown>", error)
         else:
             report = ConfigErrorReport(
@@ -1070,7 +1070,7 @@ class MainWindow(QMainWindow):
         message.setDetailedText(report.technical_details)
 
         open_button = None
-        if config_path is not None and isinstance(error, CONFIG_LOAD_ERRORS):
+        if config_path is not None and isinstance(error, ValidationError):
             open_button = message.addButton(
                 "Open configuration",
                 QMessageBox.ActionRole,

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -118,6 +118,7 @@ class MainWindow(QMainWindow):
         self.files: set[Path] = set()
 
         self._engine = Engine.PYTORCH
+        self._config_monitor = None
 
         # Update checks
         self._update_process = None
@@ -220,9 +221,8 @@ class MainWindow(QMainWindow):
     def config_path(self, value: Path | None) -> None:
         self._config_path = value
         self._cfg = None
-        monitor = getattr(self, "_config_monitor", None)
-        if monitor is not None:
-            monitor.set_path(str(value) if value is not None else None)
+        if self._config_monitor is not None:
+            self._config_monitor.set_path(str(value) if value is not None else None)
 
     @property
     def cfg(self) -> ProjectConfig | None:
@@ -272,7 +272,6 @@ class MainWindow(QMainWindow):
         self._engine = e
         self.engine_change.emit(e)
 
-    @property
     @property
     def project_folder(self) -> Path:
         cfg = self.cfg

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -220,7 +220,7 @@ class MainWindow(QMainWindow):
     @config_path.setter
     def config_path(self, value: Path | None) -> None:
         self._config_path = value
-        self._cfg = None
+        self.invalidate_config_cache()
         if self._config_monitor is not None:
             self._config_monitor.set_path(str(value) if value is not None else None)
 
@@ -922,6 +922,11 @@ class MainWindow(QMainWindow):
             return False
         return self._update_project_state(self.config_path, loaded=True)
 
+    def invalidate_config_cache(self) -> None:
+        """Drop the cached project configuration so the next ``self.cfg``
+        access performs a fresh read-and-validate from disk."""
+        self._cfg = None
+
     def _ask_for_help(self):
         dlg = QMessageBox(self)
         dlg.setWindowTitle("Ask for help")
@@ -1119,7 +1124,7 @@ class MainWindow(QMainWindow):
 
         while True:
             self._discard_partial_project_tabs()
-            self._cfg = None
+            self.invalidate_config_cache()
 
             try:
                 # Read and validate; tabs reuse the cached snapshot via self.cfg.
@@ -1197,7 +1202,7 @@ class MainWindow(QMainWindow):
         self.config_path = absolute_path(config)
 
         while True:
-            self._cfg = None
+            self.invalidate_config_cache()
 
             try:
                 cfg = self._read_current_config_for_ui()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,7 @@ dev = [
   "pre-commit",
   "pytest",
   "pytest-cov",
+  "pytest-qt",
   "ruff",
 ]
 

--- a/tests/gui/conftest.py
+++ b/tests/gui/conftest.py
@@ -1,0 +1,71 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Shared fixtures for GUI tests (headless Qt via pytest-qt)."""
+
+import os
+import sys
+
+# Render off-screen so tests do not open windows; must be set before Qt loads.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PySide6")
+pytest.importorskip("pytestqt")
+
+
+@pytest.fixture
+def write_project_config():
+    """Writer for a minimal valid project config.yaml.
+
+    ``project_path`` should be the parent of ``config_path`` so that
+    ``read_config`` does not repair (and rewrite) the file.
+    """
+
+    def _write(config_path, project_path, task: str = "demo", extra: str = "") -> None:
+        lines = [
+            f"Task: {task}",
+            "scorer: tester",
+            "date: Jan1",
+            "multianimalproject: false",
+            f"project_path: {project_path.as_posix()}",
+            "bodyparts: [nose, tail]",
+            "video_sets: {}",
+        ]
+        if extra:
+            lines.append(extra)
+        config_path.write_text("\n".join(lines) + "\n")
+
+    return _write
+
+
+@pytest.fixture
+def main_window(qapp, monkeypatch):
+    """A real MainWindow, constructed off-screen and torn down cleanly."""
+    from PySide6 import QtWidgets
+
+    from deeplabcut.gui.window import MainWindow
+
+    # Keep QSettings written by save_settings() out of the user's real settings.
+    qapp.setOrganizationName("DeepLabCut-Tests")
+    qapp.setApplicationName("DLC-GUI-Tests")
+
+    # closeEvent pops a blocking confirmation dialog; auto-confirm it in tests.
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *args, **kwargs: QtWidgets.QMessageBox.Yes,
+    )
+
+    original_stdout = sys.stdout  # MainWindow redirects stdout to its writer
+    window = MainWindow(qapp)
+    try:
+        yield window
+    finally:
+        window.close()
+        sys.stdout = original_stdout

--- a/tests/gui/test_config_editor.py
+++ b/tests/gui/test_config_editor.py
@@ -1,0 +1,57 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Tests for the raw YAML tree editor (ConfigEditor)."""
+
+import pytest
+
+pytest.importorskip("PySide6")
+pytest.importorskip("pytestqt")
+
+from deeplabcut.gui.widgets import ConfigEditor
+from deeplabcut.utils import auxiliaryfunctions
+
+
+def test_editor_displays_project_config_as_tree(qtbot, tmp_path, write_project_config):
+    """Regression: read_config returns a ProjectConfig model, which the tree
+    editor cannot display; the editor must read the raw YAML dict instead."""
+    config_path = tmp_path / "config.yaml"
+    write_project_config(config_path, tmp_path)
+
+    editor = ConfigEditor(str(config_path))
+    qtbot.addWidget(editor)
+
+    assert isinstance(editor.cfg, dict)
+
+    root = editor.viewer.tree.invisibleRootItem()
+    keys = {root.child(i).text(0) for i in range(root.childCount())}
+    assert {"Task", "bodyparts", "multianimalproject"} <= keys
+
+
+def test_editor_opens_config_that_fails_validation(qtbot, tmp_path, write_project_config):
+    """The editor is a recovery tool: it must open invalid configs so the
+    user can repair them."""
+    config_path = tmp_path / "config.yaml"
+    write_project_config(config_path, tmp_path, extra="not_a_dlc_setting: 1")
+
+    editor = ConfigEditor(str(config_path))  # must not raise
+    qtbot.addWidget(editor)
+
+    assert editor.cfg["not_a_dlc_setting"] == 1
+
+
+def test_editor_saves_edits_back_to_disk(qtbot, tmp_path, write_project_config):
+    config_path = tmp_path / "config.yaml"
+    write_project_config(config_path, tmp_path)
+
+    editor = ConfigEditor(str(config_path))
+    qtbot.addWidget(editor)
+    editor.cfg["colormap"] = "viridis"
+    editor.accept()
+
+    on_disk = auxiliaryfunctions.read_plainconfig(str(config_path))
+    assert on_disk["colormap"] == "viridis"

--- a/tests/gui/test_config_errors.py
+++ b/tests/gui/test_config_errors.py
@@ -91,19 +91,9 @@ def test_generic_error_report_includes_message():
         FileNotFoundError("x"),
         PermissionError("x"),
         OSError("x"),
-    ],
-)
-def test_config_load_errors_cover_common_failures(error):
-    assert isinstance(error, CONFIG_LOAD_ERRORS)
-
-
-@pytest.mark.parametrize(
-    "error",
-    [
         TypeError("x"),
         ValueError("x"),
     ],
 )
-def test_config_load_errors_excludes_overly_broad_types(error):
-    """TypeError / ValueError are too broad to be treated as config-load errors."""
-    assert not isinstance(error, CONFIG_LOAD_ERRORS)
+def test_config_load_errors_cover_common_failures(error):
+    assert isinstance(error, CONFIG_LOAD_ERRORS)

--- a/tests/gui/test_config_errors.py
+++ b/tests/gui/test_config_errors.py
@@ -1,0 +1,99 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Tests for user-facing formatting of configuration errors."""
+
+import pytest
+
+pytest.importorskip("PySide6")  # deeplabcut.gui imports qtpy at package level
+
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from deeplabcut.core.config import ProjectConfig
+from deeplabcut.gui.dialogs.config_errors import (
+    CONFIG_LOAD_ERRORS,
+    format_config_error,
+)
+
+CONFIG_PATH = "C:/projects/demo/config.yaml"
+# The report renders the path in native form (backslashes on Windows).
+CONFIG_PATH_DISPLAY = str(Path(CONFIG_PATH))
+
+
+def _make_validation_error(cfg: dict) -> ValidationError:
+    with pytest.raises(ValidationError) as exc_info:
+        ProjectConfig.from_dict(cfg)
+    return exc_info.value
+
+
+def test_validation_error_report_names_the_field():
+    error = _make_validation_error({"multianimalproject": "banana"})
+
+    report = format_config_error(CONFIG_PATH, error)
+
+    assert report.title == "Invalid project configuration"
+    assert "1 problem" in report.summary
+    assert CONFIG_PATH_DISPLAY in report.details
+    assert "multianimalproject" in report.details
+    assert "'banana'" in report.details  # the received value is shown
+    assert report.technical_details  # raw pydantic message preserved
+
+
+def test_extra_forbidden_gets_friendly_message():
+    error = _make_validation_error({"not_a_dlc_setting": 1})
+
+    report = format_config_error(CONFIG_PATH, error)
+
+    assert "not_a_dlc_setting" in report.details
+    assert "not supported by the installed DeepLabCut version" in report.details
+
+
+def test_multiple_errors_are_all_listed():
+    error = _make_validation_error({"not_a_dlc_setting": 1, "multianimalproject": "banana"})
+
+    report = format_config_error(CONFIG_PATH, error)
+
+    assert "2 problems" in report.summary
+    assert "not_a_dlc_setting" in report.details
+    assert "multianimalproject" in report.details
+
+
+def test_file_not_found_report():
+    report = format_config_error(CONFIG_PATH, FileNotFoundError(CONFIG_PATH))
+
+    assert report.title == "Project configuration not found"
+    assert CONFIG_PATH_DISPLAY in report.details
+
+
+def test_permission_error_report():
+    report = format_config_error(CONFIG_PATH, PermissionError("denied"))
+
+    assert report.title == "Cannot read project configuration"
+    assert "permission" in report.summary.lower()
+
+
+def test_generic_error_report_includes_message():
+    report = format_config_error(CONFIG_PATH, ValueError("config is empty or null"))
+
+    assert report.title == "Cannot load project configuration"
+    assert "config is empty or null" in report.details
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        FileNotFoundError("x"),
+        PermissionError("x"),
+        OSError("x"),
+        TypeError("x"),
+        ValueError("x"),
+    ],
+)
+def test_config_load_errors_cover_common_failures(error):
+    assert isinstance(error, CONFIG_LOAD_ERRORS)

--- a/tests/gui/test_config_errors.py
+++ b/tests/gui/test_config_errors.py
@@ -91,9 +91,19 @@ def test_generic_error_report_includes_message():
         FileNotFoundError("x"),
         PermissionError("x"),
         OSError("x"),
-        TypeError("x"),
-        ValueError("x"),
     ],
 )
 def test_config_load_errors_cover_common_failures(error):
     assert isinstance(error, CONFIG_LOAD_ERRORS)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        TypeError("x"),
+        ValueError("x"),
+    ],
+)
+def test_config_load_errors_excludes_overly_broad_types(error):
+    """TypeError / ValueError are too broad to be treated as config-load errors."""
+    assert not isinstance(error, CONFIG_LOAD_ERRORS)

--- a/tests/gui/test_config_file_monitor.py
+++ b/tests/gui/test_config_file_monitor.py
@@ -1,0 +1,80 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Tests for the external-edit watcher on the project configuration."""
+
+import pytest
+
+pytest.importorskip("PySide6")
+pytest.importorskip("pytestqt")
+
+from PySide6 import QtWidgets
+
+from deeplabcut.gui.config_file_monitor import ConfigFileMonitor
+
+
+@pytest.fixture
+def status_bar(qtbot):
+    bar = QtWidgets.QStatusBar()
+    qtbot.addWidget(bar)
+    return bar
+
+
+def _make_monitor(status_bar, config_path, on_reload=lambda: True):
+    monitor = ConfigFileMonitor(status_bar, on_reload=on_reload, debounce_ms=50)
+    monitor.set_path(str(config_path))
+    monitor.mark_current()
+    return monitor
+
+
+def test_external_edit_offers_reload(qtbot, tmp_path, status_bar):
+    config = tmp_path / "config.yaml"
+    config.write_text("Task: test\n")
+    monitor = _make_monitor(status_bar, config)
+    assert monitor._reload_button.isHidden()
+
+    config.write_text("Task: test\nedited: true\n")
+
+    qtbot.waitUntil(lambda: not monitor._reload_button.isHidden(), timeout=5000)
+
+
+def test_mark_current_dismisses_reload_offer(qtbot, tmp_path, status_bar):
+    config = tmp_path / "config.yaml"
+    config.write_text("Task: test\n")
+    monitor = _make_monitor(status_bar, config)
+
+    config.write_text("Task: changed\n")
+    qtbot.waitUntil(lambda: not monitor._reload_button.isHidden(), timeout=5000)
+
+    monitor.mark_current()  # simulates a successful reload
+    assert monitor._reload_button.isHidden()
+
+
+def test_set_path_resets_pending_notification(qtbot, tmp_path, status_bar):
+    config = tmp_path / "config.yaml"
+    config.write_text("Task: test\n")
+    monitor = _make_monitor(status_bar, config)
+
+    config.write_text("Task: changed\n")
+    qtbot.waitUntil(lambda: not monitor._reload_button.isHidden(), timeout=5000)
+
+    other = tmp_path / "other.yaml"
+    other.write_text("Task: other\n")
+    monitor.set_path(str(other))
+
+    assert monitor._reload_button.isHidden()
+
+
+def test_reload_button_triggers_callback(qtbot, tmp_path, status_bar):
+    config = tmp_path / "config.yaml"
+    config.write_text("Task: test\n")
+    reloads = []
+    monitor = _make_monitor(status_bar, config, on_reload=lambda: reloads.append(True))
+
+    monitor._reload_button.click()
+
+    assert reloads == [True]

--- a/tests/gui/test_main_window_config.py
+++ b/tests/gui/test_main_window_config.py
@@ -16,6 +16,8 @@ import pytest
 pytest.importorskip("PySide6")
 pytest.importorskip("pytestqt")
 
+from PySide6 import QtWidgets
+
 pytestmark = pytest.mark.functional
 
 
@@ -118,3 +120,67 @@ class TestRecoveryLoop:
 
         assert stubbed_window._build_project_ui_from_current_config() is True
         assert stubbed_window._built_tabs == [True]
+
+
+class TestConfigCacheInvalidation:
+    def test_invalidate_drops_cache_for_next_access(self, main_window, tmp_path, write_project_config):
+        config_path = tmp_path / "config.yaml"
+        write_project_config(config_path, tmp_path)
+        main_window.config = str(config_path)
+
+        first = main_window.cfg
+        assert first is not None
+
+        write_project_config(config_path, tmp_path, task="changed-on-disk")
+        main_window.invalidate_config_cache()
+        reloaded = main_window.cfg
+
+        assert reloaded is not first
+        assert reloaded.Task == "changed-on-disk"
+
+    def test_invalidate_is_idempotent(self, main_window):
+        # Must not raise even with no config loaded.
+        main_window.config = None
+        main_window.invalidate_config_cache()
+        assert main_window.cfg is None
+
+
+class TestReloadTimer:
+    def test_named_timer_triggers_reload(self, qapp, qtbot, tmp_path, write_project_config, monkeypatch):
+        """Verify the _reload_timer in ManageProject fires reload_project_config."""
+        from deeplabcut.gui.tabs.manage_project import ManageProject
+
+        # Keep QSettings out of the real user settings.
+        qapp.setOrganizationName("DeepLabCut-Tests")
+        qapp.setApplicationName("DLC-GUI-Tests")
+        monkeypatch.setattr(
+            QtWidgets.QMessageBox,
+            "question",
+            lambda *args, **kwargs: QtWidgets.QMessageBox.Yes,
+        )
+
+        config_path = tmp_path / "config.yaml"
+        write_project_config(config_path, tmp_path)
+
+        from deeplabcut.gui.window import MainWindow
+
+        window = MainWindow(qapp)
+        try:
+            window.config = str(config_path)
+
+            reloads = []
+            monkeypatch.setattr(
+                window,
+                "reload_project_config",
+                lambda: reloads.append(True),
+            )
+
+            tab = ManageProject(window, window, "")
+            tab._reload_timer.start()
+
+            # The timer has interval=0 so it fires on the next event loop tick.
+            qtbot.wait(50)
+
+            assert len(reloads) == 1
+        finally:
+            window.close()

--- a/tests/gui/test_main_window_config.py
+++ b/tests/gui/test_main_window_config.py
@@ -1,0 +1,120 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Functional tests for MainWindow config caching and error recovery.
+
+These construct a real (off-screen) MainWindow but stub out ``add_tabs`` and
+the error dialog, so no DLC project on disk and no user interaction is needed.
+"""
+
+import pytest
+
+pytest.importorskip("PySide6")
+pytest.importorskip("pytestqt")
+
+pytestmark = pytest.mark.functional
+
+
+class TestCfgCaching:
+    def test_cfg_is_cached_between_accesses(self, main_window, tmp_path, write_project_config):
+        config_path = tmp_path / "config.yaml"
+        write_project_config(config_path, tmp_path)
+
+        main_window.config = str(config_path)
+
+        first = main_window.cfg
+        assert first is not None
+        assert first is main_window.cfg  # same validated snapshot
+
+    def test_external_edit_does_not_silently_reload(self, main_window, tmp_path, write_project_config):
+        config_path = tmp_path / "config.yaml"
+        write_project_config(config_path, tmp_path)
+        main_window.config = str(config_path)
+        first = main_window.cfg
+
+        write_project_config(config_path, tmp_path, task="edited")
+
+        # The GUI keeps operating on the loaded snapshot until an explicit reload.
+        assert main_window.cfg is first
+        assert main_window.cfg.Task == "demo"
+
+    def test_assigning_config_invalidates_cache(self, main_window, tmp_path, write_project_config):
+        config_path = tmp_path / "config.yaml"
+        write_project_config(config_path, tmp_path)
+        main_window.config = str(config_path)
+        first = main_window.cfg
+
+        write_project_config(config_path, tmp_path, task="edited")
+        main_window.config = str(config_path)  # explicit reload boundary
+
+        reloaded = main_window.cfg
+        assert reloaded is not first
+        assert reloaded.Task == "edited"
+
+    def test_cfg_is_none_without_a_project(self, main_window):
+        main_window.config = None
+        assert main_window.cfg is None
+
+
+class TestRecoveryLoop:
+    """_build_project_ui_from_current_config must never crash the window."""
+
+    @pytest.fixture
+    def stubbed_window(self, main_window):
+        main_window._built_tabs = []
+        main_window.add_tabs = lambda: main_window._built_tabs.append(True)
+        return main_window
+
+    def test_cancel_leaves_welcome_page(self, stubbed_window, tmp_path, write_project_config):
+        from deeplabcut.gui.window import ConfigErrorAction
+
+        config_path = tmp_path / "config.yaml"
+        write_project_config(config_path, tmp_path, extra="not_a_dlc_setting: 1")
+
+        handled = []
+
+        def cancel(error):
+            handled.append(error)
+            return ConfigErrorAction.CANCEL
+
+        stubbed_window._handle_config_error = cancel
+        stubbed_window.config = str(config_path)
+
+        assert stubbed_window._build_project_ui_from_current_config() is False
+        assert len(handled) == 1
+        assert stubbed_window._built_tabs == []
+
+    def test_retry_succeeds_after_user_fixes_config(self, stubbed_window, tmp_path, write_project_config):
+        from deeplabcut.gui.window import ConfigErrorAction
+
+        config_path = tmp_path / "config.yaml"
+        write_project_config(config_path, tmp_path, extra="not_a_dlc_setting: 1")
+
+        def fix_file_and_retry(error):
+            write_project_config(config_path, tmp_path, task="repaired")
+            return ConfigErrorAction.RETRY
+
+        stubbed_window._handle_config_error = fix_file_and_retry
+        stubbed_window.config = str(config_path)
+
+        assert stubbed_window._build_project_ui_from_current_config() is True
+        assert stubbed_window._built_tabs == [True]
+        # Each retry re-reads from disk, so the repaired file is what got loaded.
+        assert stubbed_window.cfg.Task == "repaired"
+
+    def test_valid_config_builds_tabs_without_error_handling(self, stubbed_window, tmp_path, write_project_config):
+        config_path = tmp_path / "config.yaml"
+        write_project_config(config_path, tmp_path)
+
+        def unexpected(error):  # pragma: no cover - should not run
+            raise AssertionError(f"error handler should not be called: {error}")
+
+        stubbed_window._handle_config_error = unexpected
+        stubbed_window.config = str(config_path)
+
+        assert stubbed_window._build_project_ui_from_current_config() is True
+        assert stubbed_window._built_tabs == [True]

--- a/tests/gui/test_selected_shuffle_display.py
+++ b/tests/gui/test_selected_shuffle_display.py
@@ -1,0 +1,94 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Tests for the shuffle info display degrading gracefully on bad shuffles."""
+
+import pytest
+
+pytest.importorskip("PySide6")
+pytest.importorskip("pytestqt")
+
+import PySide6.QtCore as QtCore
+
+from deeplabcut.core.engine import Engine
+from deeplabcut.gui.displays.selected_shuffle_display import SelectedShuffleDisplay
+
+
+class FakeRoot(QtCore.QObject):
+    """Minimal stand-in for MainWindow as seen by SelectedShuffleDisplay."""
+
+    shuffle_change = QtCore.Signal(int)
+    engine_change = QtCore.Signal(object)
+    shuffle_created = QtCore.Signal(int)
+
+    def __init__(self, pose_cfg_path: str, raise_error: Exception | None = None):
+        super().__init__()
+        self.shuffle_value = 1
+        self.engine = Engine.PYTORCH
+        self._pose_cfg_path = pose_cfg_path
+        self._raise_error = raise_error
+
+    @property
+    def pose_cfg_path(self) -> str:
+        if self._raise_error is not None:
+            raise self._raise_error
+        return self._pose_cfg_path
+
+
+def test_missing_pose_cfg_shows_error_instead_of_crashing(qtbot, tmp_path):
+    missing = tmp_path / "missing" / "pose_cfg.yaml"
+    display = SelectedShuffleDisplay(FakeRoot(str(missing)))
+    qtbot.addWidget(display)
+
+    assert display.pose_cfg is None
+    assert "was not created" in display._label.text()
+
+
+def test_unresolvable_shuffle_shows_error(qtbot, tmp_path):
+    root = FakeRoot(str(tmp_path), raise_error=ValueError("no such shuffle"))
+    display = SelectedShuffleDisplay(root)
+    qtbot.addWidget(display)
+
+    assert display.pose_cfg is None
+    assert "Failed to read shuffle 1" in display._label.text()
+
+
+def test_valid_pose_cfg_is_displayed(qtbot, tmp_path):
+    pose_cfg_path = tmp_path / "pytorch_config.yaml"
+    pose_cfg_path.write_text("net_type: resnet_50\nmethod: TD\n")
+
+    display = SelectedShuffleDisplay(FakeRoot(str(pose_cfg_path)))
+    qtbot.addWidget(display)
+
+    assert display.pose_cfg == {"net_type": "resnet_50", "method": "TD"}
+    assert "resnet_50" in display._label.text()
+    assert "top-down" in display._label.text()
+
+
+def test_pose_cfg_without_method_key_does_not_crash(qtbot, tmp_path):
+    """Regression: pose_cfg.get('method').lower() raised AttributeError."""
+    pose_cfg_path = tmp_path / "pytorch_config.yaml"
+    pose_cfg_path.write_text("net_type: resnet_50\n")
+
+    display = SelectedShuffleDisplay(FakeRoot(str(pose_cfg_path)))
+    qtbot.addWidget(display)
+
+    assert display.pose_cfg == {"net_type": "resnet_50"}
+    assert "top-down" not in display._label.text()
+
+
+def test_pose_cfg_signal_carries_none(qtbot, tmp_path):
+    """Regression: the signal was declared Signal(dict) and mangled None."""
+    missing = tmp_path / "missing" / "pose_cfg.yaml"
+    display = SelectedShuffleDisplay(FakeRoot(str(missing)))
+    qtbot.addWidget(display)
+
+    received = []
+    display.pose_cfg_signal.connect(received.append)
+    display.pose_cfg = None
+
+    assert received == [None]

--- a/tests/gui/test_task_error.py
+++ b/tests/gui/test_task_error.py
@@ -1,0 +1,81 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Tests for MainWindow.show_task_error dialog rendering."""
+
+import pytest
+
+pytest.importorskip("PySide6")
+pytest.importorskip("pytestqt")
+
+
+from pydantic import ValidationError
+from PySide6 import QtWidgets
+
+from deeplabcut.core.config import ProjectConfig
+
+
+def _make_validation_error(cfg: dict) -> ValidationError:
+    with pytest.raises(ValidationError) as exc_info:
+        ProjectConfig.from_dict(cfg)
+    return exc_info.value
+
+
+class TestShowTaskError:
+    @pytest.fixture
+    def patched_messagebox(self, monkeypatch):
+        """Intercept every QMessageBox so show_task_error never blocks."""
+        captured = {}
+
+        class _Box(QtWidgets.QMessageBox):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                captured["instance"] = self
+
+            def exec(self):
+                captured["exec_called"] = True
+                return 0
+
+        monkeypatch.setattr(QtWidgets, "QMessageBox", _Box)
+        return captured
+
+    def test_generic_error_shows_task_failed_dialog(
+        self, main_window, tmp_path, write_project_config, patched_messagebox
+    ):
+        """Non-config exceptions get a generic 'Task failed' dialog."""
+        config_path = tmp_path / "config.yaml"
+        write_project_config(config_path, tmp_path)
+        main_window.config = str(config_path)
+
+        main_window.show_task_error(ValueError("config is empty or null"))
+
+        box = patched_messagebox["instance"]
+        assert box.windowTitle() == "Task failed"
+        assert box.text() == "DeepLabCut could not complete the task."
+        assert "config is empty or null" in box.informativeText()
+
+        button_texts = [b.text() for b in box.buttons()]
+        assert "Open configuration" not in button_texts
+
+    def test_config_validation_error_shows_open_button(
+        self, main_window, tmp_path, write_project_config, patched_messagebox
+    ):
+        """Config validation errors show an 'Open configuration' button."""
+        config_path = tmp_path / "config.yaml"
+        write_project_config(config_path, tmp_path)
+        main_window.config = str(config_path)
+
+        error = _make_validation_error({"multianimalproject": "banana"})
+
+        main_window.show_task_error(error, config_path=str(config_path))
+
+        box = patched_messagebox["instance"]
+        assert box.windowTitle() == "Invalid project configuration"
+        assert "multianimalproject" in box.informativeText()
+
+        button_texts = [b.text() for b in box.buttons()]
+        assert "Open configuration" in button_texts

--- a/tests/gui/test_worker.py
+++ b/tests/gui/test_worker.py
@@ -1,0 +1,75 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Tests for worker-thread task execution and error marshalling."""
+
+import pytest
+
+pytest.importorskip("PySide6")
+pytest.importorskip("pytestqt")
+
+from deeplabcut.gui.utils import CaptureWorker, Worker, move_to_separate_thread
+
+
+def _boom():
+    raise ZeroDivisionError("boom")
+
+
+def test_worker_emits_finished_on_success(qtbot):
+    calls = []
+    worker = Worker(lambda: calls.append(True))
+
+    with qtbot.waitSignal(worker.finished, timeout=1000):
+        worker.run()
+
+    assert calls == [True]
+
+
+def test_worker_emits_error_and_finished_on_exception(qtbot):
+    """Regression: a raising task used to kill the worker without any signal,
+    leaving progress bars spinning and buttons disabled forever."""
+    worker = Worker(_boom)
+    errors = []
+    worker.error.connect(errors.append)
+
+    with qtbot.waitSignal(worker.finished, timeout=1000):
+        worker.run()
+
+    assert len(errors) == 1
+    assert isinstance(errors[0], ZeroDivisionError)
+
+
+def test_capture_worker_captures_outputs():
+    worker = CaptureWorker(lambda: "result")
+    worker.run()
+    assert worker.outputs == "result"
+
+
+def test_capture_worker_outputs_none_on_error(qtbot):
+    worker = CaptureWorker(_boom)
+    errors = []
+    worker.error.connect(errors.append)
+
+    with qtbot.waitSignal(worker.finished, timeout=1000):
+        worker.run()
+
+    assert worker.outputs is None
+    assert len(errors) == 1
+
+
+def test_thread_quits_after_exception(qtbot):
+    """Regression: the QThread must stop even when the task raises."""
+    worker, thread = move_to_separate_thread(_boom)
+    errors = []
+    worker.error.connect(errors.append)
+
+    with qtbot.waitSignal(thread.finished, timeout=3000):
+        thread.start()
+
+    qtbot.waitUntil(thread.isFinished, timeout=3000)
+    assert len(errors) == 1
+    assert isinstance(errors[0], ZeroDivisionError)


### PR DESCRIPTION
## Summary
Some add-on follow-up commits to merge/cherry-pick into #3397 

- Simplify error messages (`83bf20d8`) and deduplicate error handling (`35eb0eb6`).
- Use a cached, typed `ProjectConfig` throughout the GUI (`a37f5ef6`, `e4832ed1`).
- Reload after in-app edits and notify users about external changes (`d649f6df`, `2f82e030`).
- Handle invalid project and pose configs without crashing or hanging workers (`83200b18`, `12d07b2a`).
- Keep the config editor usable for repairing invalid files (`1cb4d940`).
- Use the canonical typed config reader in `compat.py` (`4f9cf4af`).
- Add basic pytest-qt coverage (`991d9f77`).

## Tests

Some basic tests for the new behavior are added here:
```text
python -m pytest tests/gui
```
