### PR TITLE
Skip TensorFlow-backed tests cleanly when the tf extra is absent

### DIFF
--- a/tests/test_dataset_augmentation.py
+++ b/tests/test_dataset_augmentation.py
@@ -8,16 +8,17 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
-import imgaug.augmenters as iaa
 import numpy as np
 import pytest
-
-from deeplabcut.pose_estimation_tensorflow.datasets import augmentation
 
 tf = pytest.importorskip(
     "tensorflow",
     reason="TensorFlow not installed (use a project extra such as .[tf])",
 )
+
+import imgaug.augmenters as iaa  # noqa: E402
+
+from deeplabcut.pose_estimation_tensorflow.datasets import augmentation  # noqa: E402
 
 
 @pytest.mark.parametrize(

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -12,15 +12,15 @@ import numpy as np
 import pandas as pd
 import pytest
 
-import deeplabcut.pose_estimation_tensorflow as pet
-from deeplabcut.pose_estimation_tensorflow.core.evaluate import (
-    get_available_requested_snapshots,
-    get_snapshots_by_index,
-)
-
 tf = pytest.importorskip(
     "tensorflow",
     reason="TensorFlow not installed (use a project extra such as .[tf])",
+)
+
+import deeplabcut.pose_estimation_tensorflow as pet  # noqa: E402
+from deeplabcut.pose_estimation_tensorflow.core.evaluate import (  # noqa: E402
+    get_available_requested_snapshots,
+    get_snapshots_by_index,
 )
 
 

--- a/tests/test_pose_multianimal_imgaug.py
+++ b/tests/test_pose_multianimal_imgaug.py
@@ -14,15 +14,16 @@ import numpy as np
 import pytest
 
 from deeplabcut.core.config import read_config_as_dict, write_config
-from deeplabcut.pose_estimation_tensorflow.datasets import (
-    Batch,
-    PoseDatasetFactory,
-    pose_multianimal_imgaug,
-)
 
 tf = pytest.importorskip(
     "tensorflow",
     reason="TensorFlow not installed (use a project extra such as .[tf])",
+)
+
+from deeplabcut.pose_estimation_tensorflow.datasets import (  # noqa: E402
+    Batch,
+    PoseDatasetFactory,
+    pose_multianimal_imgaug,
 )
 
 

--- a/tests/test_predict_multianimal.py
+++ b/tests/test_predict_multianimal.py
@@ -11,12 +11,12 @@
 import numpy as np
 import pytest
 
-from deeplabcut.pose_estimation_tensorflow.core import predict_multianimal
-
 tf = pytest.importorskip(
     "tensorflow",
     reason="TensorFlow not installed (use a project extra such as .[tf])",
 )
+
+from deeplabcut.pose_estimation_tensorflow.core import predict_multianimal  # noqa: E402
 
 RADIUS = 5
 THRESHOLD = 0.01

--- a/tests/test_predict_supermodel.py
+++ b/tests/test_predict_supermodel.py
@@ -11,7 +11,14 @@
 import numpy as np
 import pytest
 
-from deeplabcut.pose_estimation_tensorflow.modelzoo.api import superanimal_inference
+tf = pytest.importorskip(
+    "tensorflow",
+    reason="TensorFlow not installed (use a project extra such as .[tf])",
+)
+
+from deeplabcut.pose_estimation_tensorflow.modelzoo.api import (  # noqa: E402
+    superanimal_inference,
+)
 
 
 def test_get_multi_scale_frames():


### PR DESCRIPTION
While working on #3417, I noticed that the test suite could no longer be collected in a base install (without the `tf` extra).

`pytest.importorskip("tensorflow")` is meant to skip these tests when TensorFlow is not installed. However, in the affected modules the guard is placed after the imports of TF-backed code from `deeplabcut.pose_estimation_tensorflow`. During pytest's collection phase those imports run first, so a base install raises an import error before the guard is ever reached, making the `importorskip` effectively a no-op.

This PR does three things. It moves `pytest.importorskip("tensorflow")` above the TF-backed imports in the affected modules so they skip cleanly instead of erroring, it adds the missing guard to `test_predict_supermodel.py` which had none, and it marks the relocated imports with `# noqa: E402` since they now intentionally follow module-level code.