### PR TITLE
Update deprecation markers (3.1 -> 3.0.1)

### DIFF
--- a/deeplabcut/core/config/utils.py
+++ b/deeplabcut/core/config/utils.py
@@ -238,7 +238,7 @@ def ensure_plain_config(fn: Callable) -> Callable:
 # -----------------------------------------------------------------------------
 
 
-@deprecated(replacement="deeplabcut.core.config.ProjectConfig", since="3.1")
+@deprecated(replacement="deeplabcut.core.config.ProjectConfig", since="3.0.1")
 def create_config_template(multianimal: bool = False) -> tuple:
     """
     Creates a template for config.yaml file. This specific order is preserved while saving as yaml file.

--- a/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
+++ b/deeplabcut/pose_estimation_pytorch/config/make_pose_config.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@deprecated(replacement="pose_estimation_pytorch.config.TestConfig.build", since="3.1")
+@deprecated(replacement="pose_estimation_pytorch.config.TestConfig.build", since="3.0.1")
 def make_pytorch_test_config(
     model_config: PoseConfig | dict | str | Path,
     test_config_path: str | Path,
@@ -49,7 +49,7 @@ def make_pytorch_test_config(
     return TestConfig.build(model_config, test_config_path=test_config_path, save=save)
 
 
-@deprecated(replacement="pose_estimation_pytorch.config.PoseConfig.build", since="3.1")
+@deprecated(replacement="pose_estimation_pytorch.config.PoseConfig.build", since="3.0.1")
 def make_pytorch_pose_config(
     project_config: ProjectConfig | dict | Path | str,
     pose_config_path: str | Path,
@@ -74,7 +74,7 @@ def make_pytorch_pose_config(
     )
 
 
-@deprecated(replacement="pose_estimation_pytorch.config.PoseMetadata", since="3.1")
+@deprecated(replacement="pose_estimation_pytorch.config.PoseMetadata", since="3.0.1")
 def make_basic_project_config(
     dataset_path: Path | str,
     bodyparts: list[str],

--- a/deeplabcut/pose_estimation_pytorch/config/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/config/utils.py
@@ -118,7 +118,7 @@ def replace_default_values(
     return config
 
 
-@deprecated(replacement=None, since="3.1")
+@deprecated(replacement=None, since="3.0.1")
 def update_config(config: dict, updates: dict, copy_original: bool = True) -> dict:
     """Deprecated helper for updating config dictionaries."""
     from deeplabcut.pose_estimation_pytorch.config.make_pose_config import _update_config
@@ -126,10 +126,10 @@ def update_config(config: dict, updates: dict, copy_original: bool = True) -> di
     return _update_config(config, updates, copy_original)
 
 
-@deprecated(replacement=None, since="3.1")
+@deprecated(replacement=None, since="3.0.1")
 def update_config_by_dotpath(config: dict, updates: dict, copy_original: bool = True) -> dict:
     """Deprecated helper for updating config dictionaries using dot notation.
-    ``DLCBaseConfig.set_nested`` (new in 3.1) can be used instead (not identical).
+    ``DLCBaseConfig.set_nested`` (new in 3.0.1) can be used instead (not identical).
 
     Updates items in the configuration file using dot notation for nested keys
 

--- a/deeplabcut/pose_estimation_pytorch/data/base.py
+++ b/deeplabcut/pose_estimation_pytorch/data/base.py
@@ -47,7 +47,7 @@ class Loader(ABC):
             Returns a dictionary containing dataset parameters derived from the configuration.
     """
 
-    @renamed_parameter(old="model_config_path", new="model_config", since="3.1.0")
+    @renamed_parameter(old="model_config_path", new="model_config", since="3.0.1")
     def __init__(
         self,
         project_root: str | Path,

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/config.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/config.py
@@ -140,7 +140,7 @@ def build_superanimal_finetune_config(
     return model_cfg
 
 
-@deprecated(replacement="PoseConfig.build_for_superanimal_finetune", since="3.1")
+@deprecated(replacement="PoseConfig.build_for_superanimal_finetune", since="3.0.1")
 def make_super_animal_finetune_config(
     weight_init: WeightInitialization,
     project_config: dict,

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/utils.py
@@ -89,7 +89,7 @@ def get_super_animal_snapshot_path(
     return model_path
 
 
-@deprecated(replacement="PoseConfig.build_for_superanimal_inference", since="3.1")
+@deprecated(replacement="PoseConfig.build_for_superanimal_inference", since="3.0.1")
 def load_super_animal_config(
     super_animal: str,
     model_name: str,


### PR DESCRIPTION
Several deprecation markers now are introduced for the new release (e.g. `@deprecated` or `@renamed_parameter`) that emit a message that a function or parameter is deprecated "since version 3.1". As we are releasing version 3.0.1 (minor release), this should be adapted accordingly.