### PR TITLE
fix WandbLoggerConfig include additional kwargs in pydantic schema

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/config/logger.py
+++ b/deeplabcut/pose_estimation_pytorch/config/logger.py
@@ -98,8 +98,9 @@ class WandbLoggerConfig(LoggerConfig):  #
         if not v:
             return v
         if set(v) & cls._FORBIDDEN_WANDB_KWARGS:
-            raise ValueError("wandb_kwargs can not include any of the reserved options: {cls._FORBIDDEN_WANDB_KWARGS}")
-        return v
+            raise ValueError(
+                f"wandb_kwargs cannot include any of the reserved options: {sorted(cls._FORBIDDEN_WANDB_KWARGS)}"
+            )
 
 
 class CSVLoggerConfig(LoggerConfig):  #

--- a/deeplabcut/pose_estimation_pytorch/config/logger.py
+++ b/deeplabcut/pose_estimation_pytorch/config/logger.py
@@ -13,9 +13,9 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
-from pydantic import model_validator
+from pydantic import field_validator, model_validator
 
 from deeplabcut.core.config import DLCBaseConfig
 
@@ -56,6 +56,9 @@ class WandbLoggerConfig(LoggerConfig):  #
         wandb_kwargs: Additional keyword arguments to pass to wandb.init
     """
 
+    # These options are reserved since they are explicitly passed to wandb.init (from `project_name` and `run_name`)
+    _FORBIDDEN_WANDB_KWARGS: ClassVar[frozenset[str]] = frozenset({"project", "name"})
+
     type: Literal[LoggerType.WandbLogger]
     project_name: str = "deeplabcut"
     run_name: str = "tmp"
@@ -87,6 +90,16 @@ class WandbLoggerConfig(LoggerConfig):  #
 
         data["wandb_kwargs"] = {**nested, **extras}
         return data
+
+    @field_validator("wandb_kwargs")
+    @classmethod
+    def validate_wandb_kwargs(cls, v: dict | None) -> dict | None:
+        """Reject nested keys that collide with reserved wandb.init options."""
+        if not v:
+            return v
+        if set(v) & cls._FORBIDDEN_WANDB_KWARGS:
+            raise ValueError("wandb_kwargs can not include any of the reserved options: {cls._FORBIDDEN_WANDB_KWARGS}")
+        return v
 
 
 class CSVLoggerConfig(LoggerConfig):  #

--- a/deeplabcut/pose_estimation_pytorch/config/logger.py
+++ b/deeplabcut/pose_estimation_pytorch/config/logger.py
@@ -74,7 +74,7 @@ class WandbLoggerConfig(LoggerConfig):  #
         if not isinstance(data, dict):
             return data
 
-        known = set(cls.model_fields)
+        known = set(cls.model_fields) | set(cls._alias_map())
         provided = set(data)
         extras = {key: data.pop(key) for key in provided - known}
         if not extras:

--- a/deeplabcut/pose_estimation_pytorch/config/logger.py
+++ b/deeplabcut/pose_estimation_pytorch/config/logger.py
@@ -41,16 +41,27 @@ class WandbLoggerConfig(LoggerConfig):  #
         type: Logger type (should be 'WandbLogger')
         project_name: The name of the wandb project
         run_name: The name of the wandb run
+        entity: The wandb user or team under which the run is logged
+        notes: A longer description of the run, displayed in the wandb UI
+        tags: Tags for the run, used to organize and filter runs in the wandb UI
+        group: The name of the group to which this run belongs
+        job_type: The type of job being logged (e.g. 'train' or 'eval')
         image_log_interval: How often train/test images are logged in epochs
             (if None, train/test inputs are never logged)
         model: The model architecture to log
         train_folder: The path of the folder containing training files.
-        wandb_kwargs: Additional keyword arguments to pass to wandb.init
+        wandb_kwargs: Additional keyword arguments to pass to wandb.init. Use this for
+            wandb.init parameters which are not declared above.
     """
 
     type: Literal[LoggerType.WandbLogger]
     project_name: str = "deeplabcut"
     run_name: str = "tmp"
+    entity: str | None = None
+    notes: str | None = None
+    tags: list[str] | None = None
+    group: str | None = None
+    job_type: str | None = None
     image_log_interval: int | None = None
     model: dict | None = None
     train_folder: str | None = None

--- a/deeplabcut/pose_estimation_pytorch/config/logger.py
+++ b/deeplabcut/pose_estimation_pytorch/config/logger.py
@@ -41,27 +41,16 @@ class WandbLoggerConfig(LoggerConfig):  #
         type: Logger type (should be 'WandbLogger')
         project_name: The name of the wandb project
         run_name: The name of the wandb run
-        entity: The wandb user or team under which the run is logged
-        notes: A longer description of the run, displayed in the wandb UI
-        tags: Tags for the run, used to organize and filter runs in the wandb UI
-        group: The name of the group to which this run belongs
-        job_type: The type of job being logged (e.g. 'train' or 'eval')
         image_log_interval: How often train/test images are logged in epochs
             (if None, train/test inputs are never logged)
         model: The model architecture to log
         train_folder: The path of the folder containing training files.
