### PR TITLE
Add CI workflow lane for dependency testing (canary lane)

### DIFF
--- a/.github/workflows/intelligent-testing.yml
+++ b/.github/workflows/intelligent-testing.yml
@@ -154,7 +154,8 @@ jobs:
           "include": [
             {"os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"numpy>=2"},
             {"os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"pandas>=3"},
-            {"os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"albumentations>=2"}
+            {"os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"albumentations>=2"},
+            {"os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"matplotlib>=3.9"}
           ]
         }
       full_suite: false

--- a/.github/workflows/intelligent-testing.yml
+++ b/.github/workflows/intelligent-testing.yml
@@ -148,7 +148,7 @@ jobs:
     if: needs.intelligent-test-selection.outputs.run_full == 'true'
     uses: ./.github/workflows/python-package.yml
     with:
-      concurrency_key: ${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || '' }}
+      concurrency_key: ${{ github.event.pull_request.number && format('pr-{0}-canary', github.event.pull_request.number) || 'canary' }}
       matrix_json: >-
         {
           "include": [

--- a/.github/workflows/intelligent-testing.yml
+++ b/.github/workflows/intelligent-testing.yml
@@ -152,10 +152,10 @@ jobs:
       matrix_json: >-
         {
           "include": [
-            {"os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"numpy>=2"},
-            {"os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"pandas>=3"},
-            {"os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"albumentations>=2"},
-            {"os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"matplotlib>=3.9"}
+            {"id":"numpy","os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"numpy>=2"},
+            {"id":"pandas","os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"pandas>=3"},
+            {"id":"albumentations","os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"albumentations>=2"},
+            {"id":"matplotlib","os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"matplotlib>=3.9"}
           ]
         }
       full_suite: false

--- a/.github/workflows/intelligent-testing.yml
+++ b/.github/workflows/intelligent-testing.yml
@@ -142,6 +142,30 @@ jobs:
         }
       full_suite: true
 
+  canary-tests:
+    name: Canary lane (dependency upgrades)
+    needs: intelligent-test-selection
+    if: needs.intelligent-test-selection.outputs.run_full == 'true'
+    uses: ./.github/workflows/python-package.yml
+    with:
+      concurrency_key: ${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || '' }}
+      matrix_json: >-
+        {
+          "include": [
+            {"os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"numpy>=2"},
+            {"os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"pandas>=3"},
+            {"os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"albumentations>=2"}
+          ]
+        }
+      full_suite: false
+      pytest_paths_json: '["tests"]'
+      functional_scripts_json: >-
+        [
+          "examples/testscript_pytorch_single_animal.py",
+          "examples/testscript_pytorch_multi_animal.py"
+        ]
+      continue_on_error: true
+
   tf-install-smoke-test:
     name: TensorFlow install smoke test
     needs: intelligent-test-selection

--- a/.github/workflows/intelligent-testing.yml
+++ b/.github/workflows/intelligent-testing.yml
@@ -145,7 +145,7 @@ jobs:
   canary-tests:
     name: Canary lane (dependency upgrades)
     needs: intelligent-test-selection
-    if: needs.intelligent-test-selection.outputs.run_full == 'true'
+    if: needs.intelligent-test-selection.outputs.run_full == 'true' && needs.intelligent-test-selection.outputs.is_dev_draft != 'true'
     uses: ./.github/workflows/python-package.yml
     with:
       concurrency_key: ${{ github.event.pull_request.number && format('pr-{0}-canary', github.event.pull_request.number) || 'canary' }}

--- a/.github/workflows/intelligent-testing.yml
+++ b/.github/workflows/intelligent-testing.yml
@@ -132,6 +132,30 @@ jobs:
         }
       full_suite: true
 
+  canary-tests:
+    name: Canary lane (dependency upgrades)
+    needs: intelligent-test-selection
+    if: needs.intelligent-test-selection.outputs.run_full == 'true'
+    uses: ./.github/workflows/python-package.yml
+    with:
+      concurrency_key: ${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || '' }}
+      matrix_json: >-
+        {
+          "include": [
+            {"os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"numpy>=2"},
+            {"os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"pandas>=3"},
+            {"os":"ubuntu-latest","python-version":"3.12","extras":"","pip_overrides":"albumentations>=2"}
+          ]
+        }
+      full_suite: false
+      pytest_paths_json: '["tests"]'
+      functional_scripts_json: >-
+        [
+          "examples/testscript_pytorch_single_animal.py",
+          "examples/testscript_pytorch_multi_animal.py"
+        ]
+      continue_on_error: true
+
   tf-install-smoke-test:
     name: TensorFlow install smoke test
     needs: intelligent-test-selection

--- a/.github/workflows/intelligent-testing.yml
+++ b/.github/workflows/intelligent-testing.yml
@@ -138,7 +138,7 @@ jobs:
     if: needs.intelligent-test-selection.outputs.run_full == 'true'
     uses: ./.github/workflows/python-package.yml
     with:
-      concurrency_key: ${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || '' }}
+      concurrency_key: ${{ github.event.pull_request.number && format('pr-{0}-canary', github.event.pull_request.number) || 'canary' }}
       matrix_json: >-
         {
           "include": [

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -126,14 +126,14 @@ jobs:
       - name: Force-install upgrade packages
         if: ${{ matrix.pip_overrides != '' }}
         shell: bash -el {0}
+        env:
+            PIP_OVERRIDES: ${{ matrix.pip_overrides }}
         run: |
-          # Split on whitespace (not commas): pip version specs legitimately
-          # contain commas to combine constraints, e.g. "numpy>=2,<3".
-          read -ra pkgs <<< "${{ matrix.pip_overrides }}"
-          for pkg in "${pkgs[@]}"; do
+            read -ra pkgs <<< "$PIP_OVERRIDES"
+            for pkg in "${pkgs[@]}"; do
             echo "Force-installing (--no-deps): $pkg"
             python -m pip install --no-cache-dir --upgrade --no-deps "$pkg"
-          done
+            done
 
       - name: Install ffmpeg (Linux/macOS)
         if: runner.os != 'Windows'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -83,6 +83,7 @@ jobs:
             || github.event_name == 'workflow_dispatch' && inputs.concurrency_key
             || github.run_id }}-
         ${{ matrix.os }}-${{ matrix.python-version }}
+        ${{ matrix.pip_overrides && format('-{0}', matrix.pip_overrides) || '' }}
       cancel-in-progress: true
 
     strategy:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -80,6 +80,8 @@ jobs:
     # Use a stable concurrency key only when one is explicitly provided
     # (e.g. PR/workflow_call/manual dedupe). Otherwise fall back to github.run_id
     # so pushes to main never cancel each other.
+    # Use matrix.id (not full pip_overrides) so canary cells that share os/python
+    # do not cancel each other.
     concurrency:
       group: >-
         tests-${{ github.workflow }}-
@@ -87,7 +89,7 @@ jobs:
             || github.event_name == 'workflow_dispatch' && inputs.concurrency_key
             || github.run_id }}-
         ${{ matrix.os }}-${{ matrix.python-version }}
-        ${{ (matrix.pip_overrides || inputs.pip_overrides) && format('-{0}', matrix.pip_overrides || inputs.pip_overrides) || '' }}
+        ${{ matrix.id && format('-{0}', matrix.id) || '' }}
       cancel-in-progress: true
 
     strategy:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,6 +22,14 @@ on:
         required: false
         type: boolean
         default: false
+      pip_overrides:
+        required: false
+        type: string
+        default: ""
+      continue_on_error:
+        required: false
+        type: boolean
+        default: false
 
   workflow_dispatch:
     inputs:
@@ -46,6 +54,16 @@ on:
         default: "[]"
       full_suite:
         description: "Run full pytest and default functional suite"
+        required: false
+        type: boolean
+        default: false
+      pip_overrides:
+        description: "Comma-separated pip specs to force-install after normal deps (e.g. numpy>=2)"
+        required: false
+        type: string
+        default: ""
+      continue_on_error:
+        description: "Allow test steps to fail without marking the job as failed"
         required: false
         type: boolean
         default: false
@@ -103,6 +121,16 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install dependency-groups
           python -m pip install --no-cache-dir -e ".${{ matrix.extras }}" --group dev
+
+      - name: Force-install upgrade packages
+        if: ${{ matrix.pip_overrides != '' }}
+        shell: bash -el {0}
+        run: |
+          IFS=',' read -ra pkgs <<< "${{ matrix.pip_overrides }}"
+          for pkg in "${pkgs[@]}"; do
+            echo "Force-installing: $pkg"
+            python -m pip install --no-cache-dir --upgrade "$pkg"
+          done
 
       - name: Install ffmpeg (Linux/macOS)
         if: runner.os != 'Windows'
@@ -179,6 +207,7 @@ jobs:
           ffprobe -version
 
       - name: Run pytest
+        continue-on-error: ${{ inputs.continue_on_error }}
         shell: bash -el {0}
         env:
           FULL_SUITE: ${{ inputs.full_suite }}
@@ -207,6 +236,7 @@ jobs:
           PY
 
       - name: Run functional scripts
+        continue-on-error: ${{ inputs.continue_on_error }}
         shell: bash -el {0}
         env:
           FULL_SUITE: ${{ inputs.full_suite }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -210,6 +210,7 @@ jobs:
           ffprobe -version
 
       - name: Run pytest
+        id: run_pytest
         continue-on-error: ${{ inputs.continue_on_error }}
         shell: bash -el {0}
         env:
@@ -239,6 +240,7 @@ jobs:
           PY
 
       - name: Run functional scripts
+        id: run_functional_scripts
         continue-on-error: ${{ inputs.continue_on_error }}
         shell: bash -el {0}
         env:
@@ -281,3 +283,24 @@ jobs:
               if rc != 0:
                   raise SystemExit(rc)
           PY
+
+      - name: Report continue-on-error failures
+        # continue-on-error hides failures behind a small icon on the step itself and
+        # reports the job as passing overall, so make failures hard to miss: emit a
+        # workflow annotation and a job-summary entry whenever this happens.
+        if: >-
+          ${{ inputs.continue_on_error &&
+              (steps.run_pytest.outcome == 'failure' || steps.run_functional_scripts.outcome == 'failure') }}
+        shell: bash
+        run: |
+          MATRIX_DESC="${{ matrix.os }}, py${{ matrix.python-version }}, pip_overrides='${{ matrix.pip_overrides }}'"
+          echo "::warning title=Non-blocking test failure::[$MATRIX_DESC] pytest=${{ steps.run_pytest.outcome }}, functional_scripts=${{ steps.run_functional_scripts.outcome }}. This job uses continue-on-error and will still report success overall, but the failure should be investigated."
+          {
+            echo "### :warning: Non-blocking test failure"
+            echo ""
+            echo "This job runs with \`continue_on_error: true\`, so it will still report as **passing** overall -- but at least one test step actually failed and should be investigated."
+            echo ""
+            echo "| Matrix | pytest | functional scripts |"
+            echo "| --- | --- | --- |"
+            echo "| $MATRIX_DESC | ${{ steps.run_pytest.outcome }} | ${{ steps.run_functional_scripts.outcome }} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -131,8 +131,8 @@ jobs:
           # contain commas to combine constraints, e.g. "numpy>=2,<3".
           read -ra pkgs <<< "${{ matrix.pip_overrides }}"
           for pkg in "${pkgs[@]}"; do
-            echo "Force-installing: $pkg"
-            python -m pip install --no-cache-dir --upgrade "$pkg"
+            echo "Force-installing (--no-deps): $pkg"
+            python -m pip install --no-cache-dir --upgrade --no-deps "$pkg"
           done
 
       - name: Install ffmpeg (Linux/macOS)

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -58,7 +58,7 @@ on:
         type: boolean
         default: false
       pip_overrides:
-        description: "Comma-separated pip specs to force-install after normal deps (e.g. numpy>=2)"
+        description: "Space-separated pip specs to force-install after normal deps (e.g. 'numpy>=2,<3' or 'numpy>=2,<3 pandas>=3')"
         required: false
         type: string
         default: ""
@@ -127,7 +127,9 @@ jobs:
         if: ${{ matrix.pip_overrides != '' }}
         shell: bash -el {0}
         run: |
-          IFS=',' read -ra pkgs <<< "${{ matrix.pip_overrides }}"
+          # Split on whitespace (not commas): pip version specs legitimately
+          # contain commas to combine constraints, e.g. "numpy>=2,<3".
+          read -ra pkgs <<< "${{ matrix.pip_overrides }}"
           for pkg in "${pkgs[@]}"; do
             echo "Force-installing: $pkg"
             python -m pip install --no-cache-dir --upgrade "$pkg"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -71,6 +71,10 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    # Matrix cell wins when set (canary lane); otherwise fall back to the workflow
+    # input so callers / workflow_dispatch can apply one override to every cell.
+    env:
+      PIP_OVERRIDES: ${{ matrix.pip_overrides || inputs.pip_overrides || '' }}
     # Cancel outdated runs on the same OS and Python version when new commits are pushed
     # Only cancels on PRs.
     # Use a stable concurrency key only when one is explicitly provided
@@ -83,7 +87,7 @@ jobs:
             || github.event_name == 'workflow_dispatch' && inputs.concurrency_key
             || github.run_id }}-
         ${{ matrix.os }}-${{ matrix.python-version }}
-        ${{ matrix.pip_overrides && format('-{0}', matrix.pip_overrides) || '' }}
+        ${{ (matrix.pip_overrides || inputs.pip_overrides) && format('-{0}', matrix.pip_overrides || inputs.pip_overrides) || '' }}
       cancel-in-progress: true
 
     strategy:
@@ -124,16 +128,16 @@ jobs:
           python -m pip install --no-cache-dir -e ".${{ matrix.extras }}" --group dev
 
       - name: Force-install upgrade packages
-        if: ${{ matrix.pip_overrides != '' }}
+        if: ${{ env.PIP_OVERRIDES != '' }}
         shell: bash -el {0}
-        env:
-            PIP_OVERRIDES: ${{ matrix.pip_overrides }}
         run: |
-            read -ra pkgs <<< "$PIP_OVERRIDES"
-            for pkg in "${pkgs[@]}"; do
+          # Split on whitespace (not commas): pip version specs legitimately
+          # contain commas to combine constraints, e.g. "numpy>=2,<3".
+          read -ra pkgs <<< "$PIP_OVERRIDES"
+          for pkg in "${pkgs[@]}"; do
             echo "Force-installing (--no-deps): $pkg"
             python -m pip install --no-cache-dir --upgrade --no-deps "$pkg"
-            done
+          done
 
       - name: Install ffmpeg (Linux/macOS)
         if: runner.os != 'Windows'
@@ -292,10 +296,8 @@ jobs:
           ${{ inputs.continue_on_error &&
               (steps.run_pytest.outcome == 'failure' || steps.run_functional_scripts.outcome == 'failure') }}
         shell: bash
-        env:
-            MATRIX_PIP_OVERRIDES: ${{ matrix.pip_overrides }}
         run: |
-          MATRIX_DESC="${{ matrix.os }}, py${{ matrix.python-version }}, pip_overrides='$MATRIX_PIP_OVERRIDES'"
+          MATRIX_DESC="${{ matrix.os }}, py${{ matrix.python-version }}, pip_overrides='$PIP_OVERRIDES'"
           echo "::warning title=Non-blocking test failure::[$MATRIX_DESC] pytest=${{ steps.run_pytest.outcome }}, functional_scripts=${{ steps.run_functional_scripts.outcome }}. This job uses continue-on-error and will still report success overall, but the failure should be investigated."
           {
             echo "### :warning: Non-blocking test failure"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -292,8 +292,10 @@ jobs:
           ${{ inputs.continue_on_error &&
               (steps.run_pytest.outcome == 'failure' || steps.run_functional_scripts.outcome == 'failure') }}
         shell: bash
+        env:
+            MATRIX_PIP_OVERRIDES: ${{ matrix.pip_overrides }}
         run: |
-          MATRIX_DESC="${{ matrix.os }}, py${{ matrix.python-version }}, pip_overrides='${{ matrix.pip_overrides }}'"
+          MATRIX_DESC="${{ matrix.os }}, py${{ matrix.python-version }}, pip_overrides='$MATRIX_PIP_OVERRIDES'"
           echo "::warning title=Non-blocking test failure::[$MATRIX_DESC] pytest=${{ steps.run_pytest.outcome }}, functional_scripts=${{ steps.run_functional_scripts.outcome }}. This job uses continue-on-error and will still report success overall, but the failure should be investigated."
           {
             echo "### :warning: Non-blocking test failure"


### PR DESCRIPTION
**Motivation**
We currently enforce version pins for quite some dependencies. This PR introduces a non-blocking test lane that can help to identify future-incompatibilities when we release these upper bounds.

**Changes**
Add add a non-blocking "canary" test lane that tests future compatibility for specific pip-overrides. Currently, we run only the pytests and the torch functional tests for just one python version (3.12) and os (ubuntu). The following dependency overrides are tested:

- `albumentations >= 2`
- `numpy >= 2`
- `pandas >= 3`
- `matplotlib >= 3.9`

**Related PRs**
- This needs to be merged first to skip TF tests: https://github.com/DeepLabCut/DeepLabCut/pull/3419 
- Merge the current PR before below PRs. These PRs are expected to change the canary test outcomes by addressing future compatibility:
  - #3420 
  - #3416
  - #3174 
  - #3394