### PR TITLE
update deprecation marker versions (TF deprecation since 3.1, removed in 3.2)

### DIFF
--- a/deeplabcut/core/deprecation.py
+++ b/deeplabcut/core/deprecation.py
@@ -98,8 +98,8 @@ class DeprecationRound(Enum):
     )
 
     INIT_TF_DEPRECATION = DeprecationRoundInfo(
-        since="3.0.2",
-        removed_in="3.1",
+        since="3.1",
+        removed_in="3.2",
         pull_request=3382,
         summary=(
             "Deprecate the TensorFlow-only API in preparation for dropping TensorFlow. "


### PR DESCRIPTION
Placeholder PR to revisit the deprecation markers before 3.1 release. To be decided: official removal date?


