### PR TITLE
Route GUI Qt imports through qtpy, keeping PySide6 preferred

### DIFF
--- a/deeplabcut/__main__.py
+++ b/deeplabcut/__main__.py
@@ -8,15 +8,15 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
+import sys
 from importlib import import_module
 
 
 def main():
     try:
         import_module("deeplabcut.gui")
-    except ImportError as err:
-        print(err)
-        return
+    except (ImportError, ValueError) as err:
+        sys.exit(str(err))
 
     # if module is executed directly (i.e. `python -m deeplabcut.__init__`) launch straight into the GUI
     print("Starting GUI...")

--- a/deeplabcut/__main__.py
+++ b/deeplabcut/__main__.py
@@ -13,23 +13,16 @@ from importlib import import_module
 
 def main():
     try:
-        import_module("PySide6")
-
-        lite = False
-    except ModuleNotFoundError:
-        lite = True
+        import_module("deeplabcut.gui")
+    except ImportError as err:
+        print(err)
+        return
 
     # if module is executed directly (i.e. `python -m deeplabcut.__init__`) launch straight into the GUI
-    if not lite:
-        print("Starting GUI...")
-        from deeplabcut.gui.launch_script import launch_dlc
+    print("Starting GUI...")
+    from deeplabcut.gui.launch_script import launch_dlc
 
-        launch_dlc()
-    else:
-        print(
-            "You installed DLC lite, thus GUI's cannot be used. If you need GUI support please: pip install"
-            "'deeplabcut[gui]''"
-        )
+    launch_dlc()
 
 
 if __name__ == "__main__":

--- a/deeplabcut/gui/__init__.py
+++ b/deeplabcut/gui/__init__.py
@@ -11,7 +11,6 @@
 
 import os
 import sys
-import warnings
 from importlib.util import find_spec
 from pathlib import Path
 
@@ -29,7 +28,6 @@ _MODULE_TO_QT_API = (
     ("PySide6", "pyside6"),
 )
 _VALID_QT_APIS = tuple(api for _, api in _MODULE_TO_QT_API)
-_GPL_QT_APIS = ("pyqt5", "pyqt6")
 
 _INSTALL_DOCS_URL = "https://deeplabcut.github.io/DeepLabCut/docs/installation.html"
 
@@ -82,14 +80,5 @@ except ImportError as err:
 # matplotlib's backends/qt_compat.py also reads QT_API and must not end up on a
 # different binding. It expects the lowercase form, which is `qtpy.API`.
 os.environ["QT_API"] = qtpy.API
-
-if qtpy.API in _GPL_QT_APIS:
-    warnings.warn(
-        f"DeepLabCut GUI is running on {qtpy.API_NAME}, which is licensed "
-        "under the GPL. DeepLabCut is LGPL and is developed against PySide6 "
-        "(LGPL). Set QT_API=pyside6, or install PySide6, to use the preferred "
-        "binding.",
-        stacklevel=2,
-    )
 
 BASE_DIR = Path(__file__).parent

--- a/deeplabcut/gui/__init__.py
+++ b/deeplabcut/gui/__init__.py
@@ -10,9 +10,68 @@
 #
 
 import os
+import sys
+import warnings
+from importlib.util import find_spec
 from pathlib import Path
 
-os.environ["QT_API"] = "pyside6"
-import qtpy  # Necessary unused import to properly store the env variable
+# Selection precedence:
+#   1. Explicit, valid, user-set QT_API always wins;
+#   2. Otherwise an already imported binding wins
+#   3. Otherwise PySide6. qtpy's own default order (pyqt5, pyside2, pyqt6,
+#      pyside6) puts PySide6 LAST, so an environment that also has PyQt6
+#      (napari[all], for instance) would silently demote without this;
+#   4. Otherwise leave QT_API unset and let qtpy autodetect.
+_MODULE_TO_QT_API = (
+    ("PyQt5", "pyqt5"),
+    ("PySide2", "pyside2"),
+    ("PyQt6", "pyqt6"),
+    ("PySide6", "pyside6"),
+)
+_VALID_QT_APIS = tuple(api for _, api in _MODULE_TO_QT_API)
+_GPL_QT_APIS = ("pyqt5", "pyqt6")
+
+_NO_BINDING_MESSAGE = (
+    "The DeepLabCut GUI requires a Qt binding, but none could be imported. "
+    "PySide6 is the supported binding; install the GUI dependencies with "
+    "`pip install 'deeplabcut[gui]'`. "
+    "If PySide6 is already installed, it could not be loaded: on Linux this "
+    "usually means the Qt system libraries are missing."
+)
+
+_user_qt_api = (os.environ.get("QT_API") or "").lower()
+if _user_qt_api and _user_qt_api not in _VALID_QT_APIS:
+    raise ValueError(
+        f"QT_API is set to an unsupported value {_user_qt_api!r}. Valid values are: {', '.join(_VALID_QT_APIS)}."
+    )
+
+if not _user_qt_api:
+    _already_loaded = next((api for module, api in _MODULE_TO_QT_API if module in sys.modules), None)
+    if _already_loaded is not None:
+        os.environ["QT_API"] = _already_loaded
+    elif find_spec("PySide6") is not None:
+        # find_spec does not import PySide6.
+        # Let qtpy import so version checks and
+        # its QT_API write-back still run
+        os.environ["QT_API"] = "pyside6"
+
+try:
+    import qtpy  # noqa: F401  imported side effect: binding selection
+except ImportError as err:
+    raise ImportError(_NO_BINDING_MESSAGE) from err
+
+# qtpy rewrites QT_API to the binding it actually loaded, but be explicit:
+# matplotlib's backends/qt_compat.py also reads QT_API and must not end up on a
+# different binding. It expects the lowercase form, which is `qtpy.API`.
+os.environ["QT_API"] = qtpy.API
+
+if qtpy.API in _GPL_QT_APIS:
+    warnings.warn(
+        f"DeepLabCut GUI is running on {qtpy.API_NAME}, which is licensed "
+        "under the GPL. DeepLabCut is LGPL and is developed against PySide6 "
+        "(LGPL). Set QT_API=pyside6, or install PySide6, to use the preferred "
+        "binding.",
+        stacklevel=2,
+    )
 
 BASE_DIR = Path(__file__).parent

