### PR TITLE
Fix operator precedence in condition NaN/non-positive mask

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/runners/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/inference.py
@@ -664,7 +664,7 @@ class CTDInferenceRunner(PoseInferenceRunner):
 
         # Extract the conditions
         conds = predictions["bodyparts"][..., :3]
-        pred_mask = ~np.all(np.any(conds <= 0 | np.isnan(conds), axis=2), axis=1)
+        pred_mask = ~np.all(np.any((conds <= 0) | np.isnan(conds), axis=2), axis=1)
         if np.sum(pred_mask) > 0:
             conds = conds[pred_mask]
         else:


### PR DESCRIPTION
The mask 'conds <= 0 | np.isnan(conds)' parses as
'conds <= (0 | np.isnan(conds))' because bitwise | binds tighter than the <= comparison, so the NaN check was not OR-ed with the non-positive check as intended. Parenthesize to '(conds <= 0) | np.isnan(conds)'.

Verified: for conds=[0.5, -0.1, nan] the buggy expression yields [False, True, False] (misses the NaN), while the fixed expression yields [False, True, True].