### PR TITLE
Replace removed np.object alias with builtin object

### DIFF
--- a/deeplabcut/pose_estimation_tensorflow/core/test.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/test.py
@@ -48,7 +48,7 @@ def test_net(visualise, cache_scoremaps):
             os.makedirs(out_dir)
 
     num_images = dataset.num_images
-    predictions = np.zeros((num_images,), dtype=np.object)
+    predictions = np.zeros((num_images,), dtype=object)
 
     for k in range(num_images):
         print(f"processing image {k}/{num_images - 1}")


### PR DESCRIPTION
test.py used np.zeros(..., dtype=np.object). np.object was a deprecated alias for the builtin object and was removed in numpy 1.24, so it raises AttributeError under the pinned numpy (>=1.18.5,<2 resolves to 1.26). Use dtype=object.