--- a/deeplabcut/gui/__init__.py
+++ b/deeplabcut/gui/__init__.py
@@ -31,13 +31,31 @@ _MODULE_TO_QT_API = (
 _VALID_QT_APIS = tuple(api for _, api in _MODULE_TO_QT_API)
 _GPL_QT_APIS = ("pyqt5", "pyqt6")
 
-_NO_BINDING_MESSAGE = (
-    "The DeepLabCut GUI requires a Qt binding, but none could be imported. "
-    "PySide6 is the supported binding; install the GUI dependencies with "
-    "`pip install 'deeplabcut[gui]'`. "
-    "If PySide6 is already installed, it could not be loaded: on Linux this "
-    "usually means the Qt system libraries are missing."
-)
+_INSTALL_DOCS_URL = "https://deeplabcut.github.io/DeepLabCut/docs/installation.html"
+
+
+def _no_binding_message() -> str:
+    if find_spec("PySide6") is None:
+        cause = (
+            "The DeepLabCut GUI could not start: the graphics libraries it needs are not installed.\n\n"
+            "Install the GUI dependencies with\n"
+            "    pip install 'deeplabcut[gui]'"
+        )
+    else:
+        cause = (
+            "The DeepLabCut GUI could not start: PySide6 is installed but could not be loaded.\n\n"
+            "The installation is likely incomplete. Try\n"
+            "    pip install --force-reinstall pyside6"
+        )
+
+    return (
+        f"{cause}\n\n"
+        f"Python currently in use:\n    {sys.executable}\n\n"
+        "If that is not the environment you expected, activate the correct conda environment "
+        "(for example `conda activate DEEPLABCUT`) and try again.\n\n"
+        f"Installation help: {_INSTALL_DOCS_URL}"
+    )
+
 
 _user_qt_api = (os.environ.get("QT_API") or "").lower()
 if _user_qt_api and _user_qt_api not in _VALID_QT_APIS:
@@ -58,7 +76,7 @@ if not _user_qt_api:
 try:
     import qtpy  # noqa: F401  imported side effect: binding selection
 except ImportError as err:
-    raise ImportError(_NO_BINDING_MESSAGE) from err
+    raise ImportError(_no_binding_message()) from err
 
 # qtpy rewrites QT_API to the binding it actually loaded, but be explicit:
 # matplotlib's backends/qt_compat.py also reads QT_API and must not end up on a

--- a/deeplabcut/gui/components.py
+++ b/deeplabcut/gui/components.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from PySide6 import QtWidgets
-from PySide6.QtCore import Qt, QTimer, Slot
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt, QTimer, Slot
 
 from deeplabcut.core.config import read_config_as_dict
 from deeplabcut.gui.dlc_params import DLCParams

--- a/deeplabcut/gui/config_file_monitor.py
+++ b/deeplabcut/gui/config_file_monitor.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from pathlib import Path
 
-from PySide6 import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 
 
 class ConfigFileMonitor(QtCore.QObject):

--- a/deeplabcut/gui/dialogs/debug_dialog.py
+++ b/deeplabcut/gui/dialogs/debug_dialog.py
@@ -13,10 +13,10 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable
 
-from PySide6 import QtGui
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QAction, QFontDatabase, QKeySequence, QTextCursor
-from PySide6.QtWidgets import (
+from qtpy import QtGui
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QAction, QFontDatabase, QKeySequence, QTextCursor
+from qtpy.QtWidgets import (
     QApplication,
     QDialog,
     QHBoxLayout,

--- a/deeplabcut/gui/displays/selected_shuffle_display.py
+++ b/deeplabcut/gui/displays/selected_shuffle_display.py
@@ -14,10 +14,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import PySide6.QtCore as QtCore
-from PySide6 import QtWidgets
-from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QSizePolicy
+from qtpy import QtCore, QtWidgets
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QSizePolicy
 
 from deeplabcut.core.engine import Engine
 from deeplabcut.utils import auxiliaryfunctions

--- a/deeplabcut/gui/displays/shuffle_metadata_viewer.py
+++ b/deeplabcut/gui/displays/shuffle_metadata_viewer.py
@@ -14,8 +14,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from PySide6 import QtWidgets
-from PySide6.QtCore import Qt
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt
 
 import deeplabcut.generate_training_dataset.metadata as metadata
 

--- a/deeplabcut/gui/gui_assets.py
+++ b/deeplabcut/gui/gui_assets.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from importlib.resources import files
 from pathlib import Path
 
-from PySide6.QtGui import QIcon, QPixmap
+from qtpy.QtGui import QIcon, QPixmap
 
 ASSETS_DIR = files("deeplabcut.gui").joinpath("assets")
 

--- a/deeplabcut/gui/launch_script.py
+++ b/deeplabcut/gui/launch_script.py
@@ -69,7 +69,7 @@ def launch_dlc():
     window.receiver.start()
     window.showMaximized()
     splash.finish(window)
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 
 if __name__ == "__main__":

--- a/deeplabcut/gui/launch_script.py
+++ b/deeplabcut/gui/launch_script.py
@@ -23,6 +23,7 @@ import logging
 import sys
 
 import qdarkstyle
+from qdarkstyle.dark.palette import DarkPalette
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt
 
@@ -39,13 +40,14 @@ def launch_dlc():
     splash = QtWidgets.QSplashScreen(pixmap)
     splash.show()
 
-    app.setStyleSheet(get_style_qss())  # this gets overridden immediately?
+    app.setStyleSheet(get_style_qss())
     try:
-        dark_stylesheet = qdarkstyle.load_stylesheet_pyside6()
-    except Exception as e:
-        logger.warning(f"Could not load qdarkstyle stylesheet for PySide6: {e}. Falling back to PySide2 stylesheet.")
-        dark_stylesheet = qdarkstyle.load_stylesheet_pyside2()
-    app.setStyleSheet(dark_stylesheet)
+        # Always pass `palette=`: the zero-argument load_stylesheet() and the
+        # load_stylesheet_<binding>() helpers overwrite os.environ["QT_API"],
+        # which desynchronises matplotlib from the binding qtpy loaded.
+        app.setStyleSheet(qdarkstyle.load_stylesheet(palette=DarkPalette))
+    except Exception:
+        logger.warning("Could not load the qdarkstyle stylesheet; keeping the bundled style.qss.", exc_info=True)
 
     # Set up a logger and add an stdout handler.
     # A single logger can have many handlers:

--- a/deeplabcut/gui/launch_script.py
+++ b/deeplabcut/gui/launch_script.py
@@ -42,9 +42,6 @@ def launch_dlc():
 
     app.setStyleSheet(get_style_qss())
     try:
-        # Always pass `palette=`: the zero-argument load_stylesheet() and the
-        # load_stylesheet_<binding>() helpers overwrite os.environ["QT_API"],
-        # which desynchronises matplotlib from the binding qtpy loaded.
         app.setStyleSheet(qdarkstyle.load_stylesheet(palette=DarkPalette))
     except Exception:
         logger.warning("Could not load the qdarkstyle stylesheet; keeping the bundled style.qss.", exc_info=True)

--- a/deeplabcut/gui/launch_script.py
+++ b/deeplabcut/gui/launch_script.py
@@ -22,9 +22,9 @@ Licensed under GNU Lesser General Public License v3.0
 import logging
 import sys
 
-import PySide6.QtWidgets as QtWidgets
 import qdarkstyle
-from PySide6.QtCore import Qt
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt
 
 from deeplabcut.gui.gui_assets import get_style_qss, icon_from_resource, pixmap_from_resource
 

--- a/deeplabcut/gui/launch_script.py
+++ b/deeplabcut/gui/launch_script.py
@@ -66,7 +66,7 @@ def launch_dlc():
     window.receiver.start()
     window.showMaximized()
     splash.finish(window)
-    sys.exit(app.exec())
+    sys.exit(app.exec_())
 
 
 if __name__ == "__main__":

--- a/deeplabcut/gui/tabs/analyze_videos.py
+++ b/deeplabcut/gui/tabs/analyze_videos.py
@@ -12,8 +12,8 @@ from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
 
-from PySide6 import QtWidgets
-from PySide6.QtCore import Qt
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt
 
 import deeplabcut
 from deeplabcut.core.config import ProjectConfig

--- a/deeplabcut/gui/tabs/create_project.py
+++ b/deeplabcut/gui/tabs/create_project.py
@@ -12,8 +12,8 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from PySide6 import QtCore, QtWidgets
-from PySide6.QtGui import QBrush, QColor, QDesktopServices, QPainter, QPen
+from qtpy import QtCore, QtWidgets
+from qtpy.QtGui import QBrush, QColor, QDesktopServices, QPainter, QPen
 
 from deeplabcut.create_project import create_new_project, create_new_project_3d
 from deeplabcut.gui.dlc_params import DLCParams

--- a/deeplabcut/gui/tabs/create_training_dataset.py
+++ b/deeplabcut/gui/tabs/create_training_dataset.py
@@ -15,8 +15,8 @@ from importlib import import_module
 from pathlib import Path
 
 import dlclibrary
-from PySide6 import QtWidgets
-from PySide6.QtCore import Qt, Slot
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt, Slot
 
 import deeplabcut
 import deeplabcut.compat as compat

--- a/deeplabcut/gui/tabs/create_videos.py
+++ b/deeplabcut/gui/tabs/create_videos.py
@@ -8,8 +8,8 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
-from PySide6 import QtWidgets
-from PySide6.QtCore import Qt
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt
 
 import deeplabcut
 from deeplabcut.gui.components import (

--- a/deeplabcut/gui/tabs/evaluate_network.py
+++ b/deeplabcut/gui/tabs/evaluate_network.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import matplotlib.image as mpimg
-from matplotlib.backends.backend_qt5agg import (
+from matplotlib.backends.backend_qtagg import (
     FigureCanvasQTAgg as FigureCanvas,
 )
 from matplotlib.figure import Figure

--- a/deeplabcut/gui/tabs/evaluate_network.py
+++ b/deeplabcut/gui/tabs/evaluate_network.py
@@ -17,8 +17,8 @@ from matplotlib.backends.backend_qt5agg import (
     FigureCanvasQTAgg as FigureCanvas,
 )
 from matplotlib.figure import Figure
-from PySide6 import QtWidgets
-from PySide6.QtCore import Qt, Slot
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt, Slot
 
 import deeplabcut
 from deeplabcut.core.engine import Engine

--- a/deeplabcut/gui/tabs/extract_frames.py
+++ b/deeplabcut/gui/tabs/extract_frames.py
@@ -11,8 +11,8 @@
 from functools import partial
 from pathlib import Path
 
-from PySide6 import QtWidgets
-from PySide6.QtCore import Qt
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt
 
 from deeplabcut.generate_training_dataset import extract_frames
 from deeplabcut.gui.components import (

--- a/deeplabcut/gui/tabs/extract_outlier_frames.py
+++ b/deeplabcut/gui/tabs/extract_outlier_frames.py
@@ -8,8 +8,8 @@
 #
 # Licensed under GNU Lesser General Public License v3.0
 #
-from PySide6 import QtWidgets
-from PySide6.QtCore import Qt
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt
 
 import deeplabcut
 from deeplabcut.gui.components import (

--- a/deeplabcut/gui/tabs/label_frames.py
+++ b/deeplabcut/gui/tabs/label_frames.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from PySide6 import QtWidgets
-from PySide6.QtCore import Qt
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt
 
 from deeplabcut.generate_training_dataset import check_labels
 from deeplabcut.gui.components import DefaultTab

--- a/deeplabcut/gui/tabs/manage_project.py
+++ b/deeplabcut/gui/tabs/manage_project.py
@@ -11,8 +11,8 @@
 import os
 from pathlib import Path
 
-from PySide6.QtCore import Qt
-from PySide6.QtWidgets import (
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (
     QFileDialog,
     QLabel,
     QLineEdit,

--- a/deeplabcut/gui/tabs/modelzoo.py
+++ b/deeplabcut/gui/tabs/modelzoo.py
@@ -13,9 +13,9 @@ from functools import partial
 from pathlib import Path
 
 import dlclibrary
-from PySide6 import QtWidgets
-from PySide6.QtCore import QRegularExpression, QSize, Qt, QTimer, Signal, Slot
-from PySide6.QtGui import QRegularExpressionValidator
+from qtpy import QtWidgets
+from qtpy.QtCore import QRegularExpression, QSize, Qt, QTimer, Signal, Slot
+from qtpy.QtGui import QRegularExpressionValidator
 
 import deeplabcut
 from deeplabcut.core.engine import Engine

--- a/deeplabcut/gui/tabs/open_project.py
+++ b/deeplabcut/gui/tabs/open_project.py
@@ -11,7 +11,7 @@
 import os
 from pathlib import Path
 
-from PySide6 import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 
 from deeplabcut.gui.gui_assets import icon_from_resource
 

--- a/deeplabcut/gui/tabs/refine_tracklets.py
+++ b/deeplabcut/gui/tabs/refine_tracklets.py
@@ -10,8 +10,8 @@
 #
 from pathlib import Path
 
-from PySide6 import QtWidgets
-from PySide6.QtCore import Qt
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt
 
 import deeplabcut
 from deeplabcut.core import trackingutils

--- a/deeplabcut/gui/tabs/train_network.py
+++ b/deeplabcut/gui/tabs/train_network.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from PySide6 import QtWidgets
-from PySide6.QtCore import Qt, Slot
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt, Slot
 
 import deeplabcut.compat as compat
 from deeplabcut.core.engine import Engine

--- a/deeplabcut/gui/tabs/unsupervised_id_tracking.py
+++ b/deeplabcut/gui/tabs/unsupervised_id_tracking.py
@@ -10,8 +10,8 @@
 #
 from functools import partial
 
-from PySide6 import QtWidgets
-from PySide6.QtCore import Qt
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt
 
 import deeplabcut
 from deeplabcut.gui.components import (

--- a/deeplabcut/gui/tabs/video_editor.py
+++ b/deeplabcut/gui/tabs/video_editor.py
@@ -10,8 +10,8 @@
 #
 import time
 
-from PySide6 import QtWidgets
-from PySide6.QtCore import Qt
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt
 
 from deeplabcut.gui.components import (
     DefaultTab,

--- a/deeplabcut/gui/tracklet_toolbox.py
+++ b/deeplabcut/gui/tracklet_toolbox.py
@@ -18,8 +18,8 @@ import numpy as np
 import pandas as pd
 from matplotlib.path import Path as MPLPath
 from matplotlib.widgets import Button, CheckButtons, LassoSelector, Slider, TextBox
-from PySide6.QtCore import QMutex
-from PySide6.QtWidgets import QMessageBox
+from qtpy.QtCore import QMutex
+from qtpy.QtWidgets import QMessageBox
 
 from deeplabcut.gui.utils import move_to_separate_thread
 from deeplabcut.refine_training_dataset.tracklets import TrackletManager

--- a/deeplabcut/gui/utils.py
+++ b/deeplabcut/gui/utils.py
@@ -16,7 +16,7 @@ import urllib.request
 from collections.abc import Callable
 from pathlib import Path
 
-from PySide6 import QtCore, QtNetwork
+from qtpy import QtCore, QtNetwork
 
 try:
     from packaging.version import InvalidVersion, Version

--- a/deeplabcut/gui/widgets.py
+++ b/deeplabcut/gui/widgets.py
@@ -15,8 +15,8 @@ from queue import Queue
 
 import napari
 import numpy as np
-from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.backends.backend_qtagg import NavigationToolbar2QT
 from matplotlib.figure import Figure
 from matplotlib.widgets import Button, LassoSelector, RectangleSelector
 from qtpy import QtCore, QtWidgets

--- a/deeplabcut/gui/widgets.py
+++ b/deeplabcut/gui/widgets.py
@@ -19,8 +19,9 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
 from matplotlib.figure import Figure
 from matplotlib.widgets import Button, LassoSelector, RectangleSelector
-from PySide6 import QtCore, QtWidgets
-from PySide6.QtGui import QAction, QCursor, QStandardItem, QStandardItemModel, Qt
+from qtpy import QtCore, QtWidgets
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QAction, QCursor, QStandardItem, QStandardItemModel
 
 from deeplabcut.utils import auxiliaryfunctions
 from deeplabcut.utils.auxfun_videos import VideoWriter

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -21,10 +21,10 @@ from pathlib import Path
 import qdarkstyle
 from napari_deeplabcut import __version__ as NAPARI_DLC_VERSION
 from pydantic import ValidationError
-from PySide6 import QtCore, QtGui, QtWidgets
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QAction, QDesktopServices, QPixmap
-from PySide6.QtWidgets import (
+from qtpy import QtCore, QtGui, QtWidgets
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QAction, QDesktopServices, QPixmap
+from qtpy.QtWidgets import (
     QComboBox,
     QLabel,
     QMainWindow,

--- a/deeplabcut/gui/window.py
+++ b/deeplabcut/gui/window.py
@@ -1234,7 +1234,9 @@ class MainWindow(QMainWindow):
             return True
 
     def darkmode(self):
-        dark_stylesheet = qdarkstyle.load_stylesheet_pyside2()
+        from qdarkstyle.dark.palette import DarkPalette
+
+        dark_stylesheet = qdarkstyle.load_stylesheet(palette=DarkPalette)
         self.app.setStyleSheet(dark_stylesheet)
 
         names = ["new_project2.png", "open2.png", "help2.png"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "h5py>=3.15.1; platform_system=='Darwin'",
   "huggingface-hub>=0.23",
   "imageio-ffmpeg",
-  "matplotlib>=3.3,<3.9,!=3.7,!=3.7.1",
+  "matplotlib>=3.5,<3.9,!=3.7,!=3.7.1",
   "networkx>=2.6",
   "numba>=0.54",
   "numpy>=1.22.4,<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ gui = [
   "pyside6<6.10; platform_system=='Linux' and platform_machine=='x86_64'",
   "qdarkstyle==3.1; platform_system=='Linux' and platform_machine=='x86_64'",
   "qdarkstyle>=3.1; platform_system!='Linux' or platform_machine!='x86_64'",
+  "qtpy>=2.4",
 ]
 openvino = [ "openvino-dev==2022.1" ]
 docs = [

--- a/tests/gui/conftest.py
+++ b/tests/gui/conftest.py
@@ -15,7 +15,7 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 import pytest
 
-pytest.importorskip("PySide6")
+pytest.importorskip("qtpy.QtWidgets")
 pytest.importorskip("pytestqt")
 
 
@@ -47,7 +47,7 @@ def write_project_config():
 @pytest.fixture
 def main_window(qapp, monkeypatch):
     """A real MainWindow, constructed off-screen and torn down cleanly."""
-    from PySide6 import QtWidgets
+    from qtpy import QtWidgets
 
     from deeplabcut.gui.window import MainWindow
 

--- a/tests/gui/test_auto_update.py
+++ b/tests/gui/test_auto_update.py
@@ -2,7 +2,7 @@ import sys
 
 import pytest
 
-pytest.importorskip("PySide6")
+pytest.importorskip("qtpy.QtWidgets")
 
 from deeplabcut.gui.utils import _build_update_commands, _package_specs_for_update
 

--- a/tests/gui/test_config_editor.py
+++ b/tests/gui/test_config_editor.py
@@ -9,7 +9,7 @@
 
 import pytest
 
-pytest.importorskip("PySide6")
+pytest.importorskip("qtpy.QtWidgets")
 pytest.importorskip("pytestqt")
 
 from deeplabcut.gui.widgets import ConfigEditor

--- a/tests/gui/test_config_errors.py
+++ b/tests/gui/test_config_errors.py
@@ -9,7 +9,7 @@
 
 import pytest
 
-pytest.importorskip("PySide6")  # deeplabcut.gui imports qtpy at package level
+pytest.importorskip("qtpy.QtWidgets")  # deeplabcut.gui imports qtpy at package level
 
 from pathlib import Path
 

--- a/tests/gui/test_config_file_monitor.py
+++ b/tests/gui/test_config_file_monitor.py
@@ -9,10 +9,10 @@
 
 import pytest
 
-pytest.importorskip("PySide6")
+pytest.importorskip("qtpy.QtWidgets")
 pytest.importorskip("pytestqt")
 
-from PySide6 import QtWidgets
+from qtpy import QtWidgets
 
 from deeplabcut.gui.config_file_monitor import ConfigFileMonitor
 

--- a/tests/gui/test_main_window_config.py
+++ b/tests/gui/test_main_window_config.py
@@ -13,10 +13,10 @@ the error dialog, so no DLC project on disk and no user interaction is needed.
 
 import pytest
 
-pytest.importorskip("PySide6")
+pytest.importorskip("qtpy.QtWidgets")
 pytest.importorskip("pytestqt")
 
-from PySide6 import QtWidgets
+from qtpy import QtWidgets
 
 pytestmark = pytest.mark.functional
 

--- a/tests/gui/test_selected_shuffle_display.py
+++ b/tests/gui/test_selected_shuffle_display.py
@@ -9,10 +9,10 @@
 
 import pytest
 
-pytest.importorskip("PySide6")
+pytest.importorskip("qtpy.QtWidgets")
 pytest.importorskip("pytestqt")
 
-import PySide6.QtCore as QtCore
+from qtpy import QtCore
 
 from deeplabcut.core.engine import Engine
 from deeplabcut.gui.displays.selected_shuffle_display import SelectedShuffleDisplay

--- a/tests/gui/test_task_error.py
+++ b/tests/gui/test_task_error.py
@@ -40,7 +40,7 @@ class TestShowTaskError:
                 captured["exec_called"] = True
                 return 0
 
-        monkeypatch.setattr(QtWidgets, "QMessageBox", _Box)
+        monkeypatch.setattr("deeplabcut.gui.window.QMessageBox", _Box)
         return captured
 
     def test_generic_error_shows_task_failed_dialog(

--- a/tests/gui/test_task_error.py
+++ b/tests/gui/test_task_error.py
@@ -9,12 +9,12 @@
 
 import pytest
 
-pytest.importorskip("PySide6")
+pytest.importorskip("qtpy.QtWidgets")
 pytest.importorskip("pytestqt")
 
 
 from pydantic import ValidationError
-from PySide6 import QtWidgets
+from qtpy import QtWidgets
 
 from deeplabcut.core.config import ProjectConfig
 

--- a/tests/gui/test_worker.py
+++ b/tests/gui/test_worker.py
@@ -9,7 +9,7 @@
 
 import pytest
 
-pytest.importorskip("PySide6")
+pytest.importorskip("qtpy.QtWidgets")
 pytest.importorskip("pytestqt")
 
 from deeplabcut.gui.utils import CaptureWorker, Worker, move_to_separate_thread

--- a/uv.lock
+++ b/uv.lock
@@ -1473,7 +1473,7 @@ requires-dist = [
     { name = "imgaug", marker = "extra == 'tf-cu12'", specifier = ">=0.4" },
     { name = "imgaug", marker = "extra == 'tf-latest'", specifier = ">=0.4" },
     { name = "jupyter-book", marker = "extra == 'docs'", specifier = "==1.0.4.post1" },
-    { name = "matplotlib", specifier = ">=3.3,!=3.7,!=3.7.1,<3.9" },
+    { name = "matplotlib", specifier = ">=3.5,!=3.7,!=3.7.1,<3.9" },
     { name = "mike", marker = "extra == 'dev-docs'", specifier = ">=2.1" },
     { name = "mkdocs", marker = "extra == 'dev-docs'", specifier = ">=1.6" },
     { name = "mkdocs-api-autonav", marker = "extra == 'dev-docs'", specifier = ">=0.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -1382,6 +1382,7 @@ gui = [
     { name = "napari-deeplabcut" },
     { name = "pyside6" },
     { name = "qdarkstyle" },
+    { name = "qtpy" },
 ]
 modelzoo = [
     { name = "huggingface-hub" },
@@ -1500,6 +1501,7 @@ requires-dist = [
     { name = "pyyaml" },
     { name = "qdarkstyle", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'gui'", specifier = "==3.1" },
     { name = "qdarkstyle", marker = "(platform_machine != 'x86_64' and extra == 'gui') or (sys_platform != 'linux' and extra == 'gui')", specifier = ">=3.1" },
+    { name = "qtpy", marker = "extra == 'gui'", specifier = ">=2.4" },
     { name = "ruamel-yaml", specifier = ">=0.15" },
     { name = "scikit-image", specifier = ">=0.17" },
     { name = "scikit-learn", specifier = ">=1" },
@@ -4497,7 +4499,7 @@ name = "opencv-python"
 version = "4.11.0.86"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "(sys_platform != 'darwin' and extra == 'extra-10-deeplabcut-fmpose3d') or (sys_platform != 'darwin' and extra == 'extra-10-deeplabcut-tf') or (sys_platform != 'darwin' and extra == 'extra-10-deeplabcut-tf-cu11') or (sys_platform != 'darwin' and extra == 'extra-10-deeplabcut-tf-cu12') or (sys_platform != 'darwin' and extra == 'extra-10-deeplabcut-tf-latest') or (sys_platform == 'darwin' and extra == 'extra-10-deeplabcut-apple-mchips') or (extra != 'extra-10-deeplabcut-apple-mchips' and extra == 'extra-10-deeplabcut-fmpose3d') or (extra != 'extra-10-deeplabcut-apple-mchips' and extra == 'extra-10-deeplabcut-tf') or (extra != 'extra-10-deeplabcut-apple-mchips' and extra == 'extra-10-deeplabcut-tf-cu11') or (extra != 'extra-10-deeplabcut-apple-mchips' and extra == 'extra-10-deeplabcut-tf-cu12') or (extra != 'extra-10-deeplabcut-apple-mchips' and extra == 'extra-10-deeplabcut-tf-latest')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/17/06/68c27a523103dad5837dc5b87e71285280c4f098c60e4fe8a8db6486ab09/opencv-python-4.11.0.86.tar.gz", hash = "sha256:03d60ccae62304860d232272e4a4fda93c39d595780cb40b161b310244b736a4", size = 95171956, upload-time = "2025-01-16T13:52:24.737Z" }
 wheels = [


### PR DESCRIPTION
# Route GUI Qt imports through qtpy, keeping PySide6 preferred

### Scope

Every Qt import in `deeplabcut/gui/` goes through `qtpy` instead of `PySide6`, and the binding is negotiated at import time rather than forced.

**This retains PySide6 as the preferred binding and a hard dependency which is installed with the GUI extra**.
No GPL package is added to dependencies.
**qtpy is MIT licensed, and does not bundle PyQt5 or PyQt6.**
Users can now select an independently installed Qt binding of their choice.

Adapts the [similar patch from conda-forge](https://github.com/conda-forge-admin/deeplabcut-feedstock/blob/ed95c21122b1108d264ef0f6dbc7841b8f7ef8d3/recipe/patches/0007-Use-qtpy-instead-of-PySide6.patch) by @hmaarrfk, thanks again!

Mentioned in #2887, closes #3356.

- [x] Ran GUI tests locally

### Motivation

DeepLabCut hard-coded PySide6 in every GUI import and forced QT_API=pyside6 at package import, so it could not share a process with a Qt stack another package had already selected.
Routing through qtpy lets the binding be negotiated instead of dictated, which broadens compatibility **without changing what DeepLabCut requires or prefers**.

### Main changes

- 26 GUI modules import from `qtpy` rather than `PySide6`; swap only aside from `widgets.py`, where `Qt` moves to `qtpy.QtCore` because PySide6 re-exporting it from `QtGui` is binding-specific.
- `deeplabcut/gui/__init__.py` selects the binding by precedence: an explicit valid `QT_API`, then a binding already imported in the process, then PySide6, then qtpy's own autodetection.
- The selector normalises `os.environ["QT_API"]` to `qtpy.API` after selection, so matplotlib's independent detection resolves the same binding instead of loading a second one.
- When no binding can be imported, the raised `ImportError` reports whether PySide6 is absent or present-but-unloadable, prints the interpreter in use, and links the installation docs. Made warnings and errors more informative and user-friendly.
- An unsupported `QT_API` value raises a `ValueError` naming the valid values, in place of qtpy's `PythonQtValueError`, whose message reports the variable name rather than the offending value.
- `matplotlib.backends.backend_qt5agg` is replaced by `backend_qtagg`, which exports the same names without setting matplotlib's `_QT_FORCE_QT5_BINDING`.
- `deeplabcut/__main__.py` determines GUI availability by importing `deeplabcut.gui` rather than `PySide6`, and prints that module's error rather than a fixed message.
- `tests/gui/` skips on `qtpy.QtWidgets` rather than `PySide6`; the submodule is used because qtpy can be installed with no binding present, in which case the tests should skip rather than fail during collection. This is mostly to match actual qtpy imports in the code.
- `qtpy>=2.4` is declared in the `[gui]` extra instead of arriving transitively through qdarkstyle or napari.
- **Important notes regarding dependencies**:
  - **`backend_qtagg` requires matplotlib 3.5, so the floor is raised from `>=3.3` to `>=3.5`.** The resolved version is unchanged (3.8.4); the recorded specifier in `uv.lock` is updated to match. The `<3.9` ceiling is untouched — #3394 is the code preparation for lifting that end.
  - `uv.lock` resolves PySide6 6.9.3, due to the Linux split in pyproject, whereas 6.11+ is installed via pip install. uv does not fork and requests 6.9.3 in the lockfile.

### Additional context

- `deeplabcut/__main__.py` is in scope because this change makes `deeplabcut.gui` raise where it previously could not. The entry point probed `PySide6` and then imported `deeplabcut.gui.launch_script` unguarded. `import PySide6` succeeds on the Python package even when the compiled `QtCore` cannot load, so that probe passes and the unguarded import reaches the new selector, producing an uncaught traceback. It also means the new installation guidance reaches users running `dlc`, rather than only callers importing `deeplabcut.gui` from a script.
- `ImportError` rather than `ModuleNotFoundError` is caught throughout, because qtpy raises `QtBindingsNotFoundError`, which subclasses the former but not the latter.
- Three defects predating this branch are fixed where the migration touches them: `qdarkstyle.load_stylesheet_pyside6` does not exist in the pinned QDarkStyle 3.1, so `launch_script.py` raised on every launch and fell through to the PySide2 code path; `window.darkmode()` requested the PySide2 stylesheet unconditionally while `lightmode()` did not; and the removed lite-install message rendered as `pip install'deeplabcut[gui]''`.
- The qdarkstyle calls pass `palette=`. The zero-argument `load_stylesheet()` and the `load_stylesheet_<binding>()` helpers write `os.environ["QT_API"]`, which would leave a value inconsistent with the loaded binding. The resulting stylesheet is byte-identical to the previous one, so the theme is unchanged.
- `tests/gui/test_task_error.py` patched `QMessageBox` on the `QtWidgets` module, which never reached `window.py` because that module binds the name directly at import. The test constructed a real modal dialog and blocked. It is fixed here because the suite cannot otherwise complete. I think Qt versions differences are why this did not surface earlier, @deruyter92 let me know if you can reproduce (before a419a77e6e0cf0bf90d3aaae9194f24d269c8140)