-        wandb_kwargs: Additional keyword arguments to pass to wandb.init. Use this for
-            wandb.init parameters which are not declared above.
+        wandb_kwargs: Additional keyword arguments to pass to wandb.init
     """
 
     type: Literal[LoggerType.WandbLogger]
     project_name: str = "deeplabcut"
     run_name: str = "tmp"
-    entity: str | None = None
-    notes: str | None = None
-    tags: list[str] | None = None
-    group: str | None = None
-    job_type: str | None = None
     image_log_interval: int | None = None
     model: dict | None = None
     train_folder: str | None = None

--- a/deeplabcut/pose_estimation_pytorch/config/logger.py
+++ b/deeplabcut/pose_estimation_pytorch/config/logger.py
@@ -74,6 +74,7 @@ class WandbLoggerConfig(LoggerConfig):  #
         if not isinstance(data, dict):
             return data
 
+        data = dict(data)
         known = set(cls.model_fields) | set(cls._alias_map())
         provided = set(data)
         extras = {key: data.pop(key) for key in provided - known}

--- a/deeplabcut/pose_estimation_pytorch/config/logger.py
+++ b/deeplabcut/pose_estimation_pytorch/config/logger.py
@@ -10,8 +10,12 @@
 #
 """Logger configuration classes for DeepLabCut training runs."""
 
+from __future__ import annotations
+
 from enum import Enum
-from typing import Literal
+from typing import Any, Literal
+
+from pydantic import model_validator
 
 from deeplabcut.core.config import DLCBaseConfig
 
@@ -37,6 +41,10 @@ class WandbLoggerConfig(LoggerConfig):  #
     This logger tracks experiments and logs data to Weights & Biases.
     Refer to: https://docs.wandb.ai/guides for more information.
 
+    Notes:
+        Different config versions might have top-level WandB options instead of
+        wandb_kwargs. Unknown top-level fields are scooped into wandb_kwargs.
+
     Attributes:
         type: Logger type (should be 'WandbLogger')
         project_name: The name of the wandb project
@@ -55,6 +63,30 @@ class WandbLoggerConfig(LoggerConfig):  #
     model: dict | None = None
     train_folder: str | None = None
     wandb_kwargs: dict | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def scoop_extra_wandb_kwargs(cls, data: Any) -> Any:
+        """Move unknown top-level keys into ``wandb_kwargs``"""
+        if not isinstance(data, dict):
+            return data
+
+        known = set(cls.model_fields)
+        provided = set(data)
+        extras = {key: data.pop(key) for key in provided - known}
+        if not extras:
+            return data
+
+        nested = data.get("wandb_kwargs") or {}
+        if not isinstance(nested, dict):
+            raise ValueError("wandb_kwargs must be a dictionary when provided")
+
+        overlap = set(extras) & set(nested)
+        if overlap:
+            raise ValueError(f"Duplicate wandb.init options at top-level and in wandb_kwargs: {sorted(overlap)}")
+
+        data["wandb_kwargs"] = {**nested, **extras}
+        return data
 
 
 class CSVLoggerConfig(LoggerConfig):  #

--- a/deeplabcut/pose_estimation_pytorch/config/logger.py
+++ b/deeplabcut/pose_estimation_pytorch/config/logger.py
@@ -102,6 +102,7 @@ class WandbLoggerConfig(LoggerConfig):  #
             raise ValueError(
                 f"wandb_kwargs cannot include any of the reserved options: {sorted(cls._FORBIDDEN_WANDB_KWARGS)}"
             )
+        return v
 
 
 class CSVLoggerConfig(LoggerConfig):  #

--- a/deeplabcut/pose_estimation_pytorch/runners/logger.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/logger.py
@@ -275,7 +275,9 @@ class WandbLogger(ImageLoggerMixin, BaseLogger):
                 None, train/test inputs are never logged).
             model: The model to log. Defaults to None.
             train_folder: path to the train folder (used to store the W&B run identifiers)
-            wandb_kwargs: extra arguments to pass to ``wb.init``
+            wandb_kwargs: extra arguments to pass to ``wb.init``. These can be given as
+                keyword arguments, or collected in a single ``wandb_kwargs`` mapping (as
+                declared by ``WandbLoggerConfig``).
 
         Example:
             logger = WandbLogger(project_name="mice", run_name="exp1", model=my_model)
@@ -290,6 +292,9 @@ class WandbLogger(ImageLoggerMixin, BaseLogger):
 
         if wandb.run is not None:
             wandb.finish()
+
+        # A nested ``wandb_kwargs``mapping must be flattened
+        wandb_kwargs.update(wandb_kwargs.pop("wandb_kwargs", None) or {})
 
         self.run = wandb.init(
             project=project_name,

--- a/deeplabcut/pose_estimation_pytorch/runners/logger.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/logger.py
@@ -293,7 +293,7 @@ class WandbLogger(ImageLoggerMixin, BaseLogger):
         if wandb.run is not None:
             wandb.finish()
 
-        # A nested ``wandb_kwargs``mapping must be flattened
+        # A nested ``wandb_kwargs`` mapping must be flattened
         wandb_kwargs.update(wandb_kwargs.pop("wandb_kwargs", None) or {})
 
         self.run = wandb.init(

--- a/deeplabcut/pose_estimation_pytorch/runners/logger.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/logger.py
@@ -275,7 +275,7 @@ class WandbLogger(ImageLoggerMixin, BaseLogger):
                 None, train/test inputs are never logged).
             model: The model to log. Defaults to None.
             train_folder: path to the train folder (used to store the W&B run identifiers)
-            wandb_kwargs: extra arguments to pass to ``wb.init``. These can be given as
+            wandb_kwargs: extra arguments to pass to ``wandb.init``. These can be given as
                 keyword arguments, or collected in a single ``wandb_kwargs`` mapping (as
                 declared by ``WandbLoggerConfig``).
 

--- a/tests/pose_estimation_pytorch/config/test_logger_config.py
+++ b/tests/pose_estimation_pytorch/config/test_logger_config.py
@@ -1,0 +1,85 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Tests for WandbLoggerConfig validation."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from deeplabcut.pose_estimation_pytorch.config.logger import LoggerType, WandbLoggerConfig
+
+
+def test_wandb_kwargs_accepts_nested_extras() -> None:
+    cfg = WandbLoggerConfig.from_dict(
+        {
+            "type": LoggerType.WandbLogger,
+            "wandb_kwargs": {
+                "entity": "team",
+                "mode": "offline",
+                "tags": ["a"],
+                "settings": {"_service_wait": 60},
+            },
+        }
+    )
+    assert cfg.wandb_kwargs["entity"] == "team"
+    assert cfg.wandb_kwargs["settings"] == {"_service_wait": 60}
+
+
+def test_scoops_top_level_extras_into_wandb_kwargs() -> None:
+    cfg = WandbLoggerConfig.from_dict(
+        {
+            "type": LoggerType.WandbLogger,
+            "project_name": "proj",
+            "group": "group_a",
+            "tags": ["mytag"],
+        }
+    )
+    assert cfg.project_name == "proj"
+    assert cfg.wandb_kwargs == {"group": "group_a", "tags": ["mytag"]}
+
+
+def test_mixed_top_level_and_nested_wandb_kwargs() -> None:
+    cfg = WandbLoggerConfig.from_dict(
+        {
+            "type": LoggerType.WandbLogger,
+            "group": "group_a",
+            "wandb_kwargs": {"tags": ["mytag"], "mode": "offline", "id": "run-1"},
+        }
+    )
+    assert cfg.wandb_kwargs == {
+        "tags": ["mytag"],
+        "mode": "offline",
+        "id": "run-1",
+        "group": "group_a",
+    }
+
+
+def test_rejects_duplicate_top_level_and_nested() -> None:
+    with pytest.raises(ValidationError, match="Duplicate wandb.init options"):
+        WandbLoggerConfig.from_dict(
+            {
+                "type": LoggerType.WandbLogger,
+                "tags": ["a"],
+                "wandb_kwargs": {"tags": ["b"], "mode": "offline"},
+            }
+        )
+
+
+@pytest.mark.parametrize("overlap_key", ["project", "name"])
+def test_wandb_kwargs_rejects_reserved_keys(overlap_key: str) -> None:
+    with pytest.raises(ValidationError, match="reserved options"):
+        WandbLoggerConfig.from_dict(
+            {
+                "type": LoggerType.WandbLogger,
+                "wandb_kwargs": {overlap_key: "x", "mode": "offline"},
+            }
+        )


### PR DESCRIPTION
The Weights and Biases logger accepts a variety of extra arguments, such as `notes`, `tags`, etc. These were mediated through `wandb_kwargs` which could be defined at top-level. However since the introduction of the stricter pydantic schemas these top-level arguments with `extra="forbid"` would raise a `ValidationError`.

This PR:
- fixes a dead `wandb_kwargs` field in the `WandBloggerConfig` (was never passed correctly to the logger)
- ~adds common top-level fields such as `notes`, `tags`, `group` to the top-level config.~

**Edit:**
To avoid breaking the current config schema I refrained from adding common WandB args like `notes`, `tags`, `group` as top-level fields. Since they may appear in older unversioned config yamls, I've added a before validator that scoops them into the `wandb_kwargs` field. I've also added testing, so that the following YAML forms are accounted for:

```yaml
# Allow both top-level and nested args (even combined, when no conflicts):
logger:
  project_name: "deeplabcut"
  ...
  tags: ["mytag"]  # <-  top-level (will be moved into wandb_kwargs by the validator)
  wandb_kwargs:
     group: "mygroup"  # <- nested


# Don't allow configs like this:
logger:
  project_name: "deeplabcut"
  ...
  project: "myproject"  # <- Reserved fields are not allowed (already defined via "project name", "run_name")
  group: "mygroup"
  wandb_kwargs: 
      group: "repeated"   # <- Duplicate top-level and nested fields are not allowed.
```

