### PR TITLE
Fix CondFromModel loading the config path as its snapshot

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/data/ctd.py
+++ b/deeplabcut/pose_estimation_pytorch/data/ctd.py
@@ -477,7 +477,7 @@ class CondFromModel(CondProvider):
     ) -> None:
         if config_path is not None and snapshot_path is not None:
             config_path = Path(config_path)
-            snapshot_path = Path(config_path)
+            snapshot_path = Path(snapshot_path)
         elif "config" in kwargs and "shuffle" in kwargs:
             bu_loader, snapshot = self.get_loader_and_snapshot(**kwargs)
             config_path = bu_loader.model_config_path


### PR DESCRIPTION
CondFromModel.__init__ set snapshot_path = Path(config_path), a copy-paste error that overwrote the snapshot path with the config path. When BU conditions were configured the documented way (inference.conditions.config_path + snapshot_path), the model tried to torch.load() the pytorch_config.yaml instead of the .pt snapshot and failed. Use snapshot_path for the snapshot.