### PR TITLE
Fix SORTSkeleton removing the wrong tracker on cleanup

### DIFF
--- a/deeplabcut/core/trackingutils.py
+++ b/deeplabcut/core/trackingutils.py
@@ -601,7 +601,7 @@ class SORTSkeleton(SORTBase):
         for tracker in reversed(self.trackers):
             i -= 1
             if tracker.time_since_update > self.max_age:
-                self.trackers.pop()
+                self.trackers.pop(i)
                 continue
             state = tracker.predict()
             states.append(np.r_[state, [tracker.id, int(animalindex[i])]])


### PR DESCRIPTION
In SORTSkeleton.track, the reverse-iteration cleanup loop maintains i as the current tracker's index but removed dead trackers with self.trackers.pop() (removes the last element) instead of self.trackers.pop(i). The sibling classes SORTBox and SORTEllipse correctly use pop(i).

With a stale tracker in the middle of the list, pop() deleted a different (often still-live) tracker; the dead one persisted and animalindex[i] alignment broke, corrupting identity/tracklet assignment for the skeleton track method.