### PR TITLE
GUI fixes (config editor + reload timer)

### DIFF
--- a/deeplabcut/gui/components.py
+++ b/deeplabcut/gui/components.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from PySide6 import QtWidgets
-from PySide6.QtCore import Qt, Slot
+from PySide6.QtCore import Qt, QTimer, Slot
 
 from deeplabcut.core.config import read_config_as_dict
 from deeplabcut.gui.dlc_params import DLCParams
@@ -666,7 +666,36 @@ class DefaultTab(QtWidgets.QWidget):
         self.scroll_area.setWidget(self.content_widget)
         outer_layout.addWidget(self.scroll_area)
 
+        # Reloading rebuilds the tabs, so it must not run while the dialog that
+        # requested it is still emitting. Deferring to the next event loop
+        # iteration lets that dialog finish closing first.
+        self._reload_timer = QTimer(self)
+        self._reload_timer.setSingleShot(True)
+        self._reload_timer.setInterval(0)
+        self._reload_timer.timeout.connect(self.root.reload_project_config)
+
+        self._config_editor: ConfigEditor | None = None
+
         self._init_default_layout()
+
+    def _open_config_editor(self, config_path: PathInput | None, reload_project: bool = False) -> None:
+        """Open the YAML editor for ``config_path``.
+
+        The editor is kept referenced so it stays alive for as long as the tab
+        that opened it. Set ``reload_project`` for files whose contents shape the
+        project UI, so that saving them rebuilds the tabs.
+        """
+        if config_path is None:
+            return
+
+        self._config_editor = ConfigEditor(config_path, parent=self.root)
+        if reload_project:
+            self._config_editor.accepted.connect(self._reload_timer.start)
+        self._config_editor.show()
+
+    def open_project_config_editor(self) -> None:
+        """Edit the active project config and reload the project once saved."""
+        self._open_config_editor(self.root.config_path, reload_project=True)
 
     def _init_default_layout(self):
         # Add tab header

--- a/deeplabcut/gui/tabs/analyze_videos.py
+++ b/deeplabcut/gui/tabs/analyze_videos.py
@@ -13,7 +13,7 @@ from functools import partial
 from pathlib import Path
 
 from PySide6 import QtWidgets
-from PySide6.QtCore import Qt, QTimer
+from PySide6.QtCore import Qt
 
 import deeplabcut
 from deeplabcut.core.config import ProjectConfig
@@ -28,7 +28,6 @@ from deeplabcut.gui.components import (
     _create_vertical_layout,
 )
 from deeplabcut.gui.utils import move_to_separate_thread
-from deeplabcut.gui.widgets import ConfigEditor
 
 
 @dataclass(frozen=True)
@@ -53,11 +52,6 @@ class AnalyzeVideosOptions:
 class AnalyzeVideos(DefaultTab):
     def __init__(self, root, parent, h1_description):
         super().__init__(root, parent, h1_description)
-
-        self._reload_timer = QTimer(self)
-        self._reload_timer.setSingleShot(True)
-        self._reload_timer.setInterval(0)
-        self._reload_timer.timeout.connect(self.root.reload_project_config)
 
         self._set_page()
 
@@ -101,7 +95,7 @@ class AnalyzeVideos(DefaultTab):
         self.analyze_videos_btn.clicked.connect(self.analyze_videos)
 
         self.edit_config_file_btn = QtWidgets.QPushButton("Edit config.yaml")
-        self.edit_config_file_btn.clicked.connect(self.edit_config_file)
+        self.edit_config_file_btn.clicked.connect(self.open_project_config_editor)
 
         self.main_layout.addWidget(self.analyze_videos_btn, alignment=Qt.AlignRight)
         self.main_layout.addWidget(self.edit_config_file_btn, alignment=Qt.AlignRight)
@@ -266,14 +260,6 @@ class AnalyzeVideos(DefaultTab):
             self.show_trajectory_plots.setEnabled(False)
             self.show_trajectory_plots.setCheckState(Qt.Unchecked)
             self.root.logger.info("Plot trajectories DISABLED.")
