### PR TITLE
Fix skeleton builder failing if first labeled-data folder is empty

### DIFF
--- a/deeplabcut/utils/skeleton.py
+++ b/deeplabcut/utils/skeleton.py
@@ -53,21 +53,57 @@ class SkeletonBuilder:
         self._ax = None
         self.df = None
         found = False
+        missing = np.empty(0, dtype=int)
+        n_inspected = 0  # candidate folders looked at
+        n_skipped = 0  # candidate folders that could not be used
         root = Path(self.cfg["project_path"]) / "labeled-data"
         for folder in root.iterdir():
-            if folder.is_dir() and not any(folder.name.endswith(s) for s in ("cropped", "labeled")):
-                self.df = pd.read_hdf(folder / f"CollectedData_{self.cfg['scorer']}.h5")
-                self.df = drop_likelihood_columns(self.df)
-                row, col = self.pick_labeled_frame()
-                if "individuals" in self.df.columns.names:
-                    self.df = self.df.xs(col, axis=1, level="individuals")
-                self.xy = self.df.loc[row].values.reshape((-1, 2))
-                missing = np.flatnonzero(np.isnan(self.xy).all(axis=1))
-                if not missing.size:
-                    found = True
-                    break
+            if not folder.is_dir() or any(folder.name.endswith(s) for s in ("cropped", "labeled")):
+                continue
+            n_inspected += 1
+            h5_file = folder / f"CollectedData_{self.cfg['scorer']}.h5"
+            if not h5_file.is_file():
+                # Frames may have been extracted but not labeled yet
+                n_skipped += 1
+                logger.warning(f"Skipping '{folder.name}': {h5_file.name} was not found.")
+                continue
+            # A single problematic folder should not abort the whole search,
+            # nor discard a usable frame already found in an earlier one
+            prev_df = self.df
+            try:
+                self.df = drop_likelihood_columns(pd.read_hdf(h5_file))
+                picked = self.pick_labeled_frame()
+                if picked is None:
+                    raise ValueError("no labeled frame was found")
+                row, col = picked
+                df = self.df
+                if "individuals" in df.columns.names:
+                    df = df.xs(col, axis=1, level="individuals")
+                xy = df.loc[row].values.reshape((-1, 2))
+                # Handle image previously annotated on a different platform
+                if isinstance(row, str):
+                    sep = "/" if "/" in row else "\\"
+                    row = row.split(sep)
+                image = io.imread(Path(self.cfg["project_path"]).joinpath(*row))
+            except (ValueError, IndexError, OSError, KeyError) as e:
+                n_skipped += 1
+                logger.warning(f"Skipping '{folder.name}': {e}")
+                self.df = prev_df
+                continue
+            self.df = df
+            self.xy = xy
+            self.image = image
+            missing = np.flatnonzero(np.isnan(self.xy).all(axis=1))
+            if not missing.size:
+                found = True
+                break
         if self.df is None:
-            raise OSError("No labeled data were found.")
+            raise OSError(
+                f"No labeled data were found. {n_inspected} folder(s) were inspected in "
+                f"'{root}', {n_skipped} of which had to be skipped (no "
+                f"CollectedData_{self.cfg['scorer']}.h5, no labeled frame in it, or a "
+                f"labeled frame missing from disk); see the warnings above for details."
+            )
 
         self.bpts = self.df.columns.get_level_values("bodyparts").unique()
         if not found:
@@ -77,11 +113,6 @@ class SkeletonBuilder:
                 stacklevel=2,
             )
         self.tree = KDTree(self.xy)
-        # Handle image previously annotated on a different platform
-        if isinstance(row, str):
-            sep = "/" if "/" in row else "\\"
-            row = row.split(sep)
-        self.image = io.imread(Path(self.cfg["project_path"]).joinpath(*row))
         self.inds = set()
         self.segs = set()
         # Draw the skeleton if already existent
@@ -136,8 +167,14 @@ class SkeletonBuilder:
                 count = count.drop(columns="single")
         else:
             count = self.df.count(axis=1).to_frame()
-        mask = count.where(count == count.to_numpy().max())
+        counts = count.to_numpy()
+        if not counts.size or not np.any(counts):
+            # Nothing was labeled in this folder
+            return None
+        mask = count.where(count == counts.max())
         kept = mask.stack().index.to_list()
+        if not kept:
+            return None
         np.random.shuffle(kept)
         picked = kept.pop()
         row = picked[:-1]

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -10,6 +10,10 @@
 #
 from __future__ import annotations
 
+# NOTE: @C-Achard 2026-09-04 : [CLEANUP-COLLECTEDDATA-FIXTURES] gen_fake_data / create_fake_project below are the most
+# complete synthetic-project builders in the repo, writing down if later we consider consolidating
+# the six test modules that each build CollectedData frames and project trees by hand.
+# They pull in cv2, PIL and top-level deeplabcut.
 import shutil
 import string
 import time

