### PR TITLE
Fix outdated str function call to correct Path suffix swap for CSV to h5 conversion

### DIFF
--- a/deeplabcut/utils/conversioncode.py
+++ b/deeplabcut/utils/conversioncode.py
@@ -79,7 +79,8 @@ def convertcsv2h5(config: str | Path, userfeedback=True, scorer=None):
                 data = pd.read_csv(fn, index_col=index_col, header=header)
                 data.columns = data.columns.set_levels([scorer], level="scorer")
                 guarantee_multiindex_rows(data)
-                data.to_hdf(fn.replace(".csv", ".h5"), key="df_with_missing", mode="w")
+                h5_path = fn.with_suffix(".h5")
+                data.to_hdf(h5_path, key="df_with_missing", mode="w")
                 data.to_csv(fn)
         except FileNotFoundError:
             print("Attention:", folder, "does not appear to have labeled data!")


### PR DESCRIPTION
Update `convertcsv2h5` to build the HDF5 output path with `Path.with_suffix(".h5")` instead of string replacement. This makes filename handling safer and consistent with `Path` objects, avoiding edge cases with `.replace()` on path strings.