### PR TITLE
Harden path-handling after pathlib migration

### DIFF
--- a/deeplabcut/generate_training_dataset/metadata.py
+++ b/deeplabcut/generate_training_dataset/metadata.py
@@ -298,7 +298,7 @@ class TrainingDatasetMetadata:
                 f for f in trainset_path.iterdir() if re.match(r"Documentation_data-.+shuffle[0-9]+\.pickle", f.name)
             ]
         else:
-            trainset_path.mkdir(parents=True)
+            trainset_path.mkdir(parents=True, exist_ok=True)
             shuffle_docs = []
 
         prefix = cfg["Task"] + cfg["date"]

--- a/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/multiple_individuals_trainingsetmanipulation.py
@@ -597,8 +597,6 @@ def convert_cropped_to_standard_dataset(
 
     from deeplabcut.utils import read_plainconfig, write_config
 
-    from . import trainingsetmanipulation
-
     cfg = auxiliaryfunctions.read_config(config_path)
     videos_orig = cfg.pop("video_sets_original")
     is_cropped = cfg.pop("croppedtraining")
@@ -616,7 +614,7 @@ def convert_cropped_to_standard_dataset(
         print("Deleting crops...")
         data_path = Path(project_path) / "labeled-data"
         for video in cfg["video_sets"]:
-            _, filename, _ = trainingsetmanipulation._robust_path_split(video)
+            filename = Path(video).stem
             if "_cropped" in video:  # One can never be too safe...
                 shutil.rmtree(data_path / filename, ignore_errors=True)
 

--- a/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcut/generate_training_dataset/trainingsetmanipulation.py
@@ -301,7 +301,7 @@ def check_labels(
         Labels = ["+", ".", "x"]
     cfg = read_config(config)
     videos = cfg["video_sets"].keys()
-    video_names = [_robust_path_split(video)[1] for video in videos]
+    video_names = [Path(video).stem for video in videos]
 
     folders = [Path(cfg["project_path"]) / "labeled-data" / Path(i) for i in video_names]
     print("Creating images with labels by {}.".format(cfg["scorer"]))
@@ -408,20 +408,6 @@ def MakeInference_yaml(itemstochange, saveasconfigfile, defaultconfigfile):
     return docs[0]
 
 
-def _robust_path_split(path):
-    sep = "\\" if "\\" in path else "/"
-    splits = path.rsplit(sep, 1)
-    if len(splits) == 1:
-        parent = "."
-        file = splits[0]
-    elif len(splits) == 2:
-        parent, file = splits
-    else:
-        raise (f"Unknown filepath split for path {path}")
-    filename, ext = Path(file).stem, Path(file).suffix
-    return parent, filename, ext
-
-
 def parse_video_filenames(videos: list[str]) -> list[str]:
     """Parses the names of all videos listed in a project's ``config.yaml`` file.
 
@@ -446,7 +432,7 @@ def parse_video_filenames(videos: list[str]) -> list[str]:
     filenames = []
     filename_to_videos = {}
     for video in videos:
-        _, filename, _ = _robust_path_split(video)
+        filename = Path(video).stem
         videos_with_filename = filename_to_videos.get(filename, [])
         if len(videos_with_filename) == 0:
             filenames.append(filename)

--- a/deeplabcut/gui/tabs/create_project.py
+++ b/deeplabcut/gui/tabs/create_project.py
@@ -25,6 +25,7 @@ from deeplabcut.gui.tabs.docs import (
 )
 from deeplabcut.gui.widgets import ClickableLabel, ItemSelectionFrame
 from deeplabcut.utils import auxiliaryfunctions
+from deeplabcut.utils.auxfun_videos import collect_video_paths
 
 
 class DynamicTextList(QtWidgets.QWidget):
@@ -434,12 +435,9 @@ class ProjectCreator(QtWidgets.QDialog):
             if not folder:
                 return
 
-            for video in auxiliaryfunctions.grab_files_in_folder(
-                folder,
-                relative=False,
-            ):
-                if Path(video).suffix[1:].lower() in DLCParams.VIDEOTYPES[1:]:
-                    self.video_frame.fancy_list.add_item(video)
+            for video in collect_video_paths(folder):
+                if video.suffix[1:].lower() in DLCParams.VIDEOTYPES[1:]:
+                    self.video_frame.fancy_list.add_item(str(video))
 
     def finalize_project(self):
         fields = [self.proj_line, self.exp_line]

--- a/deeplabcut/modelzoo/generalized_data_converter/datasets/base_dlc.py
+++ b/deeplabcut/modelzoo/generalized_data_converter/datasets/base_dlc.py
@@ -32,7 +32,7 @@ class BaseDLCPoseDataset(BasePoseDataset):
         self.proj_root = proj_root
 
         if modelprefix:
-            config_file = Path(self.proj_root) / (modelprefix + "_config.yaml")
+            config_file = Path(self.proj_root) / f"{modelprefix}_config.yaml"
         else:
             config_file = Path(self.proj_root) / "config.yaml"
 

--- a/deeplabcut/modelzoo/video_inference.py
+++ b/deeplabcut/modelzoo/video_inference.py
@@ -436,15 +436,15 @@ def video_inference_superanimal(
 
             # we prepare the pseudo dataset in the same folder of the target video
             pseudo_dataset_folder = video_path.with_name(f"pseudo_{video_path.stem}")
-            pseudo_dataset_folder.mkdir(exist_ok=True)
+            pseudo_dataset_folder.mkdir(exist_ok=True, parents=True)
             model_folder = pseudo_dataset_folder / "checkpoints"
-            model_folder.mkdir(exist_ok=True)
+            model_folder.mkdir(exist_ok=True, parents=True)
 
             image_folder = pseudo_dataset_folder / "images"
             if image_folder.exists():
                 print(f"{image_folder} exists, skipping the frame extraction")
             else:
-                image_folder.mkdir()
+                image_folder.mkdir(exist_ok=True, parents=True)
                 print(f"Video frames being extracted to {image_folder} for video adaptation.")
                 video_to_frames(video_path, pseudo_dataset_folder, cropping=cropping)
 
@@ -455,7 +455,7 @@ def video_inference_superanimal(
                     f"Delete the folder if you want to re-construct pseudo annotations"
                 )
             else:
-                anno_folder.mkdir()
+                anno_folder.mkdir(exist_ok=True, parents=True)
 
                 if dest_folder is None:
                     pseudo_anno_dir = video_path.parent

--- a/deeplabcut/pose_estimation_pytorch/apis/videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/videos.py
@@ -834,7 +834,7 @@ def _validate_destfolder(destfolder: str | None) -> None:
         output_folder = Path(destfolder)
         if not output_folder.exists():
             print(f"Creating the output folder {output_folder}")
-            output_folder.mkdir(parents=True)
+            output_folder.mkdir(parents=True, exist_ok=True)
 
         assert Path(output_folder).is_dir(), f"Output folder must be a directory: you passed '{output_folder}'"
 

--- a/deeplabcut/pose_estimation_tensorflow/core/openvino/session.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/openvino/session.py
@@ -26,7 +26,7 @@ except ImportError:
 class OpenVINOSession:
     def __init__(self, cfg, device):
         self.core = Core()
-        self.xml_path = cfg["init_weights"] + ".xml"
+        self.xml_path = str(Path(cfg["init_weights"]).with_suffix(".xml"))
         self.device = device
 
         # Convert a frozen graph to OpenVINO IR format
@@ -37,7 +37,7 @@ class OpenVINOSession:
                     "--output_dir",
                     str(Path(cfg["init_weights"]).parent),
                     "--input_model",
-                    cfg["init_weights"] + ".pb",
+                    str(Path(cfg["init_weights"]).with_suffix(".pb")),
                     "--input_shape",
                     "[1, 747, 832, 3]",
                     "--extensions",

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_deterministic.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_deterministic.py
@@ -17,7 +17,6 @@ import numpy as np
 import scipy.io as sio
 
 from deeplabcut.utils.auxfun_videos import imread, imresize
-from deeplabcut.utils.conversioncode import robust_split_path
 
 from .factory import PoseDatasetFactory
 from .pose_base import BasePoseDataset
@@ -62,11 +61,7 @@ class DeterministicPoseDataset(BasePoseDataset):
             item = DataItem()
             item.image_id = i
             im_path = sample[0][0]
-            if isinstance(im_path, str):
-                im_path = robust_split_path(im_path)
-            else:
-                im_path = [s.strip() for s in im_path]
-            item.im_path = str(Path(*im_path))
+            item.im_path = str(Path(*im_path) if isinstance(im_path, list) else Path(im_path))
             item.im_size = sample[1][0]
             if len(sample) >= 3:
                 joints = sample[2][0][0]

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_deterministic.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_deterministic.py
@@ -23,6 +23,7 @@ from .pose_base import BasePoseDataset
 from .utils import (
     Batch,
     DataItem,
+    _normalize_image_path,
     crop_image,
     data_to_input,
     mirror_joints_map,
@@ -60,8 +61,7 @@ class DeterministicPoseDataset(BasePoseDataset):
 
             item = DataItem()
             item.image_id = i
-            im_path = sample[0][0]
-            item.im_path = str(Path(*im_path) if isinstance(im_path, list) else Path(im_path))
+            item.im_path: str = _normalize_image_path(sample[0][0])
             item.im_size = sample[1][0]
             if len(sample) >= 3:
                 joints = sample[2][0][0]

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
@@ -27,7 +27,7 @@ from deeplabcut.utils.auxfun_videos import imread
 
 from .factory import PoseDatasetFactory
 from .pose_base import BasePoseDataset
-from .utils import Batch, DataItem
+from .utils import Batch, DataItem, _normalize_image_path
 
 
 @PoseDatasetFactory.register("default")
@@ -92,10 +92,7 @@ class ImgaugPoseDataset(BasePoseDataset):
 
                 item = DataItem()
                 item.image_id = i
-                im_path = sample[0][0]
-                if isinstance(im_path, np.ndarray):
-                    im_path = [str(x) for x in im_path.flatten()]
-                item.im_path = str(Path(*im_path) if isinstance(im_path, list) else Path(im_path))
+                item.im_path: str = _normalize_image_path(sample[0][0])
                 item.im_size = sample[1][0]
                 if len(sample) >= 3:
                     joints = sample[2][0][0]
@@ -125,10 +122,7 @@ class ImgaugPoseDataset(BasePoseDataset):
                 sample = pickledata[i]  # mlab[0, i]
                 item = DataItem()
                 item.image_id = i
-                im_path = sample["image"]
-                if isinstance(im_path, np.ndarray):
-                    im_path = [str(x) for x in im_path.flatten()]
-                item.im_path = str(Path(*im_path))  # [0][0]
+                item.im_path: str = _normalize_image_path(sample["image"])  # [0][0]
                 item.im_size = sample["size"]  # sample[1][0]
                 if len(sample) >= 3:
                     item.num_animals = len(sample["joints"])

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
@@ -93,6 +93,8 @@ class ImgaugPoseDataset(BasePoseDataset):
                 item = DataItem()
                 item.image_id = i
                 im_path = sample[0][0]
+                if isinstance(im_path, np.ndarray):
+                    im_path = [str(x) for x in im_path.flatten()]
                 item.im_path = str(Path(*im_path) if isinstance(im_path, list) else Path(im_path))
                 item.im_size = sample[1][0]
                 if len(sample) >= 3:
@@ -123,7 +125,10 @@ class ImgaugPoseDataset(BasePoseDataset):
                 sample = pickledata[i]  # mlab[0, i]
                 item = DataItem()
                 item.image_id = i
-                item.im_path = str(Path(*sample["image"]))  # [0][0]
+                im_path = sample["image"]
+                if isinstance(im_path, np.ndarray):
+                    im_path = [str(x) for x in im_path.flatten()]
+                item.im_path = str(Path(*im_path))  # [0][0]
                 item.im_size = sample["size"]  # sample[1][0]
                 if len(sample) >= 3:
                     item.num_animals = len(sample["joints"])

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_imgaug.py
@@ -24,7 +24,6 @@ import scipy.io as sio
 
 from deeplabcut.pose_estimation_tensorflow.datasets import augmentation
 from deeplabcut.utils.auxfun_videos import imread
-from deeplabcut.utils.conversioncode import robust_split_path
 
 from .factory import PoseDatasetFactory
 from .pose_base import BasePoseDataset
@@ -94,11 +93,7 @@ class ImgaugPoseDataset(BasePoseDataset):
                 item = DataItem()
                 item.image_id = i
                 im_path = sample[0][0]
-                if isinstance(im_path, str):
-                    im_path = robust_split_path(im_path)
-                else:
-                    im_path = [s.strip() for s in im_path]
-                item.im_path = str(Path(*im_path))
+                item.im_path = str(Path(*im_path) if isinstance(im_path, list) else Path(im_path))
                 item.im_size = sample[1][0]
                 if len(sample) >= 3:
                     joints = sample[2][0][0]

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_multianimal_imgaug.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_multianimal_imgaug.py
@@ -28,7 +28,6 @@ from deeplabcut.pose_estimation_tensorflow.datasets.pose_base import BasePoseDat
 from deeplabcut.pose_estimation_tensorflow.datasets.utils import Batch, DataItem
 from deeplabcut.utils import auxfun_multianimal, auxiliaryfunctions
 from deeplabcut.utils.auxfun_videos import VideoReader, imread
-from deeplabcut.utils.conversioncode import robust_split_path
 
 
 @PoseDatasetFactory.register("multi-animal-imgaug")
@@ -102,9 +101,7 @@ class MAImgaugPoseDataset(BasePoseDataset):
             item = DataItem()
             item.image_id = i
             im_path = sample["image"]
-            if isinstance(im_path, str):
-                im_path = robust_split_path(im_path)
-            item.im_path = str(Path(*im_path))
+            item.im_path = str(Path(*im_path) if isinstance(im_path, list) else Path(im_path))
             item.im_size = sample["size"]
             if "joints" in sample.keys():
                 Joints = sample["joints"]

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_multianimal_imgaug.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_multianimal_imgaug.py
@@ -25,7 +25,7 @@ from deeplabcut.generate_training_dataset import read_image_shape_fast
 from deeplabcut.pose_estimation_tensorflow.datasets import augmentation
 from deeplabcut.pose_estimation_tensorflow.datasets.factory import PoseDatasetFactory
 from deeplabcut.pose_estimation_tensorflow.datasets.pose_base import BasePoseDataset
-from deeplabcut.pose_estimation_tensorflow.datasets.utils import Batch, DataItem
+from deeplabcut.pose_estimation_tensorflow.datasets.utils import Batch, DataItem, _normalize_image_path
 from deeplabcut.utils import auxfun_multianimal, auxiliaryfunctions
 from deeplabcut.utils.auxfun_videos import VideoReader, imread
 
@@ -100,8 +100,7 @@ class MAImgaugPoseDataset(BasePoseDataset):
             sample = pickledata[i]  # mlab[0, i]
             item = DataItem()
             item.image_id = i
-            im_path = sample["image"]
-            item.im_path = str(Path(*im_path) if isinstance(im_path, list) else Path(im_path))
+            item.im_path: str = _normalize_image_path(sample["image"])
             item.im_size = sample["size"]
             if "joints" in sample.keys():
                 Joints = sample["joints"]

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_tensorpack.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_tensorpack.py
@@ -46,7 +46,7 @@ from tensorpack.utils.utils import get_rng
 
 from .factory import PoseDatasetFactory
 from .pose_base import BasePoseDataset
-from .utils import Batch, data_to_input
+from .utils import Batch, _normalize_image_path, data_to_input
 
 
 def img_to_bgr(im_path):
@@ -113,9 +113,7 @@ class Pose(RNGDataFlow):
             item = DataItem()
             item.image_id = i
             base = str(self.cfg["project_path"])
-            im_path = sample[0][0]
-            im_path = Path(*im_path) if isinstance(im_path, list) else Path(im_path)
-            item.im_path = str(Path(base) / im_path)
+            item.im_path = str(Path(base) / _normalize_image_path(sample[0][0]))
             item.im_size = sample[1][0]
             if len(sample) >= 3:
                 joints = sample[2][0][0]

--- a/deeplabcut/pose_estimation_tensorflow/datasets/pose_tensorpack.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/pose_tensorpack.py
@@ -44,8 +44,6 @@ from tensorpack.dataflow.imgaug.transform import CropTransform
 from tensorpack.dataflow.parallel import MultiProcessRunner, MultiProcessRunnerZMQ
 from tensorpack.utils.utils import get_rng
 
-from deeplabcut.utils.conversioncode import robust_split_path
-
 from .factory import PoseDatasetFactory
 from .pose_base import BasePoseDataset
 from .utils import Batch, data_to_input
@@ -116,11 +114,8 @@ class Pose(RNGDataFlow):
             item.image_id = i
             base = str(self.cfg["project_path"])
             im_path = sample[0][0]
-            if isinstance(im_path, str):
-                im_path = robust_split_path(im_path)
-            else:
-                im_path = [s.strip() for s in im_path]
-            item.im_path = str(Path(base).joinpath(*im_path))
+            im_path = Path(*im_path) if isinstance(im_path, list) else Path(im_path)
+            item.im_path = str(Path(base) / im_path)
             item.im_size = sample[1][0]
             if len(sample) >= 3:
                 joints = sample[2][0][0]

--- a/deeplabcut/pose_estimation_tensorflow/datasets/utils.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/utils.py
@@ -9,6 +9,7 @@
 # Licensed under GNU Lesser General Public License v3.0
 #
 from enum import Enum
+from pathlib import Path
 
 import numpy as np
 
@@ -26,6 +27,15 @@ class Batch(Enum):
 
 class DataItem:
     pass
+
+
+# NOTE @deruyter92 2026-07-21: the TensorFlow branch is deprecated soon, and excluded from the migration to pathlib
+def _normalize_image_path(im_path: np.ndarray | list | tuple | Path | str) -> str:
+    """Convert a raw image path from .mat or pickle format to a string."""
+    if isinstance(im_path, np.ndarray):
+        im_path = [str(x) for x in im_path.flatten()]
+    im_path = Path(*im_path) if isinstance(im_path, (list, tuple)) else Path(im_path)
+    return str(im_path)
 
 
 def data_to_input(data):

--- a/deeplabcut/pose_estimation_tensorflow/datasets/utils.py
+++ b/deeplabcut/pose_estimation_tensorflow/datasets/utils.py
@@ -33,7 +33,7 @@ class DataItem:
 def _normalize_image_path(im_path: np.ndarray | list | tuple | Path | str) -> str:
     """Convert a raw image path from .mat or pickle format to a string."""
     if isinstance(im_path, np.ndarray):
-        im_path = [str(x) for x in im_path.flatten()]
+        im_path = [str(x).strip() for x in im_path.flatten()]
     im_path = Path(*im_path) if isinstance(im_path, (list, tuple)) else Path(im_path)
     return str(im_path)
 

--- a/deeplabcut/pose_estimation_tensorflow/predict_videos.py
+++ b/deeplabcut/pose_estimation_tensorflow/predict_videos.py
@@ -1017,7 +1017,7 @@ def AnalyzeVideo(
         metadata = {"data": dictionary}
 
         print(f"Saving results in {destfolder}...")
-        dataname = str(Path(destfolder) / (vname + DLCscorer + ".h5"))
+        dataname = Path(destfolder) / (vname + DLCscorer + ".h5")
         auxiliaryfunctions.save_data(
             PredictedData[:nframes, :],
             metadata,
@@ -1572,7 +1572,7 @@ def convert_detections2tracklets(
                 destfolder = videofolder
             auxiliaryfunctions.attempt_to_make_folder(destfolder)
             vname = Path(video).stem
-            dataname = str(Path(destfolder) / (vname + DLCscorer + ".h5"))
+            dataname = Path(destfolder) / (vname + DLCscorer + ".h5")
             data, metadata = auxfun_multianimal.LoadFullMultiAnimalData(dataname)
             if track_method == "ellipse":
                 method = "el"
@@ -1580,7 +1580,7 @@ def convert_detections2tracklets(
                 method = "bx"
             else:
                 method = "sk"
-            trackname = dataname.split(".h5")[0] + f"_{method}.pickle"
+            trackname = dataname.with_name(f"{dataname.stem}_{method}.pickle")
             # NOTE: If dataname line above is changed then line below is obsolete?
             # trackname = trackname.replace(videofolder, destfolder)
             if Path(trackname).is_file() and not overwrite:  # TODO: check if metadata are identical (same parameters!)
@@ -1638,7 +1638,7 @@ def convert_detections2tracklets(
                     identity_only=identity_only,
                     min_n_links=inferencecfg["minimalnumberofconnections"],
                 )
-                assemblies_filename = dataname.split(".h5")[0] + "_assemblies.pickle"
+                assemblies_filename = dataname.with_name(dataname.stem + "_assemblies.pickle")
                 if not Path(assemblies_filename).exists() or overwrite:
                     if calibrate:
                         trainingsetfolder = auxiliaryfunctions.get_training_set_folder(cfg)

--- a/deeplabcut/utils/auxfun_multianimal.py
+++ b/deeplabcut/utils/auxfun_multianimal.py
@@ -189,25 +189,29 @@ def SaveFullMultiAnimalData(data, metadata, dataname, suffix="_full"):
     """Save predicted data as h5 file and metadata as pickle file; created by
     predict_videos.py.
     """
-    data_path = dataname.split(".h5")[0] + suffix + ".pickle"
-    metadata_path = dataname.split(".h5")[0] + "_meta.pickle"
+    dataname = Path(dataname)
+    data_path = dataname.with_name(dataname.stem + suffix + ".pickle")
+    metadata_path = dataname.with_name(dataname.stem + "_meta.pickle")
 
-    with Path(data_path).open("wb") as f:
+    data_path.parent.mkdir(parents=True, exist_ok=True)
+    with data_path.open("wb") as f:
         pickle.dump(data, f, pickle.HIGHEST_PROTOCOL)
-    with Path(metadata_path).open("wb") as f:
+    with metadata_path.open("wb") as f:
         pickle.dump(metadata, f, pickle.HIGHEST_PROTOCOL)
     return data_path, metadata_path
 
 
 def LoadFullMultiAnimalData(dataname):
     """Load predicted data and metadata from pickle files created by predict_videos.py."""
-    data_file = dataname.split(".h5")[0] + "_full.pickle"
+    dataname = Path(dataname)
+    data_file = dataname.with_name(dataname.stem + "_full.pickle")
+    metadata_file = dataname.with_name(dataname.stem + "_meta.pickle")
     try:
-        with Path(data_file).open("rb") as handle:
+        with data_file.open("rb") as handle:
             data = pickle.load(handle)
     except (pickle.UnpicklingError, FileNotFoundError):
         data = shelve.open(data_file, flag="r")
-    with Path(data_file.replace("_full.", "_meta.")).open("rb") as handle:
+    with metadata_file.open("rb") as handle:
         metadata = pickle.load(handle)
     return data, metadata
 

--- a/deeplabcut/utils/auxfun_multianimal.py
+++ b/deeplabcut/utils/auxfun_multianimal.py
@@ -31,7 +31,6 @@ import numpy as np
 import pandas as pd
 
 from deeplabcut.core.trackingutils import TRACK_METHODS
-from deeplabcut.generate_training_dataset import trainingsetmanipulation
 from deeplabcut.utils import auxiliaryfunctions, conversioncode
 
 
@@ -255,7 +254,7 @@ def convert2_maDLC(config: str | Path, userfeedback=True, forceindividual=None):
     """
     cfg = auxiliaryfunctions.read_config(config)
     videos = cfg["video_sets"].keys()
-    video_names = [trainingsetmanipulation._robust_path_split(i)[1] for i in videos]
+    video_names = [Path(i).stem for i in videos]
     folders = [Path(config).parent / "labeled-data" / Path(i) for i in video_names]
 
     individuals, uniquebodyparts, multianimalbodyparts = extractindividualsandbodyparts(cfg)

--- a/deeplabcut/utils/auxfun_multianimal.py
+++ b/deeplabcut/utils/auxfun_multianimal.py
@@ -282,7 +282,7 @@ def convert2_maDLC(config: str | Path, userfeedback=True, forceindividual=None):
 
         if askuser == "y" or askuser == "yes" or askuser == "Ja" or askuser == "ha":  # multilanguage support :)
             fn = folder / ("CollectedData_" + cfg["scorer"])
-            Data = pd.read_hdf(str(fn) + ".h5")
+            Data = pd.read_hdf(fn.with_suffix(".h5"))
             conversioncode.guarantee_multiindex_rows(Data)
             imindex = Data.index
 
@@ -341,13 +341,13 @@ def convert2_maDLC(config: str | Path, userfeedback=True, forceindividual=None):
                     dataFrame = pd.concat([dataFrame, frame], axis=1)
 
             Data.to_hdf(
-                fn + "singleanimal.h5",
+                fn.with_name(fn.name + "singleanimal.h5"),
                 key="df_with_missing",
             )
-            Data.to_csv(fn + "singleanimal.csv")
+            Data.to_csv(fn.with_name(fn.name + "singleanimal.csv"))
 
-            dataFrame.to_hdf(fn + ".h5", key="df_with_missing")
-            dataFrame.to_csv(fn + ".csv")
+            dataFrame.to_hdf(fn.with_suffix(".h5"), key="df_with_missing")
+            dataFrame.to_csv(fn.with_suffix(".csv"))
 
 
 def convert_single2multiplelegacyAM(config, userfeedback=True, target=None):
@@ -370,7 +370,7 @@ def convert_single2multiplelegacyAM(config, userfeedback=True, target=None):
 
         if askuser == "y" or askuser == "yes" or askuser == "Ja" or askuser == "ha":  # multilanguage support :)
             fn = folder / ("CollectedData_" + cfg["scorer"])
-            Data = pd.read_hdf(str(fn) + ".h5")
+            Data = pd.read_hdf(fn.with_suffix(".h5"))
             conversioncode.guarantee_multiindex_rows(Data)
             imindex = Data.index
 
@@ -413,16 +413,16 @@ def convert_single2multiplelegacyAM(config, userfeedback=True, target=None):
                         DataFrame = pd.concat([DataFrame, dataFrame], axis=1)
 
                 Data.to_hdf(
-                    fn + "multianimal.h5",
+                    fn.with_name(fn.name + "multianimal.h5"),
                     key="df_with_missing",
                 )
-                Data.to_csv(fn + "multianimal.csv")
+                Data.to_csv(fn.with_name(fn.name + "multianimal.csv"))
 
                 DataFrame.to_hdf(
-                    fn + ".h5",
+                    fn.with_suffix(".h5"),
                     key="df_with_missing",
                 )
-                DataFrame.to_csv(fn + ".csv")
+                DataFrame.to_csv(fn.with_suffix(".csv"))
             elif target is None or target == "multi":
                 print("This is a single animal data set, converting to multi...", folder)
                 for prfxindex, prefix in enumerate(prefixes):
@@ -500,16 +500,16 @@ def convert_single2multiplelegacyAM(config, userfeedback=True, target=None):
                         DataFrame = pd.concat([DataFrame, dataFrame], axis=1)
 
                 Data.to_hdf(
-                    fn + "singleanimal.h5",
+                    fn.with_name(fn.name + "singleanimal.h5"),
                     key="df_with_missing",
                 )
-                Data.to_csv(fn + "singleanimal.csv")
+                Data.to_csv(fn.with_name(fn.name + "singleanimal.csv"))
 
                 DataFrame.to_hdf(
-                    fn + ".h5",
+                    fn.with_suffix(".h5"),
                     key="df_with_missing",
                 )
-                DataFrame.to_csv(fn + ".csv")
+                DataFrame.to_csv(fn.with_suffix(".csv"))
 
 
 def form_default_inferencecfg(cfg):

--- a/deeplabcut/utils/auxfun_videos.py
+++ b/deeplabcut/utils/auxfun_videos.py
@@ -357,7 +357,7 @@ def imread(image_path, mode="skimage"):
         return img_as_ubyte(image)
 
     elif mode == "cv2":
-        return cv2.imread(image_path, cv2.IMREAD_UNCHANGED)[..., ::-1]  # ~10% faster than using cv2.cvtColor
+        return cv2.imread(str(image_path), cv2.IMREAD_UNCHANGED)[..., ::-1]  # ~10% faster than using cv2.cvtColor
 
 
 # https://docs.opencv.org/3.4.0/da/d54/group__imgproc__transform.html#ga5bb5a1fea74ea38e1a5445ca803ff121

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -169,12 +169,13 @@ def save_data(PredicteData, metadata, dataname, pdindex, imagenames, save_as_csv
     """Save predicted data as h5 file and metadata as pickle file; created by
     predict_videos.py.
     """
+    dataname = Path(dataname)
     DataMachine = pd.DataFrame(PredicteData, columns=pdindex, index=imagenames)
     if save_as_csv:
         print("Saving csv poses!")
-        DataMachine.to_csv(dataname.split(".h5")[0] + ".csv")
+        DataMachine.to_csv(dataname.with_suffix(".csv"))
     DataMachine.to_hdf(dataname, key="df_with_missing", format="table", mode="w")
-    with Path(dataname.split(".h5")[0] + "_meta.pickle").open("wb") as f:
+    with dataname.with_name(dataname.stem + "_meta.pickle").open("wb") as f:
         # Pickle the 'data' dictionary using the highest protocol available.
         pickle.dump(metadata, f, pickle.HIGHEST_PROTOCOL)
 
@@ -202,8 +203,7 @@ def load_metadata(metadatafile: str | Path):
         return trainingdata_details, trainIndices, testIndices, testFraction_data
 
 
-# TODO: @deruyter92 2026-05-20: this function could be updated to match the
-# signature of collect_video_paths, allowing for multiple extensions.
+@deprecated(replacement="deeplabcut.collect_video_paths", since="3.0.1")
 def grab_files_in_folder(folder, ext="", relative=True):
     """Return the paths of files with extension *ext* present in *folder*."""
     for file in Path(folder).iterdir():
@@ -559,20 +559,20 @@ def check_if_post_processing(folder, vname, DLCscorer, DLCscorerlegacy, suffix="
 
 
 def check_if_not_analyzed(destfolder, vname, DLCscorer, DLCscorerlegacy, flag="video"):
-    h5files = list(grab_files_in_folder(destfolder, "h5", relative=False))
+    h5files = collect_video_paths(destfolder, extensions=".h5")
     if not len(h5files):
-        dataname = str(Path(destfolder) / (vname + DLCscorer + ".h5"))
+        dataname = Path(destfolder) / (vname + DLCscorer + ".h5")
         return True, dataname, DLCscorer
 
     # Iterate over data files and stop as soon as one matching the scorer is found
     for h5file in h5files:
-        if vname + DLCscorer in Path(h5file).stem:
+        if vname + DLCscorer in h5file.stem:
             if flag == "video":
                 print("Video already analyzed!", h5file)
             elif flag == "framestack":
                 print("Frames already analyzed!", h5file)
             return False, h5file, DLCscorer
-        elif vname + DLCscorerlegacy in Path(h5file).stem:
+        elif vname + DLCscorerlegacy in h5file.stem:
             if flag == "video":
                 print("Video already analyzed!", h5file)
             elif flag == "framestack":
@@ -580,7 +580,7 @@ def check_if_not_analyzed(destfolder, vname, DLCscorer, DLCscorerlegacy, flag="v
             return False, h5file, DLCscorerlegacy
 
     # If there was no match...
-    dataname = str(Path(destfolder) / (vname + DLCscorer + ".h5"))
+    dataname = Path(destfolder) / (vname + DLCscorer + ".h5")
     return True, dataname, DLCscorer
 
 
@@ -640,9 +640,9 @@ def find_analyzed_data(folder, videoname: str, scorer: str, filtered=False, trac
     tracker = TRACK_METHODS.get(track_method, "")
 
     candidates = []
-    for file in grab_files_in_folder(folder, "h5"):
-        stem = Path(file).stem.replace("_filtered", "")
-        starts_by_scorer = Path(file).name.startswith((videoname + scorer, videoname + scorer_legacy))
+    for file in collect_video_paths(folder, extensions=".h5"):
+        stem = file.stem.replace("_filtered", "")
+        starts_by_scorer = file.name.startswith((videoname + scorer, videoname + scorer_legacy))
         if tracker:
             matches_tracker = stem.endswith(tracker)
         else:
@@ -650,9 +650,9 @@ def find_analyzed_data(folder, videoname: str, scorer: str, filtered=False, trac
         if all(
             (
                 starts_by_scorer,
-                "skeleton" not in file,
+                "skeleton" not in file.name,
                 matches_tracker,
-                (filtered and "filtered" in file) or (not filtered and "filtered" not in file),
+                (filtered and "filtered" in file.name) or (not filtered and "filtered" not in file.name),
             )
         ):
             candidates.append(file)
@@ -670,7 +670,7 @@ def find_analyzed_data(folder, videoname: str, scorer: str, filtered=False, trac
     n_candidates = len(candidates)
     if n_candidates > 1:  # This should not be happening anyway...
         print(f"{n_candidates} possible data files were found: {candidates}.\nPicking the first by default...")
-    filepath = str(Path(folder) / candidates[0])
+    filepath = str(candidates[0])
     scorer = scorer if scorer in filepath else scorer_legacy
     return filepath, scorer, suffix
 

--- a/deeplabcut/utils/auxiliaryfunctions.py
+++ b/deeplabcut/utils/auxiliaryfunctions.py
@@ -134,9 +134,9 @@ def attempt_to_make_folder(foldername, recursive=False):
         return
 
     if recursive:
-        foldername.mkdir(parents=True)
+        foldername.mkdir(parents=True, exist_ok=True)
     else:
-        foldername.mkdir()
+        foldername.mkdir(exist_ok=True, parents=True)
 
 
 def read_pickle(filename):
@@ -642,7 +642,7 @@ def find_analyzed_data(folder, videoname: str, scorer: str, filtered=False, trac
     candidates = []
     for file in grab_files_in_folder(folder, "h5"):
         stem = Path(file).stem.replace("_filtered", "")
-        starts_by_scorer = file.startswith((videoname + scorer, videoname + scorer_legacy))
+        starts_by_scorer = Path(file).name.startswith((videoname + scorer, videoname + scorer_legacy))
         if tracker:
             matches_tracker = stem.endswith(tracker)
         else:

--- a/deeplabcut/utils/conversioncode.py
+++ b/deeplabcut/utils/conversioncode.py
@@ -18,6 +18,7 @@ from tqdm import tqdm
 
 import deeplabcut as dlc
 from deeplabcut.utils import auxiliaryfunctions
+from deeplabcut.utils.auxfun_videos import collect_video_paths
 
 SUPPORTED_FILETYPES = "csv", "nwb"
 
@@ -207,8 +208,7 @@ def adapt_labeled_data_to_new_project(
     convertcsv2h5(config_path, userfeedback=userfeedback)
 
 
-# TODO: @deruyter92 2026-05-20: this function still uses grab_files_in_folder instead
-# of collect_video_paths and videotype instead of video_extensions.
+# TODO: @deruyter92 2026-05-20: this function uses videotype instead of video_extensions.
 def analyze_videos_converth5_to_csv(video_folder, videotype=".mp4", listofvideos=False):
     """By default the output poses (when running analyze_videos) are stored as
     MultiIndex Pandas Array, which contains the name of the network, body part name, (x,
@@ -234,18 +234,17 @@ def analyze_videos_converth5_to_csv(video_folder, videotype=".mp4", listofvideos
     if listofvideos:  # can also be called with a list of videos (from GUI)
         videos = video_folder  # GUI gives a list of videos
         if len(videos) > 0:
-            h5_files = list(auxiliaryfunctions.grab_files_in_folder(Path(videos[0]).parent, "h5", relative=False))
+            h5_files = collect_video_paths(Path(videos[0]).parent, extensions=".h5")
         else:
             h5_files = []
     else:
-        h5_files = list(auxiliaryfunctions.grab_files_in_folder(video_folder, "h5", relative=False))
-        videos = auxiliaryfunctions.grab_files_in_folder(video_folder, videotype, relative=False)
+        h5_files = collect_video_paths(video_folder, extensions=".h5")
+        videos = collect_video_paths(video_folder, extensions=videotype)
 
     _convert_h5_files_to("csv", None, h5_files, videos)
 
 
-# TODO: @deruyter92 2026-05-20: this function still uses grab_files_in_folder instead
-# of collect_video_paths and videotype instead of video_extensions.
+# TODO: @deruyter92 2026-05-20: this function uses videotype instead of video_extensions.
 def analyze_videos_converth5_to_nwb(
     config: str | Path,
     video_folder: str | Path,
@@ -272,12 +271,12 @@ def analyze_videos_converth5_to_nwb(
     if listofvideos:  # can also be called with a list of videos (from GUI)
         videos = video_folder  # GUI gives a list of videos
         if len(videos) > 0:
-            h5_files = list(auxiliaryfunctions.grab_files_in_folder(Path(videos[0]).parent, "h5", relative=False))
+            h5_files = collect_video_paths(Path(videos[0]).parent, extensions=".h5")
         else:
             h5_files = []
     else:
-        h5_files = list(auxiliaryfunctions.grab_files_in_folder(video_folder, "h5", relative=False))
-        videos = auxiliaryfunctions.grab_files_in_folder(video_folder, videotype, relative=False)
+        h5_files = collect_video_paths(video_folder, extensions=".h5")
+        videos = collect_video_paths(video_folder, extensions=videotype)
 
     _convert_h5_files_to("nwb", config, h5_files, videos)
 
@@ -297,18 +296,18 @@ def _convert_h5_files_to(filetype, config, h5_files, videos):
             raise ImportError("The package `dlc2nwb` is missing. Please run `pip install dlc2nwb`.") from e
 
     for video in videos:
-        if "_labeled" in video:
+        if "_labeled" in video.name:
             continue
-        vname = Path(video).stem
+        vname = video.stem
         for file in h5_files:
-            if vname in file:
-                scorer = file.split(vname)[1].split(".h5")[0]
+            if vname in file.name:
+                scorer = file.stem.removeprefix(vname)
                 if "DLC" in scorer or "DeepCut" in scorer:
                     print("Found output file for scorer:", scorer)
                     print(f"Converting {file}...")
                     if filetype == "csv":
                         df = pd.read_hdf(file)
-                        df.to_csv(file.replace(".h5", ".csv"))
+                        df.to_csv(file.with_suffix(".csv"))
                     else:
                         convert_h5_to_nwb(config, file)
 
@@ -323,10 +322,7 @@ def merge_windowsannotationdataONlinuxsystem(cfg):
     """
     AnnotationData = []
     data_path = Path(cfg["project_path"], "labeled-data")
-    annotationfolders = []
-    for elem in auxiliaryfunctions.grab_files_in_folder(data_path, relative=False):
-        if Path(elem).is_dir():
-            annotationfolders.append(elem)
+    annotationfolders = [d for d in data_path.iterdir() if d.is_dir()]
     print("The following folders were found:", annotationfolders)
     for folder in annotationfolders:
         filename = str(Path(folder) / ("CollectedData_" + cfg["scorer"] + ".h5"))

--- a/deeplabcut/utils/conversioncode.py
+++ b/deeplabcut/utils/conversioncode.py
@@ -343,11 +343,9 @@ def merge_windowsannotationdataONlinuxsystem(cfg):
 def guarantee_multiindex_rows(df):
     # Make paths platform-agnostic if they are not already
     if not isinstance(df.index, pd.MultiIndex):  # Backwards compatibility
-        path = df.index[0]
         try:
-            sep = "/" if "/" in path else "\\"
-            splits = tuple(df.index.str.split(sep))
-            df.index = pd.MultiIndex.from_tuples(splits)
+            splits = df.index.str.replace("\\", "/").str.split("/")
+            df.index = pd.MultiIndex.from_tuples([tuple(s) for s in splits])
         except TypeError:  #  Ignore numerical index of frame indices
             pass
 

--- a/deeplabcut/utils/conversioncode.py
+++ b/deeplabcut/utils/conversioncode.py
@@ -354,8 +354,3 @@ def guarantee_multiindex_rows(df):
         df.index = df.index.set_levels(df.index.levels[1].astype(str), level=1)
     except AttributeError:
         pass
-
-
-def robust_split_path(s):
-    sep = "/" if "/" in s else "\\"
-    return tuple(s.split(sep))

--- a/deeplabcut/utils/make_labeled_video.py
+++ b/deeplabcut/utils/make_labeled_video.py
@@ -1261,7 +1261,7 @@ def _create_video_from_tracks(video, tracks, destfolder, output_name, pcutoff, s
     from tqdm import tqdm
 
     if not Path(destfolder).is_dir():
-        Path(destfolder).mkdir()
+        Path(destfolder).mkdir(exist_ok=True, parents=True)
 
     vid = VideoWriter(video)
     nframes = len(vid)

--- a/deeplabcut/utils/pseudo_label.py
+++ b/deeplabcut/utils/pseudo_label.py
@@ -415,7 +415,7 @@ def dlc3predictions_2_annotation_from_video(
     assert len(predictions) == len(image_paths)
     imageid2annotations = defaultdict(list)
     for image_id, (prediction, image_path) in enumerate(zip(predictions, image_paths, strict=False)):
-        image_obj = cv2.imread(image_path)
+        image_obj = cv2.imread(str(image_path))
         height, width, channels = image_obj.shape
         imagename = Path(image_path).name
         image = {

--- a/tests/test_auxiliaryfunctions.py
+++ b/tests/test_auxiliaryfunctions.py
@@ -17,7 +17,8 @@ from deeplabcut.utils import auxiliaryfunctions
 from deeplabcut.utils.auxfun_videos import SUPPORTED_VIDEOS
 
 
-def test_find_analyzed_data(tmpdir_factory):
+@pytest.mark.parametrize("path_type", [str, Path])
+def test_find_analyzed_data(tmpdir_factory, path_type):
     fake_folder = tmpdir_factory.mktemp("videos")
     SUPPORTED_VIDEOS = ["avi"]
     len(SUPPORTED_VIDEOS)
@@ -26,7 +27,7 @@ def test_find_analyzed_data(tmpdir_factory):
     WRONG_SCORER = "DLC_dlcrnetms5_multi_mouseApr11shuffle3_5"
 
     def _create_fake_file(filename):
-        path = str(fake_folder.join(filename))
+        path = Path(fake_folder) / filename
         with open(path, "w") as f:
             f.write("")
         return path
@@ -37,6 +38,8 @@ def test_find_analyzed_data(tmpdir_factory):
         _ = _create_fake_file(vname + SCORER + ".pickle")
         _ = _create_fake_file(vname + SCORER + ".h5")
 
+    # Test for both str and Path types (convert from tmpdir.LocalPath object)
+    fake_folder = path_type(fake_folder)
     for ind, ext in enumerate(SUPPORTED_VIDEOS):
         # test if existing models are found:
         assert auxiliaryfunctions.find_analyzed_data(fake_folder, "video" + str(ind), SCORER)


### PR DESCRIPTION
## Summary
Follow-up of #3350 (migration to pathlib Path), after auditing for remaining fragile patterns. This PR hardens the codebase against `Path`/`str` type confusion. Catches fragile patterns that work today but could silently break if types shift.

## Changes
- **Fixed `Path + str` TypeError** — `project_path + "_bak"` at a live call
  site (was in dead code, but now safe regardless).
- **Hardened `cfg["init_weights"]` usage** — the two places that concatenated
  strings onto it now use `Path.with_suffix()` instead.
- **Eliminated `_robust_path_split`** (trainingsetmanipulation) and
  **`robust_split_path`** (conversioncode) — both were pre-pathlib relics that
  split strings on `/` or `\` only to immediately re-join via `Path(*)`. All
  callers now use `Path().stem` or `Path()` directly.
- **Simplified `guarantee_multiindex_rows`** — dropped the fragile
  single-row heuristic (`"/" in path[0]`) for a consistent
  normalize-then-split approach.
- **Deprecated `grab_files_in_folder`** — replaced all internal callers with
  `collect_video_paths`, added `@deprecated` decorator.
- **Migrated `save_data`, `check_if_not_analyzed`, `_convert_h5_files_to`**
  from string-path operations to pathlib (`.stem`, `.with_suffix`,
  `.with_name`, `.removeprefix`).
- **Removed redundant `Path()` wraps** where variables were already `Path`,
  and removed `str()` conversions where `Path` is accepted natively.