--- a/tests/pose_estimation_pytorch/data/test_data_ctd.py
+++ b/tests/pose_estimation_pytorch/data/test_data_ctd.py
@@ -8,6 +8,10 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
+# NOTE: @C-Achard 2026-09-04 : [CLEANUP-COLLECTEDDATA-FIXTURES] builds maDLC CollectedData columns inline and writes
+# them with key="df_with_missing", while tests/utils/test_skeleton.py uses key="df" for
+# CollectedData files; see the note there. Reuse target for the frame building: the
+# collected_data fixture in tests/utils/test_skeleton.py.
 import json
 import platform
 from pathlib import Path

--- a/tests/pose_estimation_pytorch/data/test_dlc_dataloader.py
+++ b/tests/pose_estimation_pytorch/data/test_dlc_dataloader.py
@@ -1,3 +1,7 @@
+# NOTE: @C-Achard 2026-09-04 : [CLEANUP-COLLECTEDDATA-FIXTURES] two CollectedData frames are built inline below, with
+# index level names "set"/"video"/"image" which is a third naming convention among the test modules that
+# each build this frame themselves.
+# Reuse target: the collected_data fixture in tests/utils/test_skeleton.py, once it is promoted to a shared conftest.
 from types import SimpleNamespace
 
 import numpy as np

--- a/tests/pose_estimation_pytorch/modelzoo/test_fmpose_integration.py
+++ b/tests/pose_estimation_pytorch/modelzoo/test_fmpose_integration.py
@@ -8,6 +8,9 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
+# NOTE: @C-Achard 2026-09-04 : [CLEANUP-COLLECTEDDATA-FIXTURES] the same maDLC CollectedData columns are built inline
+# twice in this file, and again in five or so other test modules. Reuse target: the
+# collected_data fixture in tests/utils/test_skeleton.py.
 import pathlib
 import socket
 from types import SimpleNamespace

--- a/tests/test_refine_train_dataset/test_outlierframes.py
+++ b/tests/test_refine_train_dataset/test_outlierframes.py
@@ -1,3 +1,8 @@
+# NOTE: @C-Achard 2026-09-04 : [CLEANUP-COLLECTEDDATA-FIXTURES] sparse_multianimal_df / dense_multianimal_df below
+# duplicate the prediction-shaped CollectedData frame that several other test modules also build by
+# hand, and the patch_hdf_write mock is a pattern re-defined elsewhere too. Reuse target:
+# the collected_data fixture in tests/utils/test_skeleton.py, once it is promoted to a
+# shared conftest.
 from unittest.mock import MagicMock
 
 import numpy as np

--- a/tests/test_trainingsetmanipulation.py
+++ b/tests/test_trainingsetmanipulation.py
@@ -8,6 +8,12 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
+# NOTE: @C-Achard 2026-09-04 : [CLEANUP-COLLECTEDDATA-FIXTURES] this module builds a CollectedData frame inline and
+# writes it with key="df_with_missing", while tests/utils/test_skeleton.py writes the same file with
+# key="df". Production reads "df_with_missing" in places (see
+# deeplabcut/refine_training_dataset/outlier_frames.py), so the tests do not all exercise
+# the real on-disk format. For the frame building
+# itself, the reuse target is the fixtures in tests/utils/test_skeleton.py.
 import os
 
 import numpy as np