-
-    def edit_config_file(self):
-        if not self.root.config_path:
-            return
-        config = self.root.config_path
-        editor = ConfigEditor(config, parent=self.root)
-        editor.accepted.connect(self._reload_timer.start)
-        editor.show()
 
     def _collect_options(self) -> AnalyzeVideosOptions:
         config_path = self.root.config_path

--- a/deeplabcut/gui/tabs/evaluate_network.py
+++ b/deeplabcut/gui/tabs/evaluate_network.py
@@ -31,7 +31,7 @@ from deeplabcut.gui.components import (
     _create_vertical_layout,
 )
 from deeplabcut.gui.displays.selected_shuffle_display import SelectedShuffleDisplay
-from deeplabcut.gui.widgets import ConfigEditor, launch_napari
+from deeplabcut.gui.widgets import launch_napari
 from deeplabcut.utils import auxiliaryfunctions
 
 
@@ -120,8 +120,7 @@ class EvaluateNetwork(DefaultTab):
         layout.addWidget(self.shuffle_display)
 
     def open_inferencecfg_editor(self):
-        editor = ConfigEditor(self.root.inference_cfg_path)
-        editor.show()
+        self._open_config_editor(self.root.inference_cfg_path)
 
     def plot_maps(self):
         shuffle = self.root.shuffle_value

--- a/deeplabcut/gui/tabs/manage_project.py
+++ b/deeplabcut/gui/tabs/manage_project.py
@@ -11,7 +11,7 @@
 import os
 from pathlib import Path
 
-from PySide6.QtCore import Qt, QTimer
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QFileDialog,
     QLabel,
