### PR TITLE
Fix CTD tracklet-age reset writing to a non-existent attribute

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/runners/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/inference.py
@@ -801,7 +801,7 @@ class CTDInferenceRunner(PoseInferenceRunner):
         else:
             self._prev_pose = None
             self._idx_to_id = None
-            self._idx_ages = None
+            self._ctd_track_ages = None
 
     def _merge_conditions(self, bu_cond: np.ndarray) -> np.ndarray:
         """Merges conditions made by a BU model with existing conditions from CTD


### PR DESCRIPTION
When a frame lost all individuals (NMS mask all-False), the reset branch assigned self._idx_ages = None, but the tracking-age attribute is _ctd_track_ages (initialised in __init__ and used by _ctd_tracking_postprocess). _idx_ages is never read anywhere, so the intended reset silently did nothing and a dead attribute was created.

As a result _ctd_track_ages kept its stale values; on the next BU-seeded frame the OKS-NMS ordering was biased toward stale-old indices, retaining the wrong pose/identity, and the bias compounded over subsequent frames. Reset the correct attribute.