### PR TITLE
Fix except clause catching a ValueError instance instead of the type

### DIFF
--- a/deeplabcut/refine_training_dataset/outlier_frames.py
+++ b/deeplabcut/refine_training_dataset/outlier_frames.py
@@ -480,7 +480,7 @@ def extract_outlier_frames(
                 if frames2use is not None:
                     try:
                         frames2use = np.array(frames2use).astype("int")
-                    except ValueError():
+                    except ValueError:
                         print(
                             "Could not cast frames2use into np array, "
                             "please check that frames2use is a simply a list of integers!"


### PR DESCRIPTION
In extract_outlier_frames (outlieralgorithm='list'), the handler was written 'except ValueError():', which evaluates ValueError() to an instance. When the try body raised a ValueError, Python's exception matching hit a non-class handler and raised
'TypeError: catching classes that do not inherit from BaseException is not allowed', masking the real error and the intended message. Catch the ValueError type instead.