--- a/tests/utils/test_pandas_cow.py
+++ b/tests/utils/test_pandas_cow.py
@@ -13,6 +13,10 @@
 surfaces mutation patterns that should be guarded by ``copy=True``.
 """
 
+# NOTE: @C-Achard 2026-09-04 : [CLEANUP-COLLECTEDDATA-FIXTURES] _make_dlc_df below is another variant of the
+# CollectedData frame that at least six test modules each build for themselves, this one without a row
+# index. Reuse target: the collected_data fixture in tests/utils/test_skeleton.py, once it
+# is promoted to a shared conftest.
 import numpy as np
 import pandas as pd
 import pytest

--- a/tests/utils/test_skeleton.py
+++ b/tests/utils/test_skeleton.py
@@ -1,3 +1,11 @@
+# NOTE: @C-Achard 2026-09-04 : [CLEANUP-COLLECTEDDATA-FIXTURES] the collected_data / write_collected_data / project
+# fixtures below are duplicated, in some shape, by at least six other test modules, see
+# tests/test_trainingsetmanipulation.py, tests/utils/test_pandas_cow.py,
+# tests/utils/test_visualization.py, tests/pose_estimation_pytorch/data/ and
+# tests/test_refine_train_dataset/test_outlierframes.py. They should likely be promoted to a
+# shared conftest, with examples/utils.py (gen_fake_data / create_fake_project) as the
+# reference implementation. Note also that this module writes CollectedData h5 with
+# key="df" while other modules and production code use key="df_with_missing".
 import warnings
 from types import SimpleNamespace
 

--- a/tests/utils/test_skeleton.py
+++ b/tests/utils/test_skeleton.py
@@ -47,38 +47,6 @@ def attach_fake_canvas(builder):
     builder.fig.canvas.draw_idle = lambda: None
 
 
-def make_collected_data(folder_name, values, bodyparts=("nose", "tail"), individuals=None):
-    """One-row CollectedData frame. NaN values stand for unlabeled bodyparts."""
-    index = pd.MultiIndex.from_tuples(
-        [("labeled-data", folder_name, "img001.png")],
-        names=["root", "folder", "image"],
-    )
-    levels = [["TestScorer"]]
-    names = ["scorer"]
-    if individuals is not None:
-        levels.append(list(individuals))
-        names.append("individuals")
-    levels += [list(bodyparts), ["x", "y"]]
-    names += ["bodyparts", "coords"]
-    columns = pd.MultiIndex.from_product(levels, names=names)
-    return pd.DataFrame([values], index=index, columns=columns)
-
-
-def write_collected_data(folder, df, scorer="TestScorer"):
-    folder.mkdir(parents=True, exist_ok=True)
-    df.to_hdf(folder / f"CollectedData_{scorer}.h5", key="df", mode="w")
-    return folder
-
-
-def make_project(tmp_path, skeleton=None, scorer="TestScorer"):
-    """Create a project directory with an empty labeled-data folder."""
-    project_path = tmp_path / "project"
-    (project_path / "labeled-data").mkdir(parents=True)
-    cfg_path = project_path / "config.yaml"
-    write_config(cfg_path, make_config(project_path, scorer=scorer, skeleton=skeleton))
-    return project_path, cfg_path
-
-
 def patch_builder_ui(monkeypatch, imread_calls=None):
     """Stub out the interactive parts of SkeletonBuilder.__init__."""
 
@@ -94,61 +62,105 @@ def patch_builder_ui(monkeypatch, imread_calls=None):
 
 
 # ---------------------------------------------------------------------
+# Annotation data fixtures
+# ---------------------------------------------------------------------
+
+
+@pytest.fixture
+def collected_data():
+    """Factory for a one-row CollectedData frame.
+
+    NaN values stand for unlabeled bodyparts. Pass ``individuals`` to get the
+    multi-animal column layout.
+    """
+
+    def _make(video, values, bodyparts=("nose", "tail"), individuals=None):
+        index = pd.MultiIndex.from_tuples(
+            [("labeled-data", video, "img001.png")],
+            names=["data_folder", "video", "image"],
+        )
+        levels = [["TestScorer"]]
+        names = ["scorer"]
+        if individuals is not None:
+            levels.append(list(individuals))
+            names.append("individuals")
+        levels += [list(bodyparts), ["x", "y"]]
+        names += ["bodyparts", "coords"]
+        columns = pd.MultiIndex.from_product(levels, names=names)
+        return pd.DataFrame([values], index=index, columns=columns)
+
+    return _make
+
+
+@pytest.fixture
+def write_collected_data():
+    """Factory writing a CollectedData frame into a labeled-data folder."""
+
+    def _write(folder, df, scorer="TestScorer"):
+        folder.mkdir(parents=True, exist_ok=True)
+        df.to_hdf(folder / f"CollectedData_{scorer}.h5", key="df", mode="w")
+        return folder
+
+    return _write
+
+
+@pytest.fixture
+def project(tmp_path):
+    """Factory for a project directory with an empty labeled-data folder.
+
+    Returns ``(project_path, config_path)``.
+    """
+
+    def _make(skeleton=None, scorer="TestScorer"):
+        project_path = tmp_path / "project"
+        (project_path / "labeled-data").mkdir(parents=True)
+        cfg_path = project_path / "config.yaml"
+        write_config(cfg_path, make_config(project_path, scorer=scorer, skeleton=skeleton))
+        return project_path, cfg_path
+
+    return _make
+
+
+# ---------------------------------------------------------------------
 # pick_labeled_frame
 # ---------------------------------------------------------------------
 
 
-def test_pick_labeled_frame_multi_animal_drops_single(monkeypatch):
+def test_pick_labeled_frame_multi_animal_drops_single(monkeypatch, collected_data):
     builder = make_test_builder()
-
-    index = pd.MultiIndex.from_tuples(
-        [("labeled-data/session1", "img001.png")],
-        names=["folder", "image"],
-    )
-    columns = pd.MultiIndex.from_product(
-        [["TestScorer"], ["single", "mouseA"], ["nose", "tail"], ["x", "y"]],
-        names=["scorer", "individuals", "bodyparts", "coords"],
-    )
-
     # "single" is fully labeled too, but should be dropped before choosing.
-    row = [
-        1.0,
-        2.0,
-        3.0,
-        4.0,  # single
-        10.0,
-        20.0,
-        30.0,
-        40.0,  # mouseA
-    ]
-    builder.df = pd.DataFrame([row], index=index, columns=columns)
+    builder.df = collected_data(
+        "session1",
+        [1.0, 2.0, 3.0, 4.0] + [10.0, 20.0, 30.0, 40.0],
+        individuals=["single", "mouseA"],
+    )
 
     monkeypatch.setattr(np.random, "shuffle", lambda x: None)
 
     picked_row, picked_col = builder.pick_labeled_frame()
 
-    assert picked_row == ("labeled-data/session1", "img001.png")
+    assert picked_row == ("labeled-data", "session1", "img001.png")
     assert picked_col == "mouseA"
 
 
-def test_pick_labeled_frame_returns_none_when_nothing_is_labeled():
+def test_pick_labeled_frame_returns_none_when_nothing_is_labeled(collected_data):
     builder = make_test_builder()
-    builder.df = make_collected_data("session1", [np.nan] * 4)
+    builder.df = collected_data("session1", [np.nan] * 4)
 
     assert builder.pick_labeled_frame() is None
 
 
-def test_pick_labeled_frame_returns_none_for_an_empty_frame():
+def test_pick_labeled_frame_returns_none_for_an_empty_frame(collected_data):
     builder = make_test_builder()
-    builder.df = make_collected_data("session1", [np.nan] * 4).iloc[:0]
+    builder.df = collected_data("session1", [np.nan] * 4).iloc[:0]
 
     assert builder.pick_labeled_frame() is None
 
 
-def test_pick_labeled_frame_returns_none_when_only_single_is_labeled():
+def test_pick_labeled_frame_returns_none_when_only_single_is_labeled(collected_data):
     """'single' is dropped before counting, leaving nothing to pick."""
     builder = make_test_builder()
-    builder.df = make_collected_data(
+    builder.df = collected_data(
         "session1",
         [1.0, 2.0, 3.0, 4.0] + [np.nan] * 4,
         individuals=["single", "mouseA"],
@@ -157,29 +169,15 @@ def test_pick_labeled_frame_returns_none_when_only_single_is_labeled():
     assert builder.pick_labeled_frame() is None
 
 
-def test_pick_labeled_frame_without_individuals(monkeypatch):
+def test_pick_labeled_frame_without_individuals(monkeypatch, collected_data):
     builder = make_test_builder()
-
-    index = pd.MultiIndex.from_tuples(
-        [("labeled-data/session1", "img001.png")],
-        names=["folder", "image"],
-    )
-    columns = pd.MultiIndex.from_product(
-        [["TestScorer"], ["nose", "tail"], ["x", "y"]],
-        names=["scorer", "bodyparts", "coords"],
-    )
-
-    builder.df = pd.DataFrame(
-        [[1.0, 2.0, 3.0, 4.0]],
-        index=index,
-        columns=columns,
-    )
+    builder.df = collected_data("session1", [1.0, 2.0, 3.0, 4.0])
 
     monkeypatch.setattr(np.random, "shuffle", lambda x: None)
 
     picked_row, picked_col = builder.pick_labeled_frame()
 
-    assert picked_row == ("labeled-data/session1", "img001.png")
+    assert picked_row == ("labeled-data", "session1", "img001.png")
     # fallback path uses count(...).to_frame(), so the single column is usually 0
     assert picked_col == 0
 
@@ -388,42 +386,18 @@ def test_on_pick_non_right_click_does_nothing():
 # ---------------------------------------------------------------------
 
 
-def test_init_loads_dataframe_image_and_existing_skeleton(tmp_path, monkeypatch):
-    project_path = tmp_path / "project"
-    labeled_data = project_path / "labeled-data" / "session1"
-    labeled_data.mkdir(parents=True)
-
-    cfg_path = project_path / "config.yaml"
-    cfg = make_config(
-        project_path=project_path,
-        scorer="TestScorer",
+def test_init_loads_dataframe_image_and_existing_skeleton(monkeypatch, project, collected_data, write_collected_data):
+    project_path, cfg_path = project(
         skeleton=[
             ["nose", "tail"],
             ["missing", "nose"],
         ],  # second pair should be ignored
     )
-    write_config(cfg_path, cfg)
-
-    index = pd.MultiIndex.from_tuples(
-        [("labeled-data/session1", "img001.png")],
-        names=["folder", "image"],
+    write_collected_data(
+        project_path / "labeled-data" / "session1",
+        collected_data("session1", [0.0, 0.0, 10.0, 0.0]),
     )
-    columns = pd.MultiIndex.from_product(
-        [["TestScorer"], ["nose", "tail"], ["x", "y"]],
-        names=["scorer", "bodyparts", "coords"],
-    )
-    df = pd.DataFrame(
-        [[0.0, 0.0, 10.0, 0.0]],
-        index=index,
-        columns=columns,
-    )
-    h5_path = labeled_data / "CollectedData_TestScorer.h5"
-    df.to_hdf(h5_path, key="df", mode="w")
-
-    monkeypatch.setattr(skeleton_mod.io, "imread", lambda path: np.zeros((5, 5, 3), dtype=np.uint8))
-    monkeypatch.setattr(SkeletonBuilder, "build_ui", lambda self: None)
-    monkeypatch.setattr(SkeletonBuilder, "display", lambda self: None)
-    monkeypatch.setattr(np.random, "shuffle", lambda x: None)
+    patch_builder_ui(monkeypatch)
 
     builder = SkeletonBuilder(str(cfg_path))
 
@@ -435,13 +409,8 @@ def test_init_loads_dataframe_image_and_existing_skeleton(tmp_path, monkeypatch)
     assert ((0.0, 0.0), (10.0, 0.0)) in builder.segs
 
 
-def test_init_raises_if_no_labeled_data_found(tmp_path, monkeypatch):
-    project_path = tmp_path / "project"
-    (project_path / "labeled-data").mkdir(parents=True)
-
-    cfg_path = project_path / "config.yaml"
-    cfg = make_config(project_path=project_path, scorer="TestScorer")
-    write_config(cfg_path, cfg)
+def test_init_raises_if_no_labeled_data_found(monkeypatch, project):
+    _project_path, cfg_path = project()
 
     monkeypatch.setattr(SkeletonBuilder, "build_ui", lambda self: None)
     monkeypatch.setattr(SkeletonBuilder, "display", lambda self: None)
@@ -459,17 +428,19 @@ def test_init_raises_if_no_labeled_data_found(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------
 
 
-def test_init_prefers_a_fully_labeled_folder_over_a_partial_one(tmp_path, monkeypatch):
+def test_init_prefers_a_fully_labeled_folder_over_a_partial_one(
+    monkeypatch, project, collected_data, write_collected_data
+):
     """Selection is by completeness, not by folder order."""
-    project_path, cfg_path = make_project(tmp_path)
+    project_path, cfg_path = project()
     labeled_data = project_path / "labeled-data"
     write_collected_data(
         labeled_data / "aaa_partial",
-        make_collected_data("aaa_partial", [1.0, 2.0, np.nan, np.nan]),
+        collected_data("aaa_partial", [1.0, 2.0, np.nan, np.nan]),
     )
     write_collected_data(
         labeled_data / "zzz_complete",
-        make_collected_data("zzz_complete", [0.0, 0.0, 10.0, 0.0]),
+        collected_data("zzz_complete", [0.0, 0.0, 10.0, 0.0]),
     )
     patch_builder_ui(monkeypatch)
 
@@ -481,12 +452,12 @@ def test_init_prefers_a_fully_labeled_folder_over_a_partial_one(tmp_path, monkey
     assert not any("fully labeled animal could not be found" in str(w.message) for w in record)
 
 
-def test_init_loads_the_image_of_the_picked_frame(tmp_path, monkeypatch):
+def test_init_loads_the_image_of_the_picked_frame(monkeypatch, project, collected_data, write_collected_data):
     """The image path is rebuilt from the picked row, relative to project_path."""
-    project_path, cfg_path = make_project(tmp_path)
+    project_path, cfg_path = project()
     write_collected_data(
         project_path / "labeled-data" / "session1",
-        make_collected_data("session1", [0.0, 0.0, 10.0, 0.0]),
+        collected_data("session1", [0.0, 0.0, 10.0, 0.0]),
     )
     imread_calls = []
     patch_builder_ui(monkeypatch, imread_calls=imread_calls)
@@ -497,12 +468,14 @@ def test_init_loads_the_image_of_the_picked_frame(tmp_path, monkeypatch):
     assert imread_calls == [project_path / "labeled-data" / "session1" / "img001.png"]
 
 
-def test_init_drops_the_individuals_level_for_multi_animal_data(tmp_path, monkeypatch):
+def test_init_drops_the_individuals_level_for_multi_animal_data(
+    monkeypatch, project, collected_data, write_collected_data
+):
     """self.df is narrowed to the picked individual, so bpts excludes it."""
-    project_path, cfg_path = make_project(tmp_path)
+    project_path, cfg_path = project()
     write_collected_data(
         project_path / "labeled-data" / "session1",
-        make_collected_data(
+        collected_data(
             "session1",
             [np.nan] * 4 + [0.0, 0.0, 10.0, 0.0],
             individuals=["single", "mouseA"],
@@ -517,14 +490,14 @@ def test_init_drops_the_individuals_level_for_multi_animal_data(tmp_path, monkey
     assert builder.xy.shape == (2, 2)
 
 
-def test_init_skips_a_folder_without_collected_data(tmp_path, monkeypatch, caplog):
+def test_init_skips_a_folder_without_collected_data(monkeypatch, caplog, project, collected_data, write_collected_data):
     """Frames extracted but never labeled must not abort the search."""
-    project_path, cfg_path = make_project(tmp_path)
+    project_path, cfg_path = project()
     labeled_data = project_path / "labeled-data"
     (labeled_data / "aaa_not_labeled_yet").mkdir()
     write_collected_data(
         labeled_data / "zzz_complete",
-        make_collected_data("zzz_complete", [0.0, 0.0, 10.0, 0.0]),
+        collected_data("zzz_complete", [0.0, 0.0, 10.0, 0.0]),
     )
     patch_builder_ui(monkeypatch)
 
@@ -535,16 +508,16 @@ def test_init_skips_a_folder_without_collected_data(tmp_path, monkeypatch, caplo
     assert "aaa_not_labeled_yet" in caplog.text
 
 
-def test_init_skips_a_folder_with_no_labeled_rows(tmp_path, monkeypatch, caplog):
-    project_path, cfg_path = make_project(tmp_path)
+def test_init_skips_a_folder_with_no_labeled_rows(monkeypatch, caplog, project, collected_data, write_collected_data):
+    project_path, cfg_path = project()
     labeled_data = project_path / "labeled-data"
     write_collected_data(
         labeled_data / "aaa_all_nan",
-        make_collected_data("aaa_all_nan", [np.nan] * 4),
+        collected_data("aaa_all_nan", [np.nan] * 4),
     )
     write_collected_data(
         labeled_data / "zzz_complete",
-        make_collected_data("zzz_complete", [0.0, 0.0, 10.0, 0.0]),
+        collected_data("zzz_complete", [0.0, 0.0, 10.0, 0.0]),
     )
     patch_builder_ui(monkeypatch)
 
@@ -555,17 +528,17 @@ def test_init_skips_a_folder_with_no_labeled_rows(tmp_path, monkeypatch, caplog)
     assert "aaa_all_nan" in caplog.text
 
 
-def test_init_skips_a_folder_whose_image_is_missing(tmp_path, monkeypatch):
+def test_init_skips_a_folder_whose_image_is_missing(monkeypatch, project, collected_data, write_collected_data):
     """A row pointing at a deleted frame skips that folder, not the search."""
-    project_path, cfg_path = make_project(tmp_path)
+    project_path, cfg_path = project()
     labeled_data = project_path / "labeled-data"
     write_collected_data(
         labeled_data / "aaa_image_gone",
-        make_collected_data("aaa_image_gone", [1.0, 2.0, 3.0, 4.0]),
+        collected_data("aaa_image_gone", [1.0, 2.0, 3.0, 4.0]),
     )
     write_collected_data(
         labeled_data / "zzz_complete",
-        make_collected_data("zzz_complete", [0.0, 0.0, 10.0, 0.0]),
+        collected_data("zzz_complete", [0.0, 0.0, 10.0, 0.0]),
     )
 
     def fake_imread(path):
@@ -583,14 +556,14 @@ def test_init_skips_a_folder_whose_image_is_missing(tmp_path, monkeypatch):
     assert builder.xy.tolist() == [[0.0, 0.0], [10.0, 0.0]]
 
 
-def test_init_error_reports_inspected_and_skipped_folders(tmp_path, monkeypatch):
-    project_path, cfg_path = make_project(tmp_path)
+def test_init_error_reports_inspected_and_skipped_folders(monkeypatch, project, collected_data, write_collected_data):
+    project_path, cfg_path = project()
     labeled_data = project_path / "labeled-data"
     (labeled_data / "no_h5_a").mkdir()
     (labeled_data / "no_h5_b").mkdir()
     write_collected_data(
         labeled_data / "all_nan",
-        make_collected_data("all_nan", [np.nan] * 4),
+        collected_data("all_nan", [np.nan] * 4),
     )
     patch_builder_ui(monkeypatch)
 
@@ -602,17 +575,17 @@ def test_init_error_reports_inspected_and_skipped_folders(tmp_path, monkeypatch)
     assert "3 of which had to be skipped" in message
 
 
-def test_init_still_ignores_cropped_and_labeled_folders(tmp_path, monkeypatch):
+def test_init_still_ignores_cropped_and_labeled_folders(monkeypatch, project, collected_data, write_collected_data):
     """Derived output folders are not annotation sources."""
-    project_path, cfg_path = make_project(tmp_path)
+    project_path, cfg_path = project()
     labeled_data = project_path / "labeled-data"
     write_collected_data(
         labeled_data / "session1_labeled",
-        make_collected_data("session1_labeled", [0.0, 0.0, 10.0, 0.0]),
+        collected_data("session1_labeled", [0.0, 0.0, 10.0, 0.0]),
     )
     write_collected_data(
         labeled_data / "session1cropped",
-        make_collected_data("session1cropped", [0.0, 0.0, 10.0, 0.0]),
+        collected_data("session1cropped", [0.0, 0.0, 10.0, 0.0]),
     )
     patch_builder_ui(monkeypatch)
 

--- a/tests/utils/test_skeleton.py
+++ b/tests/utils/test_skeleton.py
@@ -47,6 +47,52 @@ def attach_fake_canvas(builder):
     builder.fig.canvas.draw_idle = lambda: None
 
 
+def make_collected_data(folder_name, values, bodyparts=("nose", "tail"), individuals=None):
+    """One-row CollectedData frame. NaN values stand for unlabeled bodyparts."""
+    index = pd.MultiIndex.from_tuples(
+        [("labeled-data", folder_name, "img001.png")],
+        names=["root", "folder", "image"],
+    )
+    levels = [["TestScorer"]]
+    names = ["scorer"]
+    if individuals is not None:
+        levels.append(list(individuals))
+        names.append("individuals")
+    levels += [list(bodyparts), ["x", "y"]]
+    names += ["bodyparts", "coords"]
+    columns = pd.MultiIndex.from_product(levels, names=names)
+    return pd.DataFrame([values], index=index, columns=columns)
+
+
+def write_collected_data(folder, df, scorer="TestScorer"):
+    folder.mkdir(parents=True, exist_ok=True)
+    df.to_hdf(folder / f"CollectedData_{scorer}.h5", key="df", mode="w")
+    return folder
+
+
+def make_project(tmp_path, skeleton=None, scorer="TestScorer"):
+    """Create a project directory with an empty labeled-data folder."""
+    project_path = tmp_path / "project"
+    (project_path / "labeled-data").mkdir(parents=True)
+    cfg_path = project_path / "config.yaml"
+    write_config(cfg_path, make_config(project_path, scorer=scorer, skeleton=skeleton))
+    return project_path, cfg_path
+
+
+def patch_builder_ui(monkeypatch, imread_calls=None):
+    """Stub out the interactive parts of SkeletonBuilder.__init__."""
+
+    def fake_imread(path):
+        if imread_calls is not None:
+            imread_calls.append(path)
+        return np.zeros((5, 5, 3), dtype=np.uint8)
+
+    monkeypatch.setattr(skeleton_mod.io, "imread", fake_imread)
+    monkeypatch.setattr(SkeletonBuilder, "build_ui", lambda self: None)
+    monkeypatch.setattr(SkeletonBuilder, "display", lambda self: None)
+    monkeypatch.setattr(np.random, "shuffle", lambda x: None)
+
+
 # ---------------------------------------------------------------------
 # pick_labeled_frame
 # ---------------------------------------------------------------------
@@ -83,6 +129,32 @@ def test_pick_labeled_frame_multi_animal_drops_single(monkeypatch):
 
     assert picked_row == ("labeled-data/session1", "img001.png")
     assert picked_col == "mouseA"
+
+
+def test_pick_labeled_frame_returns_none_when_nothing_is_labeled():
+    builder = make_test_builder()
+    builder.df = make_collected_data("session1", [np.nan] * 4)
+
+    assert builder.pick_labeled_frame() is None
+
+
+def test_pick_labeled_frame_returns_none_for_an_empty_frame():
+    builder = make_test_builder()
+    builder.df = make_collected_data("session1", [np.nan] * 4).iloc[:0]
+
+    assert builder.pick_labeled_frame() is None
+
+
+def test_pick_labeled_frame_returns_none_when_only_single_is_labeled():
+    """'single' is dropped before counting, leaving nothing to pick."""
+    builder = make_test_builder()
+    builder.df = make_collected_data(
+        "session1",
+        [1.0, 2.0, 3.0, 4.0] + [np.nan] * 4,
+        individuals=["single", "mouseA"],
+    )
+
+    assert builder.pick_labeled_frame() is None
 
 
 def test_pick_labeled_frame_without_individuals(monkeypatch):
@@ -376,3 +448,175 @@ def test_init_raises_if_no_labeled_data_found(tmp_path, monkeypatch):
 
     with pytest.raises(IOError, match="No labeled data were found"):
         SkeletonBuilder(str(cfg_path))
+
+
+# ---------------------------------------------------------------------
+# __init__ labeled-data folder search
+#
+# The search loop skips folders it cannot use instead of letting the
+# first unusable one abort the whole search. The tests below pin down
+# both the unchanged selection behaviour and the skipping.
+# ---------------------------------------------------------------------
+
+
+def test_init_prefers_a_fully_labeled_folder_over_a_partial_one(tmp_path, monkeypatch):
+    """Selection is by completeness, not by folder order."""
+    project_path, cfg_path = make_project(tmp_path)
+    labeled_data = project_path / "labeled-data"
+    write_collected_data(
+        labeled_data / "aaa_partial",
+        make_collected_data("aaa_partial", [1.0, 2.0, np.nan, np.nan]),
+    )
+    write_collected_data(
+        labeled_data / "zzz_complete",
+        make_collected_data("zzz_complete", [0.0, 0.0, 10.0, 0.0]),
+    )
+    patch_builder_ui(monkeypatch)
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        builder = SkeletonBuilder(str(cfg_path))
+
+    assert not np.isnan(builder.xy).any()
+    assert not any("fully labeled animal could not be found" in str(w.message) for w in record)
+
+
+def test_init_loads_the_image_of_the_picked_frame(tmp_path, monkeypatch):
+    """The image path is rebuilt from the picked row, relative to project_path."""
+    project_path, cfg_path = make_project(tmp_path)
+    write_collected_data(
+        project_path / "labeled-data" / "session1",
+        make_collected_data("session1", [0.0, 0.0, 10.0, 0.0]),
+    )
+    imread_calls = []
+    patch_builder_ui(monkeypatch, imread_calls=imread_calls)
+
+    builder = SkeletonBuilder(str(cfg_path))
+
+    assert builder.image.shape == (5, 5, 3)
+    assert imread_calls == [project_path / "labeled-data" / "session1" / "img001.png"]
+
+
+def test_init_drops_the_individuals_level_for_multi_animal_data(tmp_path, monkeypatch):
+    """self.df is narrowed to the picked individual, so bpts excludes it."""
+    project_path, cfg_path = make_project(tmp_path)
+    write_collected_data(
+        project_path / "labeled-data" / "session1",
+        make_collected_data(
+            "session1",
+            [np.nan] * 4 + [0.0, 0.0, 10.0, 0.0],
+            individuals=["single", "mouseA"],
+        ),
+    )
+    patch_builder_ui(monkeypatch)
+
+    builder = SkeletonBuilder(str(cfg_path))
+
+    assert "individuals" not in builder.df.columns.names
+    assert list(builder.bpts) == ["nose", "tail"]
+    assert builder.xy.shape == (2, 2)
+
+
+def test_init_skips_a_folder_without_collected_data(tmp_path, monkeypatch, caplog):
+    """Frames extracted but never labeled must not abort the search."""
+    project_path, cfg_path = make_project(tmp_path)
+    labeled_data = project_path / "labeled-data"
+    (labeled_data / "aaa_not_labeled_yet").mkdir()
+    write_collected_data(
+        labeled_data / "zzz_complete",
+        make_collected_data("zzz_complete", [0.0, 0.0, 10.0, 0.0]),
+    )
+    patch_builder_ui(monkeypatch)
+
+    with caplog.at_level("WARNING"):
+        builder = SkeletonBuilder(str(cfg_path))
+
+    assert list(builder.bpts) == ["nose", "tail"]
+    assert "aaa_not_labeled_yet" in caplog.text
+
+
+def test_init_skips_a_folder_with_no_labeled_rows(tmp_path, monkeypatch, caplog):
+    project_path, cfg_path = make_project(tmp_path)
+    labeled_data = project_path / "labeled-data"
+    write_collected_data(
+        labeled_data / "aaa_all_nan",
+        make_collected_data("aaa_all_nan", [np.nan] * 4),
+    )
+    write_collected_data(
+        labeled_data / "zzz_complete",
+        make_collected_data("zzz_complete", [0.0, 0.0, 10.0, 0.0]),
+    )
+    patch_builder_ui(monkeypatch)
+
+    with caplog.at_level("WARNING"):
+        builder = SkeletonBuilder(str(cfg_path))
+
+    assert not np.isnan(builder.xy).any()
+    assert "aaa_all_nan" in caplog.text
+
+
+def test_init_skips_a_folder_whose_image_is_missing(tmp_path, monkeypatch):
+    """A row pointing at a deleted frame skips that folder, not the search."""
+    project_path, cfg_path = make_project(tmp_path)
+    labeled_data = project_path / "labeled-data"
+    write_collected_data(
+        labeled_data / "aaa_image_gone",
+        make_collected_data("aaa_image_gone", [1.0, 2.0, 3.0, 4.0]),
+    )
+    write_collected_data(
+        labeled_data / "zzz_complete",
+        make_collected_data("zzz_complete", [0.0, 0.0, 10.0, 0.0]),
+    )
+
+    def fake_imread(path):
+        if "aaa_image_gone" in str(path):
+            raise FileNotFoundError(path)
+        return np.zeros((5, 5, 3), dtype=np.uint8)
+
+    monkeypatch.setattr(skeleton_mod.io, "imread", fake_imread)
+    monkeypatch.setattr(SkeletonBuilder, "build_ui", lambda self: None)
+    monkeypatch.setattr(SkeletonBuilder, "display", lambda self: None)
+    monkeypatch.setattr(np.random, "shuffle", lambda x: None)
+
+    builder = SkeletonBuilder(str(cfg_path))
+
+    assert builder.xy.tolist() == [[0.0, 0.0], [10.0, 0.0]]
+
+
+def test_init_error_reports_inspected_and_skipped_folders(tmp_path, monkeypatch):
+    project_path, cfg_path = make_project(tmp_path)
+    labeled_data = project_path / "labeled-data"
+    (labeled_data / "no_h5_a").mkdir()
+    (labeled_data / "no_h5_b").mkdir()
+    write_collected_data(
+        labeled_data / "all_nan",
+        make_collected_data("all_nan", [np.nan] * 4),
+    )
+    patch_builder_ui(monkeypatch)
+
+    with pytest.raises(IOError, match="No labeled data were found") as excinfo:
+        SkeletonBuilder(str(cfg_path))
+
+    message = str(excinfo.value)
+    assert "3 folder(s) were inspected" in message
+    assert "3 of which had to be skipped" in message
+
+
+def test_init_still_ignores_cropped_and_labeled_folders(tmp_path, monkeypatch):
+    """Derived output folders are not annotation sources."""
+    project_path, cfg_path = make_project(tmp_path)
+    labeled_data = project_path / "labeled-data"
+    write_collected_data(
+        labeled_data / "session1_labeled",
+        make_collected_data("session1_labeled", [0.0, 0.0, 10.0, 0.0]),
+    )
+    write_collected_data(
+        labeled_data / "session1cropped",
+        make_collected_data("session1cropped", [0.0, 0.0, 10.0, 0.0]),
+    )
+    patch_builder_ui(monkeypatch)
+
+    with pytest.raises(IOError, match="No labeled data were found") as excinfo:
+        SkeletonBuilder(str(cfg_path))
+
+    assert "0 folder(s) were inspected" in str(excinfo.value)

--- a/tests/utils/test_visualization.py
+++ b/tests/utils/test_visualization.py
@@ -8,6 +8,10 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
+# NOTE: @C-Achard 2026-09-04 : [CLEANUP-COLLECTEDDATA-FIXTURES] evaluation_dataframe_factory below duplicates the
+# CollectedData frame builder that at least six test modules each roll their own version of,
+# here with likelihood columns and its own index level names. Reuse target: the
+# collected_data fixture in tests/utils/test_skeleton.py, once it is promoted to a shared conftest.
 import logging
 from unittest.mock import Mock
 


### PR DESCRIPTION
## Scope

Improves the robustness of `deeplabcut.utils.skeleton` and improved related tests. 

- Added better error handling in the skeleton builder initialization when scanning labeled data folders
- Flagged duplicated CollectedData/labeled image fixtures across the codebase