@@ -22,17 +22,11 @@ from PySide6.QtWidgets import (
 from deeplabcut.create_project import add_new_videos
 from deeplabcut.gui.components import DefaultTab, _create_horizontal_layout
 from deeplabcut.gui.dlc_params import DLCParams
-from deeplabcut.gui.widgets import ConfigEditor
 
 
 class ManageProject(DefaultTab):
     def __init__(self, root, parent, h1_description):
         super().__init__(root, parent, h1_description)
-
-        self._reload_timer = QTimer(self)
-        self._reload_timer.setSingleShot(True)
-        self._reload_timer.setInterval(0)
-        self._reload_timer.timeout.connect(self.root.reload_project_config)
 
         self._set_page()
         self._videos = []
@@ -59,19 +53,13 @@ class ManageProject(DefaultTab):
 
         self.edit_btn = QPushButton("Edit config.yaml")
         self.edit_btn.setMinimumWidth(150)
-        self.edit_btn.clicked.connect(self.open_config_editor)
+        self.edit_btn.clicked.connect(self.open_project_config_editor)
 
         self.add_videos_btn = QPushButton("Add new videos")
         self.add_videos_btn.clicked.connect(self.add_new_videos)
 
         self.main_layout.addWidget(self.edit_btn, alignment=Qt.AlignRight)
         self.main_layout.addWidget(self.add_videos_btn, alignment=Qt.AlignRight)
-
-    def open_config_editor(self):
-        config = self.root.config_path
-        editor = ConfigEditor(config, parent=self.root)
-        editor.accepted.connect(self._reload_timer.start)
-        editor.show()
 
     def add_new_videos(self):
         cwd = os.fspath(Path.cwd())

--- a/deeplabcut/gui/tabs/refine_tracklets.py
+++ b/deeplabcut/gui/tabs/refine_tracklets.py
@@ -23,7 +23,6 @@ from deeplabcut.gui.components import (
     _create_horizontal_layout,
     _create_label_widget,
 )
-from deeplabcut.gui.widgets import ConfigEditor
 from deeplabcut.utils.auxiliaryfunctions import GetScorerName
 
 
@@ -195,8 +194,7 @@ class RefineTracklets(DefaultTab):
         self.root.logger.info(f"Number of animals in video set to {num_animals}")
 
     def open_inferencecfg_editor(self):
-        editor = ConfigEditor(self.root.inference_cfg_path)
-        editor.show()
+        self._open_config_editor(self.root.inference_cfg_path)
 
     def create_tracks(self):
         deeplabcut.stitch_tracklets(

--- a/deeplabcut/gui/tabs/train_network.py
+++ b/deeplabcut/gui/tabs/train_network.py
@@ -26,7 +26,6 @@ from deeplabcut.gui.components import (
 )
 from deeplabcut.gui.displays.selected_shuffle_display import SelectedShuffleDisplay
 from deeplabcut.gui.gui_assets import icon_from_resource
-from deeplabcut.gui.widgets import ConfigEditor
 
 
 @dataclass
@@ -219,8 +218,7 @@ class TrainNetwork(DefaultTab):
         self.root.logger.info(f"{attribute.label} set to {value}")
 
     def open_posecfg_editor(self):
-        editor = ConfigEditor(self.root.pose_cfg_path)
-        editor.show()
+        self._open_config_editor(self.root.pose_cfg_path)
 
     def train_network(self):
         try:

--- a/deeplabcut/gui/widgets.py
+++ b/deeplabcut/gui/widgets.py
@@ -303,7 +303,7 @@ class DictViewer(QtWidgets.QWidget):
         layout = QtWidgets.QHBoxLayout()
         layout.addWidget(self.tree)
         layout2 = QtWidgets.QVBoxLayout()
-        layout2.addWidget(QtWidgets.QLabel(filename))
+        layout2.addWidget(QtWidgets.QLabel(os.fspath(filename)))
         layout2.addWidget(self.tree)
         self.setLayout(layout2)
 

--- a/tests/gui/test_main_window_config.py
+++ b/tests/gui/test_main_window_config.py
@@ -184,3 +184,58 @@ class TestReloadTimer:
             assert len(reloads) == 1
         finally:
             window.close()
+
+
+class TestTabConfigEditor:
+    """Tabs open the YAML editor through DefaultTab._open_config_editor."""
+
+    @pytest.fixture
+    def tab(self, main_window, tmp_path, write_project_config, monkeypatch):
+        """A tab whose project reload is stubbed out, plus the recorded reloads.
+
+        The stub is installed before the tab is built, since DefaultTab connects
+        to the bound method at construction time.
+        """
+        from deeplabcut.gui.tabs.manage_project import ManageProject
+
+        config_path = tmp_path / "config.yaml"
+        write_project_config(config_path, tmp_path)
+        main_window.config_path = config_path
+
+        reloads = []
+        monkeypatch.setattr(main_window, "reload_project_config", lambda: reloads.append(True))
+
+        return ManageProject(main_window, main_window, ""), reloads
+
+    def test_editor_outlives_the_call_that_opened_it(self, tab):
+        widget, _ = tab
+        widget.open_project_config_editor()
+
+        assert widget._config_editor is not None
+        assert widget._config_editor.config_path == widget.root.config_path
+
+    def test_saving_the_project_config_reloads_the_project(self, tab, qtbot):
+        widget, reloads = tab
+        widget.open_project_config_editor()
+
+        widget._config_editor.accept()
+        qtbot.wait(50)
+
+        assert len(reloads) == 1
+
+    def test_saving_another_config_leaves_the_project_untouched(self, tab, qtbot, tmp_path):
+        widget, reloads = tab
+        pose_cfg_path = tmp_path / "pose_cfg.yaml"
+        pose_cfg_path.write_text("net_type: resnet_50\n")
+
+        widget._open_config_editor(pose_cfg_path)
+        widget._config_editor.accept()
+        qtbot.wait(50)
+
+        assert reloads == []
+
+    def test_opening_without_a_config_is_a_no_op(self, tab):
+        widget, _ = tab
+        widget._open_config_editor(None)
+
+        assert widget._config_editor is None


### PR DESCRIPTION
## Summary

**Fix pathlib coercion & centralize editor opening**
- Move duplicated config-editor logic from five tabs into `DefaultTab._open_config_editor()` and `open_project_config_editor()`.
- After the pathlib migration, opening Edit config.yaml in the GUI raised TypeError because DictViewer passed a Path to QLabel, which only accepts str. This PR fixes that crash and consolidates how tabs open the YAML editor.

**Deduplicate deferred reload timer** 
- `ManageProject` and `AnalyzeVideos` each owned an identical single-shot `QTimer` to defer `reload_project_config` until
  after the config editor closed. That logic now lives on `DefaultTab` and is connected only when editing the project `config.yaml` (`reload_project=True`). Editing pose/inference configs still does not schedule a reload.