### PR TITLE
Fix `tools` imports under a plain `pytest` invocation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,6 +237,8 @@ generate_python_version_classifiers = true
 table_format = "long"
 
 [tool.pytest.ini_options]
+# Put repo root on sys.path, so pytest can import `tools`
+pythonpath = [ "." ]
 markers = [
   "require_models: mark test as requiring models to run",
   "fmpose3d: tests for fmpose3d integration",

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib
-import sys
 from pathlib import Path
 from types import ModuleType
 
@@ -24,11 +23,6 @@ def load_selector_module() -> ModuleType:
 
     if not init_file.exists():
         raise FileNotFoundError(f"tools package marker not found: {init_file}")
-
-    # Ensure repo root is importable so `tools.test_selector` resolves as a package import.
-    root_str = str(root)
-    if root_str not in sys.path:
-        sys.path.insert(0, root_str)
 
     return importlib.import_module("tools.test_selector")
 


### PR DESCRIPTION
**Problem**
`test_selector_decision.py` imports `tools.test_selector`, but nothing, but nothing puts the repo root in `sys.path` at collection time. The import only succeeds currently, because CI invokes `python -m pytest`, which prepends the cwd. Running `pytest` directly fails collection with an ImportError.

The following code in `tests/tools/conftest.py` is actually dead code since it only runs *after* the test collection already happened.
```python
def load_selector_module() -> ModuleType:
    root = _repo_root()
    ...
    # Ensure repo root is importable so `tools.test_selector` resolves as a package import.
    root_str = str(root)
    if root_str not in sys.path:
        sys.path.insert(0, root_str)

    return importlib.import_module("tools.test_selector")
```


**Changes**
- add `pythonpath = ["."]` in pyproject.toml under `tool.pytest.ini_options`
- remove the dead code in tests/tools/conftest.py