### PR TITLE
Handle empty PyTorch video predictions without crashing

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/apis/videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/videos.py
@@ -718,11 +718,6 @@ def create_df_from_prediction(
     output_prefix: str | Path,
     save_as_csv: bool = False,
 ) -> pd.DataFrame:
-    pred_bodyparts = np.stack([p["bodyparts"][..., :3] for p in predictions])
-    pred_unique_bodyparts = None
-    if len(predictions) > 0 and "unique_bodyparts" in predictions[0]:
-        pred_unique_bodyparts = np.stack([p["unique_bodyparts"] for p in predictions])
-
     output_h5 = Path(output_path) / f"{output_prefix}.h5"
     output_pkl = Path(output_path) / f"{output_prefix}_full.pickle"
 
@@ -741,6 +736,18 @@ def create_df_from_prediction(
         cols_names.insert(1, "individuals")
 
     results_df_index = pd.MultiIndex.from_product(cols, names=cols_names)
+    if not predictions:
+        df = pd.DataFrame(index=range(0), columns=results_df_index)
+        df.to_hdf(output_h5, key="df_with_missing", format="table", mode="w")
+        if save_as_csv:
+            df.to_csv(output_h5.with_suffix(".csv"))
+        return df
+
+    pred_bodyparts = np.stack([p["bodyparts"][..., :3] for p in predictions])
+    pred_unique_bodyparts = None
+    if "unique_bodyparts" in predictions[0]:
+        pred_unique_bodyparts = np.stack([p["unique_bodyparts"] for p in predictions])
+
     pred_bodyparts = pred_bodyparts[:, :n_individuals]
     df = pd.DataFrame(
         pred_bodyparts.reshape((len(pred_bodyparts), -1)),

--- a/deeplabcut/pose_estimation_pytorch/apis/videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/videos.py
@@ -666,7 +666,7 @@ def analyze_videos(
 
                     if predictions:
                         create_df_from_prediction(
-                            predictions=predictions,
+                            predictions=ctd_predictions,
                             multi_animal=multi_animal,
                             model_cfg=loader.model_cfg,
                             dlc_scorer=dlc_scorer,

--- a/deeplabcut/pose_estimation_pytorch/apis/videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/videos.py
@@ -229,21 +229,29 @@ def video_inference(
     if shelf_writer is not None:
         shelf_writer.close()
 
-    if shelf_writer is None and len(predictions) == 0 and n_frames > 0:
-        logging.warning(
-            "No predictions were produced for this video. This can happen if no "
-            "animals were detected in any frame. If that is unexpected, check "
-            "model performance and verify that the video can be read correctly."
-        )
-    elif shelf_writer is None and len(predictions) != n_frames:
+    if shelf_writer is None:
         tip_url = "https://deeplabcut.github.io/DeepLabCut/docs/recipes/io.html"
         header = "#tips-on-video-re-encoding-and-preprocessing"
-        logging.warning(
-            f"The video metadata indicates that there {n_frames} in the video, but "
-            f"only {len(predictions)} were able to be processed. This can happen if "
-            "the video is corrupted. You can try to fix the issue by re-encoding your "
-            f"video (tips on how to do that: {tip_url}{header})"
+        reencoding_tip = (
+            "This can happen if the video is corrupted. You can try to fix the issue "
+            f"by re-encoding your video (tips on how to do that: {tip_url}{header})"
         )
+        if len(predictions) == 0:
+            causes = (
+                "no animals were detected in any frame, or the video could not be read"
+                if detector_runner is not None
+                else "the video could not be read"
+            )
+            logging.warning(
+                f"No predictions were produced for {video.video_path}: {causes}. "
+                f"Check model performance if that is unexpected. {reencoding_tip}"
+            )
+        elif len(predictions) != n_frames:
+            logging.warning(
+                f"The video metadata indicates that there are {n_frames} frames in "
+                f"the video, but only {len(predictions)} were able to be processed. "
+                f"{reencoding_tip}"
+            )
 
     return predictions
 

--- a/deeplabcut/pose_estimation_pytorch/apis/videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/videos.py
@@ -757,7 +757,7 @@ def create_df_from_prediction(
     save_as_csv: bool = False,
 ) -> pd.DataFrame:
     if not predictions:
-        raise RuntimeError("Cannot create a results DataFrame from an empty predictions list.")
+        raise ValueError("Cannot create a results DataFrame from an empty predictions list.")
 
     output_h5 = Path(output_path) / f"{output_prefix}.h5"
     output_pkl = Path(output_path) / f"{output_prefix}_full.pickle"

--- a/deeplabcut/pose_estimation_pytorch/apis/videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/videos.py
@@ -228,7 +228,13 @@ def video_inference(
     if shelf_writer is not None:
         shelf_writer.close()
 
-    if shelf_writer is None and len(predictions) != n_frames:
+    if shelf_writer is None and len(predictions) == 0 and n_frames > 0:
+        logging.warning(
+            "No predictions were produced for this video. This can happen if no "
+            "animals were detected in any frame. If that is unexpected, check "
+            "model performance and verify that the video can be read correctly."
+        )
+    elif shelf_writer is None and len(predictions) != n_frames:
         tip_url = "https://deeplabcut.github.io/DeepLabCut/docs/recipes/io.html"
         header = "#tips-on-video-re-encoding-and-preprocessing"
         logging.warning(

--- a/deeplabcut/pose_estimation_pytorch/apis/videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/videos.py
@@ -881,11 +881,18 @@ def _generate_metadata(
     return {"data": metadata}
 
 
+def _frame_key_width(num_frames: int) -> int:
+    """Returns the zero-fill width for frame keys."""
+    if num_frames <= 1:
+        return 1
+    return int(np.ceil(np.log10(num_frames)))
+
+
 def _generate_output_data(
     pose_config: dict,
     predictions: list[dict[str, np.ndarray]],
 ) -> dict:
-    str_width = int(np.ceil(np.log10(len(predictions))))
+    str_width = _frame_key_width(len(predictions))
     output = {
         "metadata": {
             "nms radius": pose_config.get("nmsradius"),

--- a/deeplabcut/pose_estimation_pytorch/apis/videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/videos.py
@@ -605,26 +605,37 @@ def analyze_videos(
                 print("Can't ``save_as_df`` as ``use_shelve=True``. Skipping.")
 
             if not use_shelve:
-                output_data = _generate_output_data(pose_cfg, predictions)
+                output_data = _generate_output_data(pose_cfg, predictions)  # this should not consume full-NaN frames
                 with Path(output_pkl).open("wb") as f:
                     pickle.dump(output_data, f, pickle.HIGHEST_PROTOCOL)
 
-                if save_as_df and predictions:
-                    create_df_from_prediction(
-                        predictions=predictions,
-                        multi_animal=multi_animal,
-                        model_cfg=loader.model_cfg,
-                        dlc_scorer=dlc_scorer,
-                        output_path=output_path,
-                        output_prefix=output_prefix,
-                        save_as_csv=save_as_csv,
-                    )
-                    h5_files_created = True  # .h5 file was created
-                elif save_as_df:
-                    logging.warning(
-                        f"Skipping dataframe export for {video}: no predictions were "
-                        "produced, so no results .h5 file will be written."
-                    )
+                if save_as_df:
+                    df_predictions = predictions
+                    if not df_predictions:
+                        n_frames = video_iterator.get_n_frames(robust=robust_nframes)
+                        logging.warning(
+                            f"No predictions were produced for {video}: writing an "
+                            f"all-NaN results file with {n_frames} row(s) so that "
+                            "downstream steps proceed."
+                        )
+                        df_predictions = _nan_predictions(n_frames, loader.model_cfg)
+
+                    if not df_predictions:
+                        logging.error(
+                            f"Cannot write a results file for {video}: no predictions "
+                            "were produced and the video reports 0 frames."
+                        )
+                    else:
+                        create_df_from_prediction(
+                            predictions=df_predictions,
+                            multi_animal=multi_animal,
+                            model_cfg=loader.model_cfg,
+                            dlc_scorer=dlc_scorer,
+                            output_path=output_path,
+                            output_prefix=output_prefix,
+                            save_as_csv=save_as_csv,
+                        )
+                        h5_files_created = True
 
             if multi_animal:
                 assemblies_path = output_path / f"{output_prefix}_assemblies.pickle"
@@ -736,16 +747,21 @@ def create_df_from_prediction(
     output_prefix: str | Path,
     save_as_csv: bool = False,
 ) -> pd.DataFrame:
+    if not predictions:
+        raise RuntimeError("Cannot create a results DataFrame from an empty predictions list.")
+
     output_h5 = Path(output_path) / f"{output_prefix}.h5"
     output_pkl = Path(output_path) / f"{output_prefix}_full.pickle"
-
-    if not predictions:
-        raise ValueError("Cannot create a results DataFrame from an empty predictions list.")
 
     bodyparts = model_cfg["metadata"]["bodyparts"]
     unique_bodyparts = model_cfg["metadata"]["unique_bodyparts"]
     individuals = model_cfg["metadata"]["individuals"]
     n_individuals = len(individuals)
+
+    pred_bodyparts = np.stack([p["bodyparts"][..., :3] for p in predictions])
+    pred_unique_bodyparts = None
+    if "unique_bodyparts" in predictions[0]:
+        pred_unique_bodyparts = np.stack([p["unique_bodyparts"] for p in predictions])
 
     print(f"Saving results in {output_h5} and {output_pkl}")
     coords = ["x", "y", "likelihood"]
@@ -757,10 +773,6 @@ def create_df_from_prediction(
         cols_names.insert(1, "individuals")
 
     results_df_index = pd.MultiIndex.from_product(cols, names=cols_names)
-    pred_bodyparts = np.stack([p["bodyparts"][..., :3] for p in predictions])
-    pred_unique_bodyparts = None
-    if "unique_bodyparts" in predictions[0]:
-        pred_unique_bodyparts = np.stack([p["unique_bodyparts"] for p in predictions])
 
     pred_bodyparts = pred_bodyparts[:, :n_individuals]
     df = pd.DataFrame(
@@ -781,6 +793,28 @@ def create_df_from_prediction(
     if save_as_csv:
         df.to_csv(output_h5.with_suffix(".csv"))
     return df
+
+
+def _nan_predictions(n_frames: int, model_cfg: dict) -> list[dict[str, np.ndarray]]:
+    """Returns placeholder all-NaN predictions, one per frame.
+
+    Used when inference produced no predictions at all, so a well-formed results
+    file with one row per frame is still written and downstream steps (filtering,
+    labeled videos) keep working.
+    """
+    metadata = model_cfg["metadata"]
+    num_idv = len(metadata["individuals"])
+    num_bpts = len(metadata["bodyparts"])
+    num_unique = len(metadata["unique_bodyparts"])
+
+    predictions = []
+    for _ in range(n_frames):
+        prediction = dict(bodyparts=np.full((num_idv, num_bpts, 3), np.nan))
+        if num_unique > 0:
+            prediction["unique_bodyparts"] = np.full((1, num_unique, 3), np.nan)
+        predictions.append(prediction)
+
+    return predictions
 
 
 def _generate_assemblies_file(

--- a/deeplabcut/pose_estimation_pytorch/apis/videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/videos.py
@@ -668,6 +668,11 @@ def analyze_videos(
                         # add poses to the predictions
                         ctd_predictions.append(dict(bodyparts=pose))
 
+                    # ``ctd_predictions`` holds one entry per frame in the full
+                    # pickle, so it is empty only when that file reports 0 frames
+                    # (a shelf that wrote nothing, or ``save_as_df=False``). Warn
+                    # and skip rather than raise like the export above does:
+                    # inference success cannot be determined here
                     if ctd_predictions:
                         create_df_from_prediction(
                             predictions=ctd_predictions,

--- a/deeplabcut/pose_estimation_pytorch/apis/videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/videos.py
@@ -614,37 +614,21 @@ def analyze_videos(
                 print("Can't ``save_as_df`` as ``use_shelve=True``. Skipping.")
 
             if not use_shelve:
-                output_data = _generate_output_data(pose_cfg, predictions)  # this should not consume full-NaN frames
+                output_data = _generate_output_data(pose_cfg, predictions)
                 with Path(output_pkl).open("wb") as f:
                     pickle.dump(output_data, f, pickle.HIGHEST_PROTOCOL)
 
                 if save_as_df:
-                    df_predictions = predictions
-                    if not df_predictions:
-                        n_frames = video_iterator.get_n_frames(robust=robust_nframes)
-                        logging.warning(
-                            f"No predictions were produced for {video}: writing an "
-                            f"all-NaN results file with {n_frames} row(s) so that "
-                            "downstream steps proceed."
-                        )
-                        df_predictions = _nan_predictions(n_frames, loader.model_cfg)
-
-                    if not df_predictions:
-                        logging.error(
-                            f"Cannot write a results file for {video}: no predictions "
-                            "were produced and the video reports 0 frames."
-                        )
-                    else:
-                        create_df_from_prediction(
-                            predictions=df_predictions,
-                            multi_animal=multi_animal,
-                            model_cfg=loader.model_cfg,
-                            dlc_scorer=dlc_scorer,
-                            output_path=output_path,
-                            output_prefix=output_prefix,
-                            save_as_csv=save_as_csv,
-                        )
-                        h5_files_created = True
+                    create_df_from_prediction(
+                        predictions=predictions,
+                        multi_animal=multi_animal,
+                        model_cfg=loader.model_cfg,
+                        dlc_scorer=dlc_scorer,
+                        output_path=output_path,
+                        output_prefix=output_prefix,
+                        save_as_csv=save_as_csv,
+                    )
+                    h5_files_created = True  # .h5 file was created
 
             if multi_animal:
                 assemblies_path = output_path / f"{output_prefix}_assemblies.pickle"
@@ -802,28 +786,6 @@ def create_df_from_prediction(
     if save_as_csv:
         df.to_csv(output_h5.with_suffix(".csv"))
     return df
-
-
-def _nan_predictions(n_frames: int, model_cfg: dict) -> list[dict[str, np.ndarray]]:
-    """Returns placeholder all-NaN predictions, one per frame.
-
-    Used when inference produced no predictions at all, so a well-formed results
-    file with one row per frame is still written and downstream steps (filtering,
-    labeled videos) keep working.
-    """
-    metadata = model_cfg["metadata"]
-    num_idv = len(metadata["individuals"])
-    num_bpts = len(metadata["bodyparts"])
-    num_unique = len(metadata["unique_bodyparts"])
-
-    predictions = []
-    for _ in range(n_frames):
-        prediction = dict(bodyparts=np.full((num_idv, num_bpts, 3), np.nan))
-        if num_unique > 0:
-            prediction["unique_bodyparts"] = np.full((1, num_unique, 3), np.nan)
-        predictions.append(prediction)
-
-    return predictions
 
 
 def _generate_assemblies_file(

--- a/deeplabcut/pose_estimation_pytorch/apis/videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/videos.py
@@ -668,7 +668,7 @@ def analyze_videos(
                         # add poses to the predictions
                         ctd_predictions.append(dict(bodyparts=pose))
 
-                    if predictions:
+                    if ctd_predictions:
                         create_df_from_prediction(
                             predictions=ctd_predictions,
                             multi_animal=multi_animal,
@@ -681,9 +681,9 @@ def analyze_videos(
                         h5_files_created = True  # .h5 file was created for CTD tracking
                     else:
                         logging.warning(
-                            f"Skipping CTD dataframe export for {video}: no "
-                            "predictions were produced, so no results .h5 file will "
-                            "be written."
+                            f"Skipping CTD dataframe export for {video}: {output_pkl} "
+                            "contains no frames, so no results .h5 file will be "
+                            "written."
                         )
 
                 elif auto_track:

--- a/deeplabcut/pose_estimation_pytorch/apis/videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/videos.py
@@ -42,6 +42,7 @@ from deeplabcut.pose_estimation_pytorch.runners import (
     TopDownDynamicCropper,
 )
 from deeplabcut.pose_estimation_pytorch.runners.inference import InferenceConfig
+from deeplabcut.pose_estimation_pytorch.runners.shelving import frame_key_width
 from deeplabcut.pose_estimation_pytorch.task import Task
 from deeplabcut.refine_training_dataset.stitch import stitch_tracklets
 from deeplabcut.utils import VideoReader, auxiliaryfunctions
@@ -936,18 +937,11 @@ def _generate_metadata(
     return {"data": metadata}
 
 
-def _frame_key_width(num_frames: int) -> int:
-    """Returns the zero-fill width for frame keys."""
-    if num_frames <= 1:
-        return 1
-    return int(np.ceil(np.log10(num_frames)))
-
-
 def _generate_output_data(
     pose_config: dict,
     predictions: list[dict[str, np.ndarray]],
 ) -> dict:
-    str_width = _frame_key_width(len(predictions))
+    str_width = frame_key_width(len(predictions))
     output = {
         "metadata": {
             "nms radius": pose_config.get("nmsradius"),

--- a/deeplabcut/pose_estimation_pytorch/apis/videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/videos.py
@@ -609,7 +609,7 @@ def analyze_videos(
                 with Path(output_pkl).open("wb") as f:
                     pickle.dump(output_data, f, pickle.HIGHEST_PROTOCOL)
 
-                if save_as_df:
+                if save_as_df and predictions:
                     create_df_from_prediction(
                         predictions=predictions,
                         multi_animal=multi_animal,
@@ -620,6 +620,11 @@ def analyze_videos(
                         save_as_csv=save_as_csv,
                     )
                     h5_files_created = True  # .h5 file was created
+                elif save_as_df:
+                    logging.warning(
+                        f"Skipping dataframe export for {video}: no predictions were "
+                        "produced, so no results .h5 file will be written."
+                    )
 
             if multi_animal:
                 assemblies_path = output_path / f"{output_prefix}_assemblies.pickle"
@@ -659,16 +664,23 @@ def analyze_videos(
                         # add poses to the predictions
                         ctd_predictions.append(dict(bodyparts=pose))
 
-                    create_df_from_prediction(
-                        predictions=predictions,
-                        multi_animal=multi_animal,
-                        model_cfg=loader.model_cfg,
-                        dlc_scorer=dlc_scorer,
-                        output_path=output_path,
-                        output_prefix=output_prefix + "_ctd",
-                        save_as_csv=save_as_csv,
-                    )
-                    h5_files_created = True  # .h5 file was created for CTD tracking
+                    if predictions:
+                        create_df_from_prediction(
+                            predictions=predictions,
+                            multi_animal=multi_animal,
+                            model_cfg=loader.model_cfg,
+                            dlc_scorer=dlc_scorer,
+                            output_path=output_path,
+                            output_prefix=output_prefix + "_ctd",
+                            save_as_csv=save_as_csv,
+                        )
+                        h5_files_created = True  # .h5 file was created for CTD tracking
+                    else:
+                        logging.warning(
+                            f"Skipping CTD dataframe export for {video}: no "
+                            "predictions were produced, so no results .h5 file will "
+                            "be written."
+                        )
 
                 elif auto_track:
                     convert_detections2tracklets(
@@ -727,6 +739,9 @@ def create_df_from_prediction(
     output_h5 = Path(output_path) / f"{output_prefix}.h5"
     output_pkl = Path(output_path) / f"{output_prefix}_full.pickle"
 
+    if not predictions:
+        raise ValueError("Cannot create a results DataFrame from an empty predictions list.")
+
     bodyparts = model_cfg["metadata"]["bodyparts"]
     unique_bodyparts = model_cfg["metadata"]["unique_bodyparts"]
     individuals = model_cfg["metadata"]["individuals"]
@@ -742,13 +757,6 @@ def create_df_from_prediction(
         cols_names.insert(1, "individuals")
 
     results_df_index = pd.MultiIndex.from_product(cols, names=cols_names)
-    if not predictions:
-        df = pd.DataFrame(index=range(0), columns=results_df_index)
-        df.to_hdf(output_h5, key="df_with_missing", format="table", mode="w")
-        if save_as_csv:
-            df.to_csv(output_h5.with_suffix(".csv"))
-        return df
-
     pred_bodyparts = np.stack([p["bodyparts"][..., :3] for p in predictions])
     pred_unique_bodyparts = None
     if "unique_bodyparts" in predictions[0]:

--- a/deeplabcut/pose_estimation_pytorch/modelzoo/fmpose_3d/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/modelzoo/fmpose_3d/inference.py
@@ -192,6 +192,9 @@ def _video_inference_fmpose3d(
         if batch:
             _process_batch(batch)
 
+        if not predictions_2d:
+            raise RuntimeError(f"No pose predictions were made for video {video_path}. Were no individuals detected?")
+
         output_prefix = f"{Path(video_path).stem}_{dlc_scorer}"
         output_h5 = dest_folder / f"{output_prefix}.h5"
 

--- a/deeplabcut/pose_estimation_pytorch/runners/inference.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/inference.py
@@ -267,6 +267,9 @@ class InferenceRunner(Runner, Generic[ModelType], metaclass=ABCMeta):
                 # propagate any exception from the producer immediately
                 if self._exception is not None:
                     raise self._exception
+            # emit images with an available prediction,
+            # even if no detections were made (which does not produce a queue item)
+            results.extend(self._extract_results(shelf_writer))
 
         except BaseException as e:  # catches KeyboardInterrupt, SystemExit, etc.
             # tell producer to quit

--- a/deeplabcut/pose_estimation_pytorch/runners/shelving.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/shelving.py
@@ -73,6 +73,23 @@ class ShelfReader(ShelfManager):
         return self._db[item]
 
 
+def frame_key_width(num_frames: int | None, default: int = 5) -> int:
+    """Returns the zero-fill width for frame keys in a full-data dict.
+
+    Args:
+        num_frames: The number of frames in the video, if known.
+        default: The width to use when the number of frames is unknown.
+
+    Returns:
+        The number of leading zeros to pad frame indices with.
+    """
+    if num_frames is None:
+        return default
+    if num_frames <= 1:
+        return 1
+    return int(np.ceil(np.log10(num_frames)))
+
+
 class ShelfWriter(ShelfManager):
     """Writes data to a shelf on-the-fly during video analysis.
 
@@ -95,7 +112,7 @@ class ShelfWriter(ShelfManager):
 
         self._str_width = 5
         if num_frames is not None:
-            self._str_width = int(np.ceil(np.log10(num_frames)))
+            self._str_width = frame_key_width(num_frames)
 
     def add_prediction(
         self,

--- a/deeplabcut/pose_estimation_pytorch/runners/shelving.py
+++ b/deeplabcut/pose_estimation_pytorch/runners/shelving.py
@@ -110,9 +110,7 @@ class ShelfWriter(ShelfManager):
         self._num_frames = num_frames
         self._frame_index = 0
 
-        self._str_width = 5
-        if num_frames is not None:
-            self._str_width = frame_key_width(num_frames)
+        self._str_width = frame_key_width(num_frames)
 
     def add_prediction(
         self,

--- a/tests/pose_estimation_pytorch/apis/test_videos.py
+++ b/tests/pose_estimation_pytorch/apis/test_videos.py
@@ -52,27 +52,108 @@ def test_create_df_from_prediction_rejects_empty_predictions(tmp_path):
     assert not (tmp_path / "video.h5").exists()
 
 
-def test_video_inference_warns_distinctly_for_zero_predictions(monkeypatch, caplog):
-    class FakeVideoIterator:
-        def __init__(self, video_path, cropping=None):
-            self.video_path = video_path
-            self.fps = 25
-            self.dimensions = (640, 480)
+@pytest.fixture
+def patch_video_iterator(monkeypatch):
+    """Patches ``VideoIterator`` with a stub reporting ``n_frames`` empty frames."""
 
-        def get_n_frames(self, robust=False):
-            return 3
+    def _patch(n_frames: int):
+        class FakeVideoIterator:
+            def __init__(self, video_path, cropping=None):
+                self.video_path = video_path
+                self.fps = 25
+                self.dimensions = (640, 480)
 
-        def __iter__(self):
-            return iter(())
+            def get_n_frames(self, robust=False):
+                return n_frames
 
-    monkeypatch.setattr(videos, "VideoIterator", FakeVideoIterator)
-    pose_runner = Mock()
-    pose_runner.batch_size = 2
-    pose_runner.inference.return_value = []
+            def set_context(self, context):
+                pass
+
+            def __iter__(self):
+                return iter(())
+
+        monkeypatch.setattr(videos, "VideoIterator", FakeVideoIterator)
+        return FakeVideoIterator
+
+    return _patch
+
+
+def _pose_runner(predictions: list) -> Mock:
+    runner = Mock()
+    runner.batch_size = 2
+    runner.inference.return_value = predictions
+    return runner
+
+
+def test_video_inference_zero_predictions_warns_about_unreadable_video(patch_video_iterator, caplog):
+    """Without a detector, every readable frame yields a prediction, so an empty
+    result means the video could not be read - not that no animals were found."""
+    patch_video_iterator(3)
 
     with caplog.at_level("WARNING"):
-        predictions = videos.video_inference("video.mp4", pose_runner)
+        predictions = videos.video_inference("video.mp4", _pose_runner([]))
 
     assert predictions == []
-    assert "No predictions were produced for this video." in caplog.text
-    assert "video is corrupted" not in caplog.text
+    assert "No predictions were produced for video.mp4" in caplog.text
+    assert "the video could not be read" in caplog.text
+    assert "no animals were detected" not in caplog.text
+    # the re-encoding tip is the actionable advice in this case
+    assert "re-encoding your video" in caplog.text
+
+
+def test_video_inference_zero_predictions_with_detector_warns_about_detections(patch_video_iterator, caplog):
+    patch_video_iterator(3)
+
+    with caplog.at_level("WARNING"):
+        predictions = videos.video_inference("video.mp4", _pose_runner([]), detector_runner=_pose_runner([]))
+
+    assert predictions == []
+    assert "no animals were detected in any frame" in caplog.text
+    assert "the video could not be read" in caplog.text
+    assert "re-encoding your video" in caplog.text
+
+
+def test_video_inference_zero_predictions_warns_when_frame_count_is_zero(patch_video_iterator, caplog):
+    """A video whose metadata reports 0 frames must still warn."""
+    patch_video_iterator(0)
+
+    with caplog.at_level("WARNING"):
+        predictions = videos.video_inference("video.mp4", _pose_runner([]))
+
+    assert predictions == []
+    assert "No predictions were produced for video.mp4" in caplog.text
+
+
+def test_video_inference_warns_when_some_frames_are_missing(patch_video_iterator, caplog):
+    patch_video_iterator(3)
+
+    with caplog.at_level("WARNING"):
+        predictions = videos.video_inference("video.mp4", _pose_runner([{}, {}]))
+
+    assert len(predictions) == 2
+    assert "there are 3 frames in the video, but only 2" in caplog.text
+    assert "re-encoding your video" in caplog.text
+    assert "No predictions were produced" not in caplog.text
+
+
+def test_video_inference_does_not_warn_when_all_frames_are_predicted(patch_video_iterator, caplog):
+    patch_video_iterator(3)
+
+    with caplog.at_level("WARNING"):
+        predictions = videos.video_inference("video.mp4", _pose_runner([{}, {}, {}]))
+
+    assert len(predictions) == 3
+    assert "No predictions were produced" not in caplog.text
+    assert "were able to be processed" not in caplog.text
+
+
+def test_video_inference_does_not_warn_when_writing_to_a_shelf(patch_video_iterator, caplog):
+    """The returned list is empty by design when a shelf writer is given."""
+    patch_video_iterator(3)
+
+    with caplog.at_level("WARNING"):
+        predictions = videos.video_inference("video.mp4", _pose_runner([]), shelf_writer=Mock())
+
+    assert predictions == []
+    assert "No predictions were produced" not in caplog.text
+    assert "were able to be processed" not in caplog.text

--- a/tests/pose_estimation_pytorch/apis/test_videos.py
+++ b/tests/pose_estimation_pytorch/apis/test_videos.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+
+import pandas as pd
+
 import deeplabcut.pose_estimation_pytorch.apis.videos as videos
 
 POSE_CFG = {
@@ -25,3 +29,32 @@ def test_generate_output_data_handles_empty_predictions():
             "key_str_width": 1,
         }
     }
+
+
+def test_create_df_from_prediction_handles_empty_predictions(monkeypatch, tmp_path):
+    writes: list[tuple[Path, str, str, str]] = []
+
+    def _fake_to_hdf(self, path_or_buf, key, format, mode):
+        writes.append((Path(path_or_buf), key, format, mode))
+
+    monkeypatch.setattr(pd.DataFrame, "to_hdf", _fake_to_hdf)
+
+    df = videos.create_df_from_prediction(
+        predictions=[],
+        dlc_scorer="DLC_test",
+        multi_animal=False,
+        model_cfg={
+            "metadata": {
+                "bodyparts": ["snout", "leftear", "rightear"],
+                "unique_bodyparts": [],
+                "individuals": ["animal_0"],
+            }
+        },
+        output_path=tmp_path,
+        output_prefix="video",
+        save_as_csv=False,
+    )
+
+    assert df.empty
+    assert list(df.columns.names) == ["scorer", "bodyparts", "coords"]
+    assert writes == [(tmp_path / "video.h5", "df_with_missing", "table", "w")]

--- a/tests/pose_estimation_pytorch/apis/test_videos.py
+++ b/tests/pose_estimation_pytorch/apis/test_videos.py
@@ -17,13 +17,13 @@ POSE_CFG = {
 def test_generate_output_data_handles_empty_predictions():
     output = videos._generate_output_data(POSE_CFG, [])
 
+    assert output["metadata"].pop("PAFinds").tolist() == []
     assert output == {
         "metadata": {
             "nms radius": 5,
             "minimal confidence": 0.1,
             "sigma": 1,
             "PAFgraph": None,
-            "PAFinds": [],
             "all_joints": [[0], [1], [2]],
             "all_joints_names": ["snout", "leftear", "rightear"],
             "nframes": 0,

--- a/tests/pose_estimation_pytorch/apis/test_videos.py
+++ b/tests/pose_estimation_pytorch/apis/test_videos.py
@@ -1,7 +1,6 @@
-from pathlib import Path
 from unittest.mock import Mock
 
-import pandas as pd
+import pytest
 
 import deeplabcut.pose_estimation_pytorch.apis.videos as videos
 
@@ -32,33 +31,25 @@ def test_generate_output_data_handles_empty_predictions():
     }
 
 
-def test_create_df_from_prediction_handles_empty_predictions(monkeypatch, tmp_path):
-    writes: list[tuple[Path, str, str, str]] = []
+def test_create_df_from_prediction_rejects_empty_predictions(tmp_path):
+    with pytest.raises(ValueError, match="empty predictions list"):
+        videos.create_df_from_prediction(
+            predictions=[],
+            dlc_scorer="DLC_test",
+            multi_animal=False,
+            model_cfg={
+                "metadata": {
+                    "bodyparts": ["snout", "leftear", "rightear"],
+                    "unique_bodyparts": [],
+                    "individuals": ["animal_0"],
+                }
+            },
+            output_path=tmp_path,
+            output_prefix="video",
+            save_as_csv=False,
+        )
 
-    def _fake_to_hdf(self, path_or_buf, key, format, mode):
-        writes.append((Path(path_or_buf), key, format, mode))
-
-    monkeypatch.setattr(pd.DataFrame, "to_hdf", _fake_to_hdf)
-
-    df = videos.create_df_from_prediction(
-        predictions=[],
-        dlc_scorer="DLC_test",
-        multi_animal=False,
-        model_cfg={
-            "metadata": {
-                "bodyparts": ["snout", "leftear", "rightear"],
-                "unique_bodyparts": [],
-                "individuals": ["animal_0"],
-            }
-        },
-        output_path=tmp_path,
-        output_prefix="video",
-        save_as_csv=False,
-    )
-
-    assert df.empty
-    assert list(df.columns.names) == ["scorer", "bodyparts", "coords"]
-    assert writes == [(tmp_path / "video.h5", "df_with_missing", "table", "w")]
+    assert not (tmp_path / "video.h5").exists()
 
 
 def test_video_inference_warns_distinctly_for_zero_predictions(monkeypatch, caplog):

--- a/tests/pose_estimation_pytorch/apis/test_videos.py
+++ b/tests/pose_estimation_pytorch/apis/test_videos.py
@@ -1,0 +1,27 @@
+import deeplabcut.pose_estimation_pytorch.apis.videos as videos
+
+POSE_CFG = {
+    "all_joints": [[0], [1], [2]],
+    "all_joints_names": ["snout", "leftear", "rightear"],
+    "nmsradius": 5,
+    "minconfidence": 0.1,
+    "sigma": 1,
+}
+
+
+def test_generate_output_data_handles_empty_predictions():
+    output = videos._generate_output_data(POSE_CFG, [])
+
+    assert output == {
+        "metadata": {
+            "nms radius": 5,
+            "minimal confidence": 0.1,
+            "sigma": 1,
+            "PAFgraph": None,
+            "PAFinds": [],
+            "all_joints": [[0], [1], [2]],
+            "all_joints_names": ["snout", "leftear", "rightear"],
+            "nframes": 0,
+            "key_str_width": 1,
+        }
+    }

--- a/tests/pose_estimation_pytorch/apis/test_videos.py
+++ b/tests/pose_estimation_pytorch/apis/test_videos.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import Mock
 
 import pandas as pd
 
@@ -58,3 +59,29 @@ def test_create_df_from_prediction_handles_empty_predictions(monkeypatch, tmp_pa
     assert df.empty
     assert list(df.columns.names) == ["scorer", "bodyparts", "coords"]
     assert writes == [(tmp_path / "video.h5", "df_with_missing", "table", "w")]
+
+
+def test_video_inference_warns_distinctly_for_zero_predictions(monkeypatch, caplog):
+    class FakeVideoIterator:
+        def __init__(self, video_path, cropping=None):
+            self.video_path = video_path
+            self.fps = 25
+            self.dimensions = (640, 480)
+
+        def get_n_frames(self, robust=False):
+            return 3
+
+        def __iter__(self):
+            return iter(())
+
+    monkeypatch.setattr(videos, "VideoIterator", FakeVideoIterator)
+    pose_runner = Mock()
+    pose_runner.batch_size = 2
+    pose_runner.inference.return_value = []
+
+    with caplog.at_level("WARNING"):
+        predictions = videos.video_inference("video.mp4", pose_runner)
+
+    assert predictions == []
+    assert "No predictions were produced for this video." in caplog.text
+    assert "video is corrupted" not in caplog.text

--- a/tests/pose_estimation_pytorch/runners/test_runners_inference.py
+++ b/tests/pose_estimation_pytorch/runners/test_runners_inference.py
@@ -172,7 +172,7 @@ def test_async_inference_emits_images_without_detections(detections_per_image):
     queue item. The async consumer therefore only emits it if results are drained
     once more after the producer signals completion; without that final drain the
     trailing undetected images are dropped, and with no detections at all the whole
-    result set comes back empty (issue #3485). Pinned against the sequential path,
+    result set comes back empty (issue #3485). Compared to the sequential path,
     which has always handled this because it extracts after every image.
     """
     images = _top_down_images(detections_per_image, h=8, w=8)

--- a/tests/pose_estimation_pytorch/runners/test_runners_inference.py
+++ b/tests/pose_estimation_pytorch/runners/test_runners_inference.py
@@ -158,6 +158,39 @@ def test_mock_top_down(batch_size, detections_per_image):
             assert i_det[0, 0, 0] == p_det["mock"]["index"]
 
 
+@pytest.mark.parametrize(
+    "detections_per_image",
+    [
+        [0, 0, 0, 0],  # issue #3485: no detections anywhere
+        [1, 1, 0, 0],
+        [1, 0],
+        [2, 0, 1, 0],
+    ],
+)
+def test_async_inference_emits_images_without_detections(detections_per_image):
+    """An image without detections adds nothing to the batch, so it never produces a
+    queue item. The async consumer therefore only emits it if results are drained
+    once more after the producer signals completion; without that final drain the
+    trailing undetected images are dropped, and with no detections at all the whole
+    result set comes back empty (issue #3485). Pinned against the sequential path,
+    which has always handled this because it extracts after every image.
+    """
+    images = _top_down_images(detections_per_image, h=8, w=8)
+
+    async_runner = MockInferenceRunner(batch_size=2)
+    assert async_runner.inference_cfg.multithreading.enabled, "async is the default path"
+
+    sequential_runner = MockInferenceRunner(batch_size=2)
+    sequential_runner.inference_cfg.multithreading.enabled = False
+
+    async_predictions = async_runner.inference(images)
+    sequential_predictions = sequential_runner.inference(images)
+
+    assert len(async_predictions) == len(images)
+    assert [len(p) for p in async_predictions] == detections_per_image
+    assert [len(p) for p in async_predictions] == [len(p) for p in sequential_predictions]
+
+
 def test_dynamic_pose_inference_calls_dynamic():
     pose_batch = torch.zeros((1, 1, 1, 3))
     pose_batch_updated = torch.ones((1, 1, 1, 3))

--- a/tests/pose_estimation_pytorch/runners/test_runners_inference.py
+++ b/tests/pose_estimation_pytorch/runners/test_runners_inference.py
@@ -93,20 +93,8 @@ def test_mock_bottom_up(batch_size):
         assert i[0, 0, 0, 0] == p[0]["mock"]["index"]
 
 
-@pytest.mark.parametrize("batch_size", [1, 2, 4, 8])
-@pytest.mark.parametrize(
-    "detections_per_image",
-    [
-        [1, 1, 1, 1, 1],
-        [0, 1, 0, 1, 1],  # some frames might not have predictions
-        [0, 0, 0, 5, 2],
-        [1, 2, 3, 4],
-        [3, 4, 2, 1, 4],
-        [4, 23, 5, 20, 64, 100],
-    ],
-)
-def test_mock_top_down(batch_size, detections_per_image):
-    h, w = 8, 8
+def _top_down_images(detections_per_image, h: int, w: int) -> list[np.ndarray]:
+    """Builds one input batch per image, empty for images without detections."""
     images = []
     for index, num_detections in enumerate(detections_per_image):
         if num_detections == 0:
@@ -118,6 +106,28 @@ def test_mock_top_down(batch_size, detections_per_image):
             )
 
         images.append(detections)
+
+    return images
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 4, 8])
+@pytest.mark.parametrize(
+    "detections_per_image",
+    [
+        [1, 1, 1, 1, 1],
+        [0, 1, 0, 1, 1],  # some frames might not have predictions
+        [0, 0, 0, 5, 2],
+        [1, 2, 3, 4],
+        [3, 4, 2, 1, 4],
+        [4, 23, 5, 20, 64, 100],
+        [0, 0, 0, 0, 0],  # no detections at all: nothing is ever queued
+        [1, 1, 0, 0],  # trailing frames without detections
+        [5, 2, 0],
+    ],
+)
+def test_mock_top_down(batch_size, detections_per_image):
+    h, w = 8, 8
+    images = _top_down_images(detections_per_image, h, w)
 
     runner = MockInferenceRunner(batch_size=batch_size)
     predictions = runner.inference(images)
@@ -183,6 +193,9 @@ def test_dynamic_pose_inference_calls_dynamic():
 
 
 def _check_batch_shapes(batch_size, h, w, batch_shapes) -> None:
+    if not batch_shapes:
+        return  # no image had detections, so no batch was ever run
+
     for b in batch_shapes[:-1]:
         assert b[0] == batch_size
         assert b[1] == 3


### PR DESCRIPTION
This PR fixes a set of related bugs in the PyTorch `analyze_videos` output path when inference produces no predictions, which can happen legitimately for clips where no animal is detected.

**Problem**
1. For top-down inference, `video_inference()` can return an empty predictions list when no detections are produced across the whole clip: `_generate_output_data()` computes frame-key width with `np.log10(len(predictions))`, which crashes with `OverflowError` when `len(predictions) == 0`.
2. That case is currently not handled consistently downstream. (e.g. `np.stack(...)` is called on the empty list + a misleading warning message is emmitted).




**Changes**
- Guard frame-key width generation for zero predictions.
- No DataFrames are exported when empty predictions. A clear warning is emitted.
- Add regression coverage for empty-prediction output paths.


**Related issues**
Current issue:
- closes #3485 

Previous related issues:
-  [#2449](https://github.com/DeepLabCut/DeepLabCut/issues/2449)
-  [#3108](https://github.com/DeepLabCut/DeepLabCut/issues/3108)
-  [#2989](https://github.com/DeepLabCut/DeepLabCut/issues/2989)