### PR TITLE
Fix destfolder leaking across videos in filter/skeleton loops

### DIFF
--- a/deeplabcut/post_processing/analyze_skeleton.py
+++ b/deeplabcut/post_processing/analyze_skeleton.py
@@ -271,13 +271,14 @@ def analyzeskeleton(
     Videos = collect_video_paths(videos, extensions=video_extensions)
     for video in Videos:
         print(f"Processing {video}")
-        if destfolder is None:
-            destfolder = str(Path(video).parents[0])
+        videofolder = destfolder
+        if videofolder is None:
+            videofolder = str(Path(video).parents[0])
 
         vname = Path(video).stem
         try:
             df, filepath, scorer, _ = auxiliaryfunctions.load_analyzed_data(
-                destfolder, vname, DLCscorer, filtered, track_method
+                videofolder, vname, DLCscorer, filtered, track_method
             )
         except FileNotFoundError as e:
             print(e)

--- a/deeplabcut/post_processing/filtering.py
+++ b/deeplabcut/post_processing/filtering.py
@@ -235,14 +235,17 @@ def filterpredictions(
             return video_to_filtered_df
 
     for video in Videos:
-        if destfolder is None:
-            destfolder = str(Path(video).parents[0])
+        videofolder = destfolder
+        if videofolder is None:
+            videofolder = str(Path(video).parents[0])
 
         print(f"Filtering with {filtertype} model {video}")
         vname = Path(video).stem
 
         try:
-            df, filepath, _, _ = auxiliaryfunctions.load_analyzed_data(destfolder, vname, DLCscorer, True, track_method)
+            df, filepath, _, _ = auxiliaryfunctions.load_analyzed_data(
+                videofolder, vname, DLCscorer, True, track_method
+            )
             print(f"Data from {vname} were already filtered. Skipping...")
             video_to_filtered_df[video] = df
             # Data has been filtered so continue to the next video
@@ -253,7 +256,7 @@ def filterpredictions(
         # Data haven't been filtered yet
         try:
             df, filepath, _, _ = auxiliaryfunctions.load_analyzed_data(
-                destfolder, vname, DLCscorer, track_method=track_method
+                videofolder, vname, DLCscorer, track_method=track_method
             )
         except FileNotFoundError as e:
             video_to_filtered_df[video] = None


### PR DESCRIPTION
filterpredictions() and analyzeskeleton() reassigned the destfolder parameter inside their 'for video in Videos' loop when it was None. After the first iteration destfolder stayed pinned to the first video's folder, so videos located in a different folder were looked up in the wrong place: load_analyzed_data raised FileNotFoundError and the video was silently reported as not analyzed (and any output would go to the wrong folder).

Use a per-iteration local 'videofolder' instead of mutating the parameter, matching plot_trajectories and extract_outlier_frames.