### PR TITLE
Harden wandb logger error handling

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/runners/logger.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/logger.py
@@ -290,22 +290,34 @@ class WandbLogger(ImageLoggerMixin, BaseLogger):
                 "``pip install wandb`` if you want to log to wandb"
             )
 
+        # Validate arguments before wandb,
+        # so an unusable call cannot leave an orphaned run.
+        if model is None:
+            raise ValueError("Specify the model to track!")
+        if train_folder is None:
+            raise ValueError("Specify the train folder!")
+
         if wandb.run is not None:
             wandb.finish()
 
         # A nested ``wandb_kwargs``mapping must be flattened
         wandb_kwargs.update(wandb_kwargs.pop("wandb_kwargs", None) or {})
 
-        self.run = wandb.init(
-            project=project_name,
-            name=run_name,
-            **wandb_kwargs,
-        )
-        if model is None:
-            raise ValueError("Specify the model to track!")
+        try:
+            self.run = wandb.init(
+                project=project_name,
+                name=run_name,
+                **wandb_kwargs,
+            )
+        except TypeError as err:
+            raise ValueError(
+                f"Failed to initialize the W&B run: {err}\n"
+                f"Options forwarded to wandb.init: {sorted(wandb_kwargs)}\n"
+                "These come from the `logger` section of pytorch_config.yaml; extra "
+                "W&B options belong under `wandb_kwargs`."
+            ) from err
+
         self.run.watch(model)
-        if train_folder is None:
-            raise ValueError("Specify the train folder!")
         self.train_folder = Path(train_folder)
         self._save_wandb_info()
 

--- a/tests/pose_estimation_pytorch/runners/test_logger.py
+++ b/tests/pose_estimation_pytorch/runners/test_logger.py
@@ -100,3 +100,85 @@ def test_csv_logger_resume(tmp_path: Path) -> None:
     logger2.log({"loss": 0.3, "accuracy": 0.95}, step=3)
     assert len(logger2._steps) == 3
     assert logger2._steps == [1, 2, 3]
+
+
+class _FakeRun:
+    """Minimal stand-in for a wandb Run."""
+
+    entity = "test-entity"
+    project = "test-project"
+    id = "test-id"
+
+    def watch(self, model: Any) -> None:
+        pass
+
+
+class _FakeWandb:
+    """Fake ``wandb`` module recording ``init`` calls."""
+
+    def __init__(self) -> None:
+        self.run = None
+        self.init_calls: list[dict[str, Any]] = []
+        self.init_error: Exception | None = None
+
+    def init(self, **kwargs: Any) -> _FakeRun:
+        self.init_calls.append(kwargs)
+        if self.init_error is not None:
+            raise self.init_error
+        return _FakeRun()
+
+    def finish(self) -> None:
+        self.run = None
+
+
+@pytest.fixture
+def fake_wandb(monkeypatch: pytest.MonkeyPatch) -> _FakeWandb:
+    fake = _FakeWandb()
+    monkeypatch.setattr(logging, "wandb", fake, raising=False)
+    monkeypatch.setattr(logging, "has_wandb", True)
+    return fake
+
+
+def test_wandb_logger_reports_unknown_init_option(fake_wandb: _FakeWandb, tmp_path: Path) -> None:
+    """An option wandb.init rejects must be reported against the project config."""
+    cause = TypeError("init() got an unexpected keyword argument 'run_nmae'")
+    fake_wandb.init_error = cause
+
+    with pytest.raises(ValueError) as excinfo:
+        logging.WandbLogger(model=object(), train_folder=str(tmp_path), run_nmae="typo")
+
+    message = str(excinfo.value)
+    assert "run_nmae" in message
+    assert "wandb_kwargs" in message
+    assert excinfo.value.__cause__ is cause
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"train_folder": "folder"}, "Specify the model to track!"),
+        ({"model": object()}, "Specify the train folder!"),
+    ],
+    ids=["no-model", "no-train-folder"],
+)
+def test_wandb_logger_validates_before_opening_a_run(
+    fake_wandb: _FakeWandb, kwargs: dict[str, Any], match: str
+) -> None:
+    """Unusable arguments must be rejected before a run is created, to avoid orphans."""
+    with pytest.raises(ValueError, match=match):
+        logging.WandbLogger(**kwargs)
+
+    assert fake_wandb.init_calls == []
+
+
+def test_wandb_logger_forwards_options_to_init(fake_wandb: _FakeWandb, tmp_path: Path) -> None:
+    logging.WandbLogger(
+        project_name="mice",
+        run_name="exp1",
+        model=object(),
+        train_folder=str(tmp_path),
+        tags=["a"],
+    )
+
+    assert fake_wandb.init_calls == [{"project": "mice", "name": "exp1", "tags": ["a"]}]
+    assert (tmp_path / "wandb_info.yaml").exists()


### PR DESCRIPTION
- Validate model and train_folder before any wandb call, so unusable kwargs no longer open a W&B run before raising
- Guard wandb.init so an invalid kwarg surfaces as a config error naming the forwarded options and pointing at the logger: section of pytorch_config.yaml, instead of a bare TypeError.