### PR TITLE
Train object detectors on Apple MPS for validated variants

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/apis/training.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/training.py
@@ -60,7 +60,9 @@ def train(
         loader: the loader containing the data to train on/validate with
         run_config: the model and run configuration
         task: the task to train the model for
-        device: the torch device to train on (such as "cpu", "cuda", "mps")
+        device: the torch device to train on (such as "cpu", "cuda", "mps"). Detectors
+            only run on MPS for validated variants, and fall back to the CPU with a
+            warning otherwise.
         gpus: the list of GPU indices to use for multi-GPU training
         logger_config: the configuration of a logger to use
         snapshot_path: if continuing to train from a snapshot, the path containing the
@@ -114,8 +116,8 @@ def train(
     if gpus is None:
         gpus = run_config["runner"].get("gpus")
 
-    if device == "mps" and task == Task.DETECT:
-        device = "cpu"  # FIXME: Cannot train detectors on MPS
+    if task == Task.DETECT:
+        device = utils.resolve_detector_device(device, utils.detector_variant(run_config))
 
     if snapshot_path is None:
         snapshot_path = run_config.get("resume_training_from")
@@ -228,7 +230,15 @@ def train_network(
         modelprefix: directory containing the deeplabcut configuration files to use
             to train the network (and where snapshots will be saved). By default, they
              are assumed to exist in the project folder.
-        device: the torch device to train on (such as "cpu", "cuda", "mps")
+        device: the torch device to train on (such as "cpu", "cuda", "mps"). For top-down
+            models this applies to both the detector and the pose model. When None, the
+            devices set in the model configuration are used: the detector inherits the
+            top-level device unless detector.device is set in the model configuration,
+            and picks its own device when both are "auto". With "auto" the auto policy is
+            applied to both models regardless of the configured top-level device (an
+            explicit detector.device is still kept).
+            Detectors run on MPS only for validated variants (they fall back to the CPU
+            with a warning otherwise).
         snapshot_path: if resuming training, the snapshot from which to resume
         detector_path: if resuming training of a top-down model, used to specify the
             detector snapshot from which to resume
@@ -348,13 +358,15 @@ def train_network(
             logger_config["run_name"] += "-detector"
 
         detector_run_config = loader.model_cfg["detector"]
-        detector_run_config["device"] = loader.model_cfg["device"]
+        if detector_run_config["device"] == "auto":
+            # an explicit detector.device is kept; "auto" leaves the detector its own policy
+            detector_run_config["device"] = "auto" if device == "auto" else loader.model_cfg["device"]
         detector_run_config["train_settings"]["weight_init"] = loader.model_cfg["train_settings"].get("weight_init")
         train(
             loader=loader,
             run_config=detector_run_config,
             task=Task.DETECT,
-            device=device,
+            device=None if device == "auto" else device,  # "auto": resolved from the detector config
             logger_config=logger_config,
             snapshot_path=detector_path,
             max_snapshots_to_keep=max_snapshots_to_keep,

--- a/deeplabcut/pose_estimation_pytorch/runners/train.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/train.py
@@ -38,6 +38,7 @@ from deeplabcut.pose_estimation_pytorch.runners.logger import (
 )
 from deeplabcut.pose_estimation_pytorch.runners.snapshots import TorchSnapshotManager
 from deeplabcut.pose_estimation_pytorch.task import Task
+from deeplabcut.pose_estimation_pytorch.utils import is_mps_device
 
 
 class TrainingRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
@@ -532,6 +533,17 @@ class PoseTrainingRunner(TrainingRunner[PoseModel]):
         self._epoch_predictions[name] = epoch_metric
 
 
+def _move_target_to_device(tensor: torch.Tensor, device: str | torch.device) -> torch.Tensor:
+    """Moves a detector target tensor to ``device``.
+
+    MPS has no float64 support, so float64 targets such as boxes and areas are cast to
+    float32; integer labels are moved unchanged.
+    """
+    if is_mps_device(device) and tensor.dtype == torch.float64:
+        return tensor.to(device, dtype=torch.float32)
+    return tensor.to(device)
+
+
 class DetectorTrainingRunner(TrainingRunner[BaseDetector]):
     """Runner to train object detection models."""
 
@@ -588,7 +600,7 @@ class DetectorTrainingRunner(TrainingRunner[BaseDetector]):
         for item in target:  # target is a list here
             for key in item:
                 if item[key] is not None:
-                    item[key] = item[key].to(self.device)
+                    item[key] = _move_target_to_device(item[key], self.device)
 
         losses, predictions = self.model(images, target)
 

--- a/deeplabcut/pose_estimation_pytorch/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/utils.py
@@ -49,14 +49,20 @@ torchvision 0.29.0 (pytorch/vision#9510) but not validated here yet.
 def torch_meets_detector_mps_floor() -> bool:
     """Whether the installed torch is a release >= ``MIN_TORCH_FOR_DETECTOR_MPS``.
 
-    Pre-releases and unparsable version strings do not qualify.
+    Official pre-releases and unparsable version strings do not qualify. A pre-release
+    tag paired with a ``"+git..."`` local segment marks a from-source build of that
+    release (PyTorch's own versioning convention, e.g. ``"2.13.0a0+git1234567"``); those
+    still qualify, since the source tree already has the release's fixes.
     """
     floor = Version(".".join(str(v) for v in MIN_TORCH_FOR_DETECTOR_MPS))
     try:
         installed = Version(torch.__version__)
     except InvalidVersion:
         return False
-    return not installed.is_prerelease and installed >= floor
+    from_source_build = installed.local is not None and installed.local.startswith("git")
+    if installed.is_prerelease and not from_source_build:
+        return False
+    return installed >= floor
 
 
 def is_mps_device(device: str | torch.device | None) -> bool:

--- a/deeplabcut/pose_estimation_pytorch/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/utils.py
@@ -52,7 +52,10 @@ def torch_meets_detector_mps_floor() -> bool:
     Official pre-releases and unparsable version strings do not qualify. A pre-release
     tag paired with a ``"+git..."`` local segment marks a from-source build of that
     release (PyTorch's own versioning convention, e.g. ``"2.13.0a0+git1234567"``); those
-    still qualify, since the source tree already has the release's fixes.
+    still qualify, since the source tree already has the release's fixes. Such builds are
+    compared by release number alone: PEP 440 orders a pre-release below its final release,
+    so a from-source build of the floor version itself (e.g. ``"2.12.0a0+git1234567"``)
+    would otherwise be rejected.
     """
     floor = Version(".".join(str(v) for v in MIN_TORCH_FOR_DETECTOR_MPS))
     try:
@@ -62,6 +65,8 @@ def torch_meets_detector_mps_floor() -> bool:
     from_source_build = installed.local is not None and installed.local.startswith("git")
     if installed.is_prerelease and not from_source_build:
         return False
+    if from_source_build:
+        return installed.release >= floor.release
     return installed >= floor
 
 

--- a/deeplabcut/pose_estimation_pytorch/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/utils.py
@@ -11,9 +11,11 @@
 from __future__ import annotations
 
 import random
+import warnings
 
 import numpy as np
 import torch
+from packaging.version import InvalidVersion, Version
 
 from deeplabcut.pose_estimation_pytorch.config.pose import DetectorConfig, PoseConfig
 
@@ -31,12 +33,100 @@ def fix_seeds(seed: int) -> None:
     torch.backends.cudnn.benchmark = False
 
 
+MIN_TORCH_FOR_DETECTOR_MPS = (2, 12)
+"""Minimum torch release for running detectors on Apple MPS; older ones hang (DeepLabCut#3155)."""
+
+DETECTOR_MPS_VALIDATED_VARIANTS: frozenset[str] = frozenset({"ssdlite"})
+"""Detector variants checked against CPU runs on Apple MPS (ssdlite, torch 2.12.1 and 2.13.0).
+
+Only these resolve to MPS with ``device: auto``; other variants fall back to the CPU. Training the
+Faster R-CNN variants on MPS hangs the GPU (fasterrcnn_resnet50_fpn_v2 hard enough to trigger a
+macOS watchdog kernel panic) through torchvision's ``roi_align`` backward kernel, fixed in
+torchvision 0.29.0 (pytorch/vision#9510) but not validated here yet.
+"""
+
+
+def torch_meets_detector_mps_floor() -> bool:
+    """Whether the installed torch is a release >= ``MIN_TORCH_FOR_DETECTOR_MPS``.
+
+    Pre-releases and unparsable version strings do not qualify.
+    """
+    floor = Version(".".join(str(v) for v in MIN_TORCH_FOR_DETECTOR_MPS))
+    try:
+        installed = Version(torch.__version__)
+    except InvalidVersion:
+        return False
+    return not installed.is_prerelease and installed >= floor
+
+
+def is_mps_device(device: str | torch.device | None) -> bool:
+    """Whether a device targets Apple MPS (``"mps"``, ``"mps:0"``, ...)."""
+    return device is not None and str(device).startswith("mps")
+
+
+def detector_variant(config: DetectorConfig | dict) -> str | None:
+    """Returns the canonical variant name of a detector configuration, or None if unknown."""
+    model = config["model"] if isinstance(config, dict) else config.model
+    variant = model.get("variant")
+    if variant:
+        return str(variant)
+    if str(model.get("type", "")).lower() == "ssdlite":
+        return "ssdlite"
+    return None
+
+
+def detector_mps_supported(variant: str | None) -> bool:
+    """Whether MPS is available, torch meets the floor and ``variant`` is validated (None is not)."""
+    return (
+        torch.backends.mps.is_built()
+        and torch.backends.mps.is_available()
+        and torch_meets_detector_mps_floor()
+        and variant in DETECTOR_MPS_VALIDATED_VARIANTS
+    )
+
+
+def resolve_detector_device(device: str | torch.device | None, variant: str | None) -> str | torch.device | None:
+    """Applies the MPS gate to the device a detector is about to be trained on.
+
+    Non-MPS devices and validated variants are returned unchanged; otherwise a warning names the
+    reason and the detector falls back to ``"cpu"``.
+    """
+    if device is None or not is_mps_device(device):
+        return device
+    if detector_mps_supported(variant):
+        return device
+
+    if not (torch.backends.mps.is_built() and torch.backends.mps.is_available()):
+        reason = f"Detector device {str(device)!r} was requested, but MPS is not available on this machine."
+    elif not torch_meets_detector_mps_floor():
+        floor = ".".join(str(v) for v in MIN_TORCH_FOR_DETECTOR_MPS)
+        reason = (
+            f"Running detectors on MPS requires torch >= {floor} (found {torch.__version__}); "
+            "older versions are known to hang (DeepLabCut#3155)."
+        )
+    else:
+        reason = (
+            f"Detector variant {variant!r} has not been validated on MPS. Training unvalidated detectors on "
+            "MPS has been observed to hang the GPU badly enough to trigger a system watchdog reboot "
+            "(fasterrcnn_resnet50_fpn_v2 on Apple Silicon; torchvision roi_align backward bug, "
+            "pytorch/vision#9510, fixed in torchvision 0.29.0)."
+        )
+    warnings.warn(
+        f"{reason} The detector is trained on the CPU instead. To silence this warning, put the detector on "
+        'the CPU explicitly (detector.device: cpu in the model configuration, or device="cpu").',
+        UserWarning,
+        stacklevel=2,
+    )
+    return "cpu"
+
+
 def resolve_device(model_config: PoseConfig | DetectorConfig) -> str:
     """Determines which device should be used from the model config.
 
     When the device is set to 'auto':
         If an Nvidia GPU is available, selects the device as cuda:0.
-        Selects 'mps' if available (on macOS) and the net type is compatible.
+        Selects 'mps' if available (on macOS) and the model supports it: resnet pose
+        backbones, and detector variants validated on MPS on torch >= 2.12.
         Otherwise, returns 'cpu'.
     Otherwise, simply returns the selected device
 
@@ -49,7 +139,7 @@ def resolve_device(model_config: PoseConfig | DetectorConfig) -> str:
     device = model_config.device
 
     if isinstance(model_config, DetectorConfig):
-        supports_mps = False
+        supports_mps = detector_mps_supported(detector_variant(model_config))
     else:
         supports_mps = "resnet" in model_config.get("net_type", "")
 

--- a/deeplabcut/pose_estimation_pytorch/utils.py
+++ b/deeplabcut/pose_estimation_pytorch/utils.py
@@ -50,12 +50,12 @@ def torch_meets_detector_mps_floor() -> bool:
     """Whether the installed torch is a release >= ``MIN_TORCH_FOR_DETECTOR_MPS``.
 
     Official pre-releases and unparsable version strings do not qualify. A pre-release
-    tag paired with a ``"+git..."`` local segment marks a from-source build of that
-    release (PyTorch's own versioning convention, e.g. ``"2.13.0a0+git1234567"``); those
-    still qualify, since the source tree already has the release's fixes. Such builds are
-    compared by release number alone: PEP 440 orders a pre-release below its final release,
-    so a from-source build of the floor version itself (e.g. ``"2.12.0a0+git1234567"``)
-    would otherwise be rejected.
+    tag paired with a ``"+git..."`` local segment marks a from-source build (PyTorch's
+    own versioning convention, e.g. ``"2.13.0a0+git1234567"``); such a build only
+    qualifies when its target release is strictly newer than the floor. A from-source
+    build tagged with the floor release itself (e.g. ``"2.12.0a0+git1234567"``) may be
+    checked out from anywhere in that release's development, so it cannot be assumed to
+    already contain the fixes the floor exists for.
     """
     floor = Version(".".join(str(v) for v in MIN_TORCH_FOR_DETECTOR_MPS))
     try:
@@ -63,10 +63,10 @@ def torch_meets_detector_mps_floor() -> bool:
     except InvalidVersion:
         return False
     from_source_build = installed.local is not None and installed.local.startswith("git")
-    if installed.is_prerelease and not from_source_build:
-        return False
-    if from_source_build:
-        return installed.release >= floor.release
+    if installed.is_prerelease:
+        if not from_source_build:
+            return False
+        return Version(installed.base_version) > floor
     return installed >= floor
 
 

--- a/docs/recipes/TechHardware.md
+++ b/docs/recipes/TechHardware.md
@@ -34,13 +34,42 @@ If you encounter errors during inference related to
 context to `torch.no_grad`, which is compatible with the DirectML execution path.
 ```
 
+#### Apple Silicon (MPS)
+
+On Apple Silicon Macs, the PyTorch engine can use the GPU through Metal (`mps`):
+
+- **Pose models**: with `device: auto`, ResNet backbones run on MPS. Other
+  backbones (e.g. HRNets) stay on the CPU unless `device` is set explicitly in
+  `pytorch_config.yaml`.
+- **Object detectors** (top-down / multi-animal models): a detector is trained
+  on MPS only when MPS is available, the installed torch is a release
+  `>= 2.12`, and the detector variant has been validated on MPS. Currently
+  validated: `ssdlite` (the default detector), on Apple Silicon with torch
+  2.12.1 and 2.13.0. Other variants are trained on the CPU, and a warning says
+  why when MPS was requested: on older torch versions, detectors hang on MPS
+  (see [#3155](https://github.com/DeepLabCut/DeepLabCut/issues/3155)), and
+  training the Faster R-CNN variants on MPS hung the GPU hard enough to trigger a macOS
+  watchdog kernel panic and reboot. The cause is a bug in the MPS backward
+  kernel of torchvision's `roi_align`
+  ([pytorch/vision#9510](https://github.com/pytorch/vision/pull/9510)), fixed
+  in torchvision 0.29.0 (which requires torch 2.14). Faster R-CNN training on
+  MPS has not been validated against that release yet, so it stays on the CPU
+  for now.
+- **Which device the detector trains on**: the `device` argument of
+  `train_network` applies to both models. Otherwise the detector inherits the
+  top-level `device` of `pytorch_config.yaml` unless `detector.device` is set,
+  and picks its own device by the rule above when both are `auto` (so a
+  top-down HRNet model that stays on the CPU still trains its `ssdlite`
+  detector on MPS). To keep the detector on the CPU, set `detector.device: cpu`
+  or pass `device="cpu"`; both silence the warning.
+
 ### Camera Hardware
 
 The software is very robust to track data from any camera (cell phone cameras, grayscale, color; captured under infrared light, different manufacturers, etc.). See demos on our [website](https://www.mousemotorlab.org/deeplabcut/).
 
 ### Software
 
-**Operating System:** Linux (Ubuntu), MacOS\* (Mojave), or Windows 10. However, the authors strongly recommend Ubuntu! \*MacOS does not support NVIDIA GPUs (easily), so we only suggest this option for CPU use or a case where the user wants to label data, refine data, etc and then push the project to a cloud resource for GPU computing steps, or use MobileNets.
+**Operating System:** Linux (Ubuntu), MacOS\* (Mojave), or Windows 10. However, the authors strongly recommend Ubuntu! \*MacOS does not support NVIDIA GPUs (easily); on Apple Silicon the PyTorch engine can use the GPU through MPS for some models (see *Apple Silicon (MPS)* above). Otherwise we suggest this option for CPU use or a case where the user wants to label data, refine data, etc and then push the project to a cloud resource for GPU computing steps, or use MobileNets.
 
 **Anaconda/Python3:** Anaconda: a free and open source distribution of the Python programming language (download from https://www.anaconda.com/). DeepLabCut is written in Python 3 (https://www.python.org/) and not compatible with Python 2.
 

--- a/tests/pose_estimation_pytorch/apis/test_apis_training.py
+++ b/tests/pose_estimation_pytorch/apis/test_apis_training.py
@@ -13,25 +13,49 @@
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-from deeplabcut.pose_estimation_pytorch.apis.training import train
+import pytest
+import torch
+
+import deeplabcut.pose_estimation_pytorch.utils as dlc_utils
+from deeplabcut.pose_estimation_pytorch.apis.training import train, train_network
 from deeplabcut.pose_estimation_pytorch.config import make_pytorch_pose_config
-from deeplabcut.pose_estimation_pytorch.config.pose import PoseConfig
+from deeplabcut.pose_estimation_pytorch.config.enums import DetectorType
+from deeplabcut.pose_estimation_pytorch.config.pose import DetectorConfig, PoseConfig
 from deeplabcut.pose_estimation_pytorch.task import Task
 
 
-def _minimal_run_config(tmp_path: Path, *, resume_from: str | None = None) -> PoseConfig:
-    project_cfg = {
+def _project_cfg(tmp_path: Path) -> dict:
+    return {
         "multianimalproject": False,
         "project_path": str(tmp_path),
         "bodyparts": ["nose"],
         "uniquebodyparts": [],
         "individuals": ["mouse"],
     }
+
+
+def _minimal_run_config(tmp_path: Path, *, resume_from: str | None = None) -> PoseConfig:
     cfg_path = tmp_path / "pytorch_config.yaml"
-    pose_config = make_pytorch_pose_config(project_cfg, str(cfg_path), net_type="resnet_50")
+    pose_config = make_pytorch_pose_config(_project_cfg(tmp_path), str(cfg_path), net_type="resnet_50")
     if resume_from is not None:
         pose_config.resume_training_from = resume_from
     return pose_config
+
+
+def _top_down_config(tmp_path: Path) -> PoseConfig:
+    """A top-down ResNet pose config; its detector is an SSDLite (a variant validated on MPS)."""
+    cfg_path = tmp_path / "pytorch_config.yaml"
+    return make_pytorch_pose_config(_project_cfg(tmp_path), str(cfg_path), net_type="resnet_50", top_down=True)
+
+
+def _make_loader(tmp_path: Path, run_config: PoseConfig | DetectorConfig) -> Mock:
+    loader = Mock()
+    loader.model_folder = tmp_path
+    loader.model_cfg = run_config
+    train_dataset = Mock(__len__=Mock(return_value=1))
+    valid_dataset = Mock(__len__=Mock(return_value=1))
+    loader.create_dataset = Mock(side_effect=[train_dataset, valid_dataset])
+    return loader
 
 
 @patch("deeplabcut.pose_estimation_pytorch.apis.training.build_transforms", return_value=Mock())
@@ -44,14 +68,145 @@ def test_train_uses_resume_training_from_config(
     tmp_path: Path,
 ) -> None:
     run_config = _minimal_run_config(tmp_path, resume_from="/train/snapshot-010.pt")
-
-    loader = Mock()
-    loader.model_folder = tmp_path
-    loader.model_cfg = run_config
-    train_dataset = Mock(__len__=Mock(return_value=1))
-    valid_dataset = Mock(__len__=Mock(return_value=1))
-    loader.create_dataset = Mock(side_effect=[train_dataset, valid_dataset])
+    loader = _make_loader(tmp_path, run_config)
 
     train(loader=loader, run_config=run_config, task=Task.BOTTOM_UP, device="cpu", snapshot_path=None)
 
     assert mock_build_runner.call_args.kwargs["snapshot_path"] == "/train/snapshot-010.pt"
+
+
+# the phrase every gate warning ends with, to tell them apart from unrelated ones
+_GATE_WARNING_MARKER = "trained on the CPU instead"
+_FRCNN = "fasterrcnn_resnet50_fpn_v2"
+
+
+def _apple_silicon(monkeypatch, *, mps: bool = True, floor: bool = True) -> None:
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(torch.backends.mps, "is_built", lambda: mps)
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: mps)
+    monkeypatch.setattr(dlc_utils, "torch_meets_detector_mps_floor", lambda: floor)
+
+
+def _run_config(kind: str, tmp_path: Path) -> PoseConfig | DetectorConfig:
+    if kind == "pose":
+        return _top_down_config(tmp_path)
+    if kind == "ssdlite":
+        return _top_down_config(tmp_path)["detector"]
+    detector_config = DetectorConfig.build(
+        1, DetectorType.FASTERRCNN_RESNET50_FPN_V2
+    )  # variant fasterrcnn_resnet50_fpn_v2
+    if kind == "no-variant":
+        detector_config["model"]["variant"] = None
+    return detector_config
+
+
+# ---------------------------------------------------------------------------
+# train(): the MPS gate for detectors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kind, config_device, requested, env, expected, warns",
+    [
+        pytest.param("ssdlite", "auto", "mps", {}, "mps", False, id="validated-mps"),
+        pytest.param("ssdlite", "auto", None, {}, "mps", False, id="validated-config-auto"),
+        pytest.param("ssdlite", "auto", "cpu", {}, "cpu", False, id="explicit-cpu"),
+        pytest.param("ssdlite", "auto", "mps", {"floor": False}, "cpu", True, id="torch-below-floor"),
+        pytest.param("ssdlite", "auto", "mps", {"mps": False}, "cpu", True, id="mps-not-available"),
+        pytest.param("fasterrcnn", "auto", "mps", {}, "cpu", True, id="unvalidated-mps"),
+        pytest.param("fasterrcnn", "auto", "mps:0", {}, "cpu", True, id="unvalidated-mps0"),
+        pytest.param("fasterrcnn", "auto", torch.device("mps"), {}, "cpu", True, id="unvalidated-torch-device"),
+        pytest.param("fasterrcnn", "mps", None, {}, "cpu", True, id="unvalidated-config-mps"),
+        pytest.param("fasterrcnn", "auto", None, {}, "cpu", False, id="unvalidated-config-auto"),
+        pytest.param("no-variant", "auto", "mps", {}, "cpu", True, id="unknown-variant"),
+        pytest.param("pose", "auto", "mps", {}, "mps", False, id="pose-model-untouched"),
+    ],
+)
+@patch("deeplabcut.pose_estimation_pytorch.apis.training.build_transforms", return_value=Mock())
+@patch("deeplabcut.pose_estimation_pytorch.apis.training.DETECTORS.build", return_value=Mock())
+@patch("deeplabcut.pose_estimation_pytorch.apis.training.PoseModel.build", return_value=Mock())
+@patch("deeplabcut.pose_estimation_pytorch.apis.training.build_training_runner", return_value=Mock())
+def test_train_applies_detector_mps_gate(
+    mock_build_runner: Mock,
+    mock_build_pose: Mock,
+    mock_build_detector: Mock,
+    mock_build_transforms: Mock,
+    kind: str,
+    config_device: str,
+    requested,
+    env: dict,
+    expected: str,
+    warns: bool,
+    tmp_path: Path,
+    monkeypatch,
+    recwarn,
+) -> None:
+    """Detectors reach the training runner on MPS only when validated; the pose model is untouched."""
+    _apple_silicon(monkeypatch, **env)
+    run_config = _run_config(kind, tmp_path)
+    run_config["device"] = config_device
+    task = Task.TOP_DOWN if kind == "pose" else Task.DETECT
+
+    train(loader=_make_loader(tmp_path, run_config), run_config=run_config, task=task, device=requested)
+
+    assert mock_build_runner.call_args.kwargs["device"] == expected
+    model = mock_build_pose.return_value if kind == "pose" else mock_build_detector.return_value
+    model.to.assert_called_with(expected)  # the patched builders are shared across the parametrized cases
+    gate_warnings = [str(w.message) for w in recwarn if _GATE_WARNING_MARKER in str(w.message)]
+    assert (len(gate_warnings) == 1) is warns
+    if kind in ("fasterrcnn", "no-variant") and warns:
+        assert "watchdog" in gate_warnings[0]
+
+
+# ---------------------------------------------------------------------------
+# train_network(): detector device inheritance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "detector_device, top_level_device, explicit_device, expected_detector_device, expected_detector_arg",
+    [
+        pytest.param("cpu", "auto", None, "cpu", None, id="explicit-detector-cpu-kept"),
+        pytest.param("auto", "cuda:1", None, "cuda:1", None, id="detector-auto-inherits-top-level"),
+        pytest.param("auto", "auto", None, "auto", None, id="both-auto"),
+        pytest.param("cpu", "auto", "mps", "cpu", "mps", id="explicit-argument-forwarded"),
+        pytest.param("cpu", "auto", "auto", "cpu", None, id="auto-argument-keeps-detector-cpu"),
+        pytest.param("auto", "cpu", "auto", "auto", None, id="auto-argument-detector-auto-policy"),
+    ],
+)
+@patch("deeplabcut.pose_estimation_pytorch.apis.training.destroy_file_logging")
+@patch("deeplabcut.pose_estimation_pytorch.apis.training.setup_file_logging")
+@patch("deeplabcut.pose_estimation_pytorch.apis.training.train")
+@patch("deeplabcut.pose_estimation_pytorch.apis.training.DLCLoader")
+def test_train_network_detector_device_inheritance(
+    mock_loader_cls: Mock,
+    mock_train: Mock,
+    mock_setup_file_logging: Mock,
+    mock_destroy_file_logging: Mock,
+    detector_device: str,
+    top_level_device: str,
+    explicit_device: str | None,
+    expected_detector_device: str,
+    expected_detector_arg: str | None,
+    tmp_path: Path,
+) -> None:
+    """A detector left on auto inherits the top-level device; an explicit detector.device is kept."""
+    pose_config = _top_down_config(tmp_path)
+    pose_config["device"] = top_level_device
+    pose_config["detector"]["device"] = detector_device
+    loader = Mock()
+    loader.model_cfg = pose_config
+    loader.model_folder = tmp_path
+    loader.model_config_path = tmp_path / "pytorch_config.yaml"
+    mock_loader_cls.return_value = loader
+
+    train_network(config=tmp_path / "config.yaml", device=explicit_device)
+
+    assert mock_train.call_count == 2
+    detector_call, pose_call = mock_train.call_args_list
+    assert detector_call.kwargs["task"] == Task.DETECT
+    assert detector_call.kwargs["run_config"]["device"] == expected_detector_device
+    assert detector_call.kwargs["device"] == expected_detector_arg
+    assert pose_call.kwargs["task"] == Task.TOP_DOWN
+    assert pose_call.kwargs["run_config"]["device"] == top_level_device
+    assert pose_call.kwargs["device"] == explicit_device

--- a/tests/pose_estimation_pytorch/runners/test_runners_train.py
+++ b/tests/pose_estimation_pytorch/runners/test_runners_train.py
@@ -318,3 +318,39 @@ def _assert_learning_rates_match(e, optimizer, expected):
     for lr in current_lrs:
         assert isinstance(lr, float)
         np.testing.assert_almost_equal(lr, expected)
+
+
+# ---------------------------------------------------------------------------
+# _move_target_to_device
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("device", ["mps", "mps:0", torch.device("mps")])
+def test_move_target_to_device_casts_float64_to_float32_on_mps(device) -> None:
+    tensor = Mock(dtype=torch.float64)
+    moved = train_runners._move_target_to_device(tensor, device)
+    tensor.to.assert_called_once_with(device, dtype=torch.float32)
+    assert moved is tensor.to.return_value
+
+
+def test_move_target_to_device_keeps_float32_on_mps() -> None:
+    tensor = Mock(dtype=torch.float32)
+    moved = train_runners._move_target_to_device(tensor, "mps")
+    tensor.to.assert_called_once_with("mps")
+    assert moved is tensor.to.return_value
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+def test_move_target_to_device_keeps_float64_off_mps(device: str) -> None:
+    tensor = Mock(dtype=torch.float64)
+    moved = train_runners._move_target_to_device(tensor, device)
+    tensor.to.assert_called_once_with(device)
+    assert moved is tensor.to.return_value
+
+
+@pytest.mark.parametrize("dtype", [torch.float64, torch.float32, torch.int64])
+def test_move_target_to_device_preserves_dtype_on_cpu(dtype: torch.dtype) -> None:
+    tensor = torch.tensor([[1.0, 2.0, 30.0, 40.0]], dtype=dtype)
+    moved = train_runners._move_target_to_device(tensor, "cpu")
+    assert moved.dtype == dtype
+    assert torch.equal(moved, tensor)

--- a/tests/pose_estimation_pytorch/test_device_resolution.py
+++ b/tests/pose_estimation_pytorch/test_device_resolution.py
@@ -115,7 +115,10 @@ def test_is_mps_device(device, expected):
         ("2.12.0", True),
         ("2.13.0+cu128", True),
         ("2.11.9", False),
-        ("2.13.0a0+git1234", False),
+        ("2.13.0a0+git1234", True),  # from-source build of the 2.13.0 release
+        ("2.11.9a0+git1234", False),  # from-source build, but below the floor
+        ("2.13.0rc1", False),  # official pre-release, not a from-source build
+        ("2.13.0.dev20260101+cu124", False),  # nightly wheel, not a from-source build
         ("not-a-version", False),
     ],
 )

--- a/tests/pose_estimation_pytorch/test_device_resolution.py
+++ b/tests/pose_estimation_pytorch/test_device_resolution.py
@@ -115,10 +115,12 @@ def test_is_mps_device(device, expected):
         ("2.12.0", True),
         ("2.13.0+cu128", True),
         ("2.11.9", False),
-        ("2.13.0a0+git1234", True),  # from-source build of the 2.13.0 release
-        ("2.12.0a0+git1234", True),  # from-source build of the floor release itself
+        ("2.13.0a0+git1234", True),  # from-source build targeting a release past the floor
+        ("2.12.1a0+git1234", True),  # from-source build of a patch release past the floor
+        ("2.12.0a0+git1234", False),  # from-source build of the floor release itself: unproven
         ("2.12.0+git1234", True),  # from-source build, tagged (not pre-release)
         ("2.11.9a0+git1234", False),  # from-source build, but below the floor
+        ("2.11.9+git1234", False),  # from-source build, tagged, but below the floor
         ("2.13.0rc1", False),  # official pre-release, not a from-source build
         ("2.13.0.dev20260101+cu124", False),  # nightly wheel, not a from-source build
         ("2.13.0.dev20260101", False),  # macOS-style nightly wheel, no local segment at all

--- a/tests/pose_estimation_pytorch/test_device_resolution.py
+++ b/tests/pose_estimation_pytorch/test_device_resolution.py
@@ -1,0 +1,153 @@
+#
+# DeepLabCut Toolbox (deeplabcut.org)
+# © A. & M.W. Mathis Labs
+# https://github.com/DeepLabCut/DeepLabCut
+#
+# Please see AUTHORS for contributors.
+# https://github.com/DeepLabCut/DeepLabCut/blob/main/AUTHORS
+#
+# Licensed under GNU Lesser General Public License v3.0
+#
+"""Tests for the MPS hardware gate for object detectors (pose_estimation_pytorch.utils).
+
+Every test fakes the hardware, so the suite passes on machines without MPS or CUDA.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import deeplabcut.pose_estimation_pytorch.utils as dlc_utils
+from deeplabcut.pose_estimation_pytorch.config.model import DetectorModelConfig
+from deeplabcut.pose_estimation_pytorch.config.pose import DetectorConfig
+from deeplabcut.pose_estimation_pytorch.utils import (
+    detector_mps_supported,
+    detector_variant,
+    is_mps_device,
+    resolve_detector_device,
+    resolve_device,
+)
+
+FRCNN = "fasterrcnn_resnet50_fpn_v2"
+
+
+class FakePoseConfig:
+    """Duck-typed pose config: .device and .get("net_type")."""
+
+    def __init__(self, device="auto", net_type="resnet_50"):
+        self.device = device
+        self.net_type = net_type
+
+    def get(self, key, default=None):
+        return getattr(self, key, default)
+
+
+def make_detector(device: str = "auto", type_: str = "SSDLite", variant: str | None = None) -> DetectorConfig:
+    return DetectorConfig(model=DetectorModelConfig(type=type_, variant=variant), device=device)
+
+
+@pytest.fixture
+def apple_silicon(monkeypatch):
+    """No CUDA, MPS built and available, torch above the floor, ssdlite the only validated variant."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(torch.backends.mps, "is_built", lambda: True)
+    monkeypatch.setattr(torch.backends.mps, "is_available", lambda: True)
+    monkeypatch.setattr(dlc_utils, "torch_meets_detector_mps_floor", lambda: True)
+    monkeypatch.setattr(dlc_utils, "DETECTOR_MPS_VALIDATED_VARIANTS", frozenset({"ssdlite"}))
+
+
+def _break(monkeypatch, condition: str) -> None:
+    if condition == "registry":
+        monkeypatch.setattr(dlc_utils, "DETECTOR_MPS_VALIDATED_VARIANTS", frozenset())
+    elif condition == "floor":
+        monkeypatch.setattr(dlc_utils, "torch_meets_detector_mps_floor", lambda: False)
+    elif condition == "mps":
+        monkeypatch.setattr(torch.backends.mps, "is_available", lambda: False)
+    elif condition == "mps-built":
+        monkeypatch.setattr(torch.backends.mps, "is_built", lambda: False)
+
+
+def test_shipped_registry():
+    assert dlc_utils.DETECTOR_MPS_VALIDATED_VARIANTS == {"ssdlite"}
+
+
+def test_resolve_device_pose_models_unchanged(apple_silicon):
+    assert resolve_device(FakePoseConfig(net_type="resnet_50")) == "mps"
+    assert resolve_device(FakePoseConfig(net_type="hrnet_w32")) == "cpu"
+    assert resolve_device(FakePoseConfig(device="cuda:1")) == "cuda:1"
+
+
+def test_resolve_device_detector_auto(apple_silicon, monkeypatch):
+    assert resolve_device(make_detector()) == "mps"
+    assert resolve_device(make_detector(type_="FasterRCNN", variant=FRCNN)) == "cpu"
+    assert resolve_device(make_detector(device="cpu")) == "cpu"  # explicit devices are returned verbatim
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    assert resolve_device(make_detector()) == "cuda"
+
+
+@pytest.mark.parametrize("condition", ["registry", "floor", "mps", "mps-built"])
+def test_detector_needs_every_condition(apple_silicon, monkeypatch, condition):
+    assert detector_mps_supported("ssdlite") is True
+    _break(monkeypatch, condition)
+    assert detector_mps_supported("ssdlite") is False
+    assert resolve_device(make_detector()) == "cpu"
+
+
+def test_detector_variant():
+    assert detector_variant(make_detector(type_="FasterRCNN", variant=FRCNN)) == FRCNN
+    assert detector_variant(make_detector()) == "ssdlite"
+    assert detector_variant(make_detector(type_="FasterRCNN")) is None  # unknown -> unvalidated
+    assert detector_variant({"model": {"type": "SSDLite", "variant": None}}) == "ssdlite"
+
+
+@pytest.mark.parametrize(
+    "device, expected",
+    [("mps", True), ("mps:0", True), (torch.device("mps"), True), ("cpu", False), ("cuda:0", False), (None, False)],
+)
+def test_is_mps_device(device, expected):
+    assert is_mps_device(device) is expected
+
+
+@pytest.mark.parametrize(
+    "version, expected",
+    [
+        ("2.12.0", True),
+        ("2.13.0+cu128", True),
+        ("2.11.9", False),
+        ("2.13.0a0+git1234", False),
+        ("not-a-version", False),
+    ],
+)
+def test_torch_meets_detector_mps_floor(monkeypatch, version, expected):
+    monkeypatch.setattr(torch, "__version__", version)
+    assert dlc_utils.torch_meets_detector_mps_floor() is expected
+
+
+def test_resolve_detector_device_keeps_allowed_devices(apple_silicon, recwarn):
+    assert resolve_detector_device("cpu", FRCNN) == "cpu"
+    assert resolve_detector_device(None, None) is None
+    assert resolve_detector_device("mps", "ssdlite") == "mps"
+    assert resolve_detector_device("mps:0", "ssdlite") == "mps:0"
+    assert recwarn.list == []
+
+
+@pytest.mark.parametrize(
+    "condition, variant, expected_text",
+    [
+        ("registry", FRCNN, [FRCNN, "not been validated", "watchdog"]),
+        ("registry", None, ["None", "not been validated"]),
+        ("floor", "ssdlite", ["2.12"]),
+        ("mps", "ssdlite", ["not available"]),
+    ],
+)
+def test_resolve_detector_device_falls_back_to_cpu_with_reason(
+    apple_silicon, monkeypatch, condition, variant, expected_text
+):
+    _break(monkeypatch, condition)
+    with pytest.warns(UserWarning) as record:
+        assert resolve_detector_device("mps", variant) == "cpu"
+    (message,) = [str(w.message) for w in record]
+    for text in expected_text:
+        assert text in message
+    assert "trained on the CPU instead" in message

--- a/tests/pose_estimation_pytorch/test_device_resolution.py
+++ b/tests/pose_estimation_pytorch/test_device_resolution.py
@@ -116,9 +116,12 @@ def test_is_mps_device(device, expected):
         ("2.13.0+cu128", True),
         ("2.11.9", False),
         ("2.13.0a0+git1234", True),  # from-source build of the 2.13.0 release
+        ("2.12.0a0+git1234", True),  # from-source build of the floor release itself
+        ("2.12.0+git1234", True),  # from-source build, tagged (not pre-release)
         ("2.11.9a0+git1234", False),  # from-source build, but below the floor
         ("2.13.0rc1", False),  # official pre-release, not a from-source build
         ("2.13.0.dev20260101+cu124", False),  # nightly wheel, not a from-source build
+        ("2.13.0.dev20260101", False),  # macOS-style nightly wheel, no local segment at all
         ("not-a-version", False),
     ],
 )


### PR DESCRIPTION
On Apple Silicon, top-down (multi-animal) models train their detector on the CPU even when the pose model uses MPS, so the default `ssdlite` detector trains about 13x slower than it could. Three things cause it: `resolve_device()` never selects MPS for a `DetectorConfig`, `train()` rewrites an `"mps"` device to `"cpu"`, and moving float64 targets to an MPS device raises a `TypeError`.

The third is the runtime blocker that remains once the first two are lifted, and lifting them without a policy would send Faster R-CNN detectors to MPS as well, where training hangs the GPU. This PR therefore replaces the blanket fallback with an explicit allow-list.

## Scope

Detector **training** only. The inference runner builders are untouched; a follow-up PR applies the same rule there.

## Changes

- Add the gate to `pose_estimation_pytorch/utils.py`: `MIN_TORCH_FOR_DETECTOR_MPS`, `DETECTOR_MPS_VALIDATED_VARIANTS`, `torch_meets_detector_mps_floor()`, `is_mps_device()`, `detector_variant()`, `detector_mps_supported()` and `resolve_detector_device()`. A detector reaches MPS only when MPS is available, torch is a release `>= 2.12` and the variant is on the allow-list (currently `ssdlite`). `auto` selects the CPU for any other variant; an explicit MPS request falls back to the CPU with a warning naming the reason.
- `resolve_device()` applies the gate to detector configs left on `auto`.
- `train()` replaces the unconditional `"mps"` -> `"cpu"` rewrite with the gate, matched on the device prefix so `"mps:0"` and `torch.device` objects are covered too.
- `DetectorTrainingRunner` casts float64 floating-point targets such as boxes and areas to float32 on MPS; integer labels are moved unchanged.
- `train_network()` only copies the top-level device into the detector configuration when `detector.device` is `auto`, so an explicit `detector.device` is no longer overwritten. This also fixes the issue where it was ignored on CUDA machines.
- Document the rule in `docs/recipes/TechHardware.md`.

## Validation

Apple M5, macOS 26.5.2, Python 3.12.13, torch 2.13.0 / torchvision 0.28.0 (the versions in `uv.lock`). Detector fine-tuning resumed from a frozen snapshot, epochs 251-255, same seed and data, `train_network(device=None)`:

| `detector.device` | resolved device | wall time |
|---|---|---|
| `auto` | mps | 9.8 s |
| `cpu` | cpu | 124 s |

Snapshots are written on both devices, with no NaN losses. The `cpu` row also covers the `detector.device` fix.

Faster R-CNN is not on the allow-list because, on the same setup, training `fasterrcnn_resnet50_fpn_v2` on MPS hung the GPU hard enough to trigger a macOS watchdog kernel panic and reboot, and `fasterrcnn_resnet50_fpn` hung at the same point. The cause is torchvision's MPS `roi_align` backward kernel, which over-accumulates gradients in proportion to the number of RoIs (pytorch/vision#9510); the forward pass is unaffected. We checked device resolution for all three Faster R-CNN configs without building a model: `auto` silently resolves to `cpu`, and an explicit `"mps"` or `"mps:0"` falls back to `cpu` with a warning.

The same checks were repeated on another machine, an Apple M2 (16 GB, macOS 26.5.1) with the same torch 2.13.0 / torchvision 0.28.0, under Python 3.11 and 3.12. Device resolution matches and the float64 `TypeError` and its fix reproduce. A 24-step `ssdlite` run took 1.9 s on MPS against 19.9 s on the CPU, with repeated runs on each device producing identical losses. No combination of `device` argument and `detector.device` reached MPS with a Faster R-CNN detector there either.

`tests/pose_estimation_pytorch` and `tests/core/config`: 1320 passed, 29 skipped, 5 xfailed. The new tests fake MPS availability, the torch version, and the allow-list, so they run on CPU-only CI. Each commit passes the suite on its own.

## Follow-up
torchvision 0.29.0 (2026-09-02, requires torch 2.14) fixes roi_align: backward gradients match CPU exactly, and a smoke test trains both Faster R-CNN variants on MPS without hanging. They stay off the allow-list because they have not been compared against CPU runs on that release. Enabling them later needs a per-variant floor of torch >= 2.14 and torchvision >= 0.29, not just a longer list, since the gate checks only the torch version. The torchvision floor must be enforced in code: uv.lock pins 0.28.0 for development but does not constrain user installs.
Related: #3155.

All tests and docs were generated with [Claude Code](https://claude.com/claude-code)
