### PR TITLE
fix `export_model` dumping unnormalized objects in pickle

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/apis/export.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/export.py
@@ -136,7 +136,7 @@ def export_model(
             # Convert typed config to plain dict so torch.save doesn't pickle
             # custom types (which require weights_only=False to load)
             if isinstance(model_cfg, PoseConfig):
-                model_cfg = model_cfg.to_dict()
+                model_cfg = model_cfg.to_dict(normalize=True)
 
             pose_weights = torch.load(snapshot.path, **load_kwargs)["model"]
             export_dict = dict(config=model_cfg, pose=pose_weights)

--- a/tests/pose_estimation_pytorch/apis/test_apis_export.py
+++ b/tests/pose_estimation_pytorch/apis/test_apis_export.py
@@ -224,10 +224,10 @@ def test_export_model(
 
 def _assert_plain_data(obj, path: str = "config") -> None:
     """Asserts that ``obj`` only contains primitive types, recursively."""
-    if isinstance(obj, dict):
+    if type(obj) is dict:
         for key, value in obj.items():
             _assert_plain_data(value, f"{path}[{key!r}]")
-    elif isinstance(obj, (list, tuple)):
+    elif type(obj) in (list, tuple):
         for index, value in enumerate(obj):
             _assert_plain_data(value, f"{path}[{index}]")
     else:

--- a/tests/pose_estimation_pytorch/apis/test_apis_export.py
+++ b/tests/pose_estimation_pytorch/apis/test_apis_export.py
@@ -222,6 +222,39 @@ def test_export_model(
             assert exported_data["detector"] == detector_data[detector_idx]["model"]
 
 
+def _assert_plain_data(obj, path: str = "config") -> None:
+    """Asserts that ``obj`` only contains primitive types, recursively."""
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            _assert_plain_data(value, f"{path}[{key!r}]")
+    elif isinstance(obj, (list, tuple)):
+        for index, value in enumerate(obj):
+            _assert_plain_data(value, f"{path}[{index}]")
+    else:
+        assert type(obj) in (bool, int, float, str, type(None)), f"{path} is a raw {type(obj)}: {obj!r}"
+
+
+def test_export_model_config_contains_no_raw_objects(project_dir):
+    """The exported config must be plain data (no Enum, Path, PoseConfig, ...)."""
+    mock_loader = _get_export_model_data(project_dir, 1, Task.BOTTOM_UP)[0]
+    mock_loader.model_cfg = _minimal_pose_config(project_dir)
+
+    def get_mock_loader(*args, **kwargs):
+        return mock_loader
+
+    with patch(
+        "deeplabcut.pose_estimation_pytorch.apis.export.dlc3_data.DLCLoader",
+        get_mock_loader,
+    ):
+        export.export_model(project_dir / "config.yaml")
+
+    exports = list((project_dir / "exported-models-pytorch").rglob("*.pt"))
+    assert len(exports) == 1
+
+    # ``weights_only=True`` only loads if no custom types were pickled.
+    _assert_plain_data(torch.load(exports[0], weights_only=True)["config"])
+
+
 @patch("deeplabcut.pose_estimation_pytorch.apis.export.wipe_paths_from_model_config")
 @pytest.mark.parametrize("task", [Task.BOTTOM_UP, Task.TOP_DOWN])
 def test_export_model_clear_paths(mock_wipe: Mock, project_dir, task: Task):


### PR DESCRIPTION
Export model unintendedly missed the `normalize=True` flag, which makes sure that all objects in the config are normalized to primitive types: e.g. `Path` -> `str`,  `Enum` -> `str`, etc

This is addressed in the current PR by adding `normalize=True` in the `PoseConfig.to_dict()` call.