### PR TITLE
Update CI to target the dev branch

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,10 +3,10 @@ name: Code / Codespell
 
 on:
   push:
-    branches: [main]
+    branches: [ main, dev ]
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [ main ]
+    branches: [ main, dev ]
 
 jobs:
   codespell:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,7 +2,7 @@ name: Docs / Deploy docs (main + dev-docs main)
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main ] # do not add dev/ here
 
 permissions:
   contents: write

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,7 +2,7 @@ name: Docs / Deploy docs (main + dev-docs main)
 
 on:
   push:
-    branches: [ main ] # do not add dev/ here
+    branches: [ main ] # do not add dev here
 
 permissions:
   contents: write

--- a/.github/workflows/docs_and_notebooks_checks.yml
+++ b/.github/workflows/docs_and_notebooks_checks.yml
@@ -2,9 +2,9 @@ name: Docs / Docs & notebooks freshness and formatting checks
 
 on:
   pull_request:
-    branches: [main]
+    branches: [ main, dev ]
   push:
-    branches: [main]
+    branches: [ main, dev ]
 
 permissions:
   contents: read

--- a/.github/workflows/intelligent-testing.yml
+++ b/.github/workflows/intelligent-testing.yml
@@ -2,10 +2,10 @@ name: Code / Intelligent Python Testing
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [ main ]
+    branches: [ main, dev ]
 
 concurrency:
   group: intelligent-${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || format('run-{0}', github.run_id) }}

--- a/.github/workflows/intelligent-testing.yml
+++ b/.github/workflows/intelligent-testing.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, dev ]
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     branches: [ main, dev ]
 
 concurrency:
@@ -19,6 +19,7 @@ jobs:
     name: Select test plan
     runs-on: ubuntu-latest
     outputs:
+      is_dev_draft: ${{ steps.is_dev_draft.outputs.is_dev_draft }}
       run_skip: ${{ steps.selector.outputs.run_skip }}
       run_docs: ${{ steps.selector.outputs.run_docs }}
       run_fast: ${{ steps.selector.outputs.run_fast }}
@@ -31,6 +32,15 @@ jobs:
       changed_files: ${{ steps.selector.outputs.changed_files }}
       provenance: ${{ steps.selector.outputs.provenance }}
     steps:
+      - name: Evaluate if PR is a draft on dev/
+        id: is_dev_draft
+        run: |
+          echo "is_dev_draft=${{
+            github.event_name == 'pull_request' &&
+            github.base_ref == 'dev' &&
+            github.event.pull_request.draft == true
+          }}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout code
         uses: actions/checkout@v6
         with:
@@ -78,7 +88,7 @@ jobs:
   docs:
     name: Main docs build
     needs: intelligent-test-selection
-    if: needs.intelligent-test-selection.outputs.run_docs == 'true'
+    if: needs.intelligent-test-selection.outputs.run_docs == 'true' && needs.intelligent-test-selection.outputs.is_dev_draft != 'true'
     uses: ./.github/workflows/build-main-docs.yml
     with:
       python-version: "3.10"
@@ -89,7 +99,7 @@ jobs:
   dev-docs:
     name: Dev docs build
     needs: intelligent-test-selection
-    if: needs.intelligent-test-selection.outputs.run_docs == 'true'
+    if: needs.intelligent-test-selection.outputs.run_docs == 'true' && needs.intelligent-test-selection.outputs.is_dev_draft != 'true'
     uses: ./.github/workflows/build-dev-docs.yml
     with:
       python-version: "3.10"
@@ -99,7 +109,7 @@ jobs:
   fast-tests:
     name: Fast lane (targeted pytest + selected functional)
     needs: intelligent-test-selection
-    if: needs.intelligent-test-selection.outputs.run_fast == 'true'
+    if: needs.intelligent-test-selection.outputs.run_fast == 'true' && needs.intelligent-test-selection.outputs.is_dev_draft != 'true'
     uses: ./.github/workflows/python-package.yml
     with:
       concurrency_key: ${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || '' }}
@@ -112,7 +122,7 @@ jobs:
   full-tests:
     name: Full matrix tests
     needs: intelligent-test-selection
-    if: needs.intelligent-test-selection.outputs.run_full == 'true'
+    if: needs.intelligent-test-selection.outputs.run_full == 'true' && needs.intelligent-test-selection.outputs.is_dev_draft != 'true'
     uses: ./.github/workflows/python-package.yml
     with:
       concurrency_key: ${{ github.event.pull_request.number && format('pr-{0}', github.event.pull_request.number) || '' }}
@@ -135,7 +145,7 @@ jobs:
   tf-install-smoke-test:
     name: TensorFlow install smoke test
     needs: intelligent-test-selection
-    if: needs.intelligent-test-selection.outputs.run_full == 'true'
+    if: needs.intelligent-test-selection.outputs.run_full == 'true' && needs.intelligent-test-selection.outputs.is_dev_draft != 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/lockfile-check.yml
+++ b/.github/workflows/lockfile-check.yml
@@ -6,14 +6,14 @@ on:
       - "pyproject.toml"
       - "uv.lock"
       # - ".python-version"
-      - ".github/workflows/uv-lockfile-check.yml"
+      - ".github/workflows/lockfile-check.yml"
   push:
-    branches: [main]
+    branches: [ main, dev ]
     paths:
       - "pyproject.toml"
       - "uv.lock"
       # - ".python-version"
-      - ".github/workflows/uv-lockfile-check.yml"
+      - ".github/workflows/lockfile-check.yml"
 
 jobs:
   uv-lockfile-check:


### PR DESCRIPTION
Adds the dev branch to CI targets for testing, spell checks and uv lockfile checks.

### To consider when reviewing/merging

- [x] Ensure there are no side effects from adding dev
  - Aside from extra CI runs, there is no deploy logic that is specific to main besides docs
- [ ] [**ADMIN ONLY**] Ideally apply ruleset for main to dev, or a lightly updated one (if we could discuss together @MMathisLab @AlexEMG, this shouldn't take long to setup)
- [x] To save on CI runner congestion, avoid running on draft dev PRs

Fixes a workflow name consistency issue in uv lock check workflow.