### PR TITLE
Fix uncaught NetworkX exceptions in TrackletStitcher.stitch() fallback

### DIFF
--- a/deeplabcut/refine_training_dataset/stitch.py
+++ b/deeplabcut/refine_training_dataset/stitch.py
@@ -670,12 +670,18 @@ class TrackletStitcher:
             # Preflow push seems to work slightly better than shortest
             # augmentation path..., and is more computationally efficient.
             paths = []
-            for path in nx.node_disjoint_paths(self.G, "source", "sink", preflow_push, self.n_tracks):
-                temp = set()
-                for node in path[1:-1]:
-                    self.G.remove_node(node)
-                    temp.add(self._mapping_inv[node])
-                paths.append(list(temp))
+            try:
+                for path in nx.node_disjoint_paths(self.G, "source", "sink", preflow_push, self.n_tracks):
+                    temp = set()
+                    for node in path[1:-1]:
+                        self.G.remove_node(node)
+                        temp.add(self._mapping_inv[node])
+                    paths.append(list(temp))
+            except nx.exception.NetworkXNoPath:
+                warnings.warn(
+                    "Could not find disjoint paths connecting all tracklets. Continuing with partial results.",
+                    stacklevel=2,
+                )
             incomplete_tracks = self.n_tracks - len(paths)
             remaining_nodes = set(self._mapping_inv[node] for node in self.G if node not in ("source", "sink"))
             if len(remaining_nodes) > 0:
@@ -709,8 +715,17 @@ class TrackletStitcher:
                     self.build_graph(list(remaining_nodes), max_gap=np.inf)
                     self.G.nodes["source"]["demand"] = -incomplete_tracks
                     self.G.nodes["sink"]["demand"] = incomplete_tracks
-                    _, self.flow = nx.capacity_scaling(self.G)
-                    paths += self.reconstruct_paths()
+                    try:
+                        _, self.flow = nx.capacity_scaling(self.G)
+                        paths += self.reconstruct_paths()
+                    except nx.exception.NetworkXUnfeasible:
+                        warnings.warn(
+                            "The fallback flow problem is also infeasible. "
+                            f"Could not reconstruct {incomplete_tracks} "
+                            f"remaining tracks from {len(remaining_nodes)} "
+                            f"remaining tracklets.",
+                            stacklevel=2,
+                        )
             self.paths = paths
             if len(self.paths) != self.n_tracks:
                 warnings.warn(f"Only {len(self.paths)} tracks could be reconstructed.", stacklevel=2)


### PR DESCRIPTION
## Summary

- `TrackletStitcher.stitch()` crashes with `ValueError: Could not reconstruct N tracks` when the fallback ("black magic") path encounters infeasible flow problems, discarding all stitching work and leaving users with no `.h5`/`.csv` output after a completed detection run.
- The root cause is two uncaught `networkx` exceptions inside the `except NetworkXUnfeasible` handler, which prevent `self.paths` from ever being set.

**Reported by**: [image.sc forum](https://forum.image.sc/t/runtime-error-when-analysing-videos/121893) — user analyzing 4 visually similar mice in 1-hour videos at 60fps.

## Fix

Wrap both exception sources in `try/except` (matching the existing design intent):
- `node_disjoint_paths` → catch `NetworkXNoPath`, warn, continue with any paths already found.
- Second `capacity_scaling` → catch `NetworkXUnfeasible`, warn, keep existing paths.
