### PR TITLE
fix broken numpy 2.0 compat in crossvalutils and predict_multianimal

### DIFF
--- a/deeplabcut/core/crossvalutils.py
+++ b/deeplabcut/core/crossvalutils.py
@@ -30,7 +30,7 @@ from deeplabcut.core.inferenceutils import (
 )
 from deeplabcut.utils import auxfun_multianimal, auxiliaryfunctions
 
-_trapz = getattr(np, "trapezoid", np.trapz)  # NumPy 2.0+ compat; drop once NumPy 1 unsupported
+_trapz = np.trapezoid if hasattr(np, "trapezoid") else np.trapz  # NumPy 2.0+ compat; drop once NumPy 1 unsupported
 
 
 def _set_up_evaluation(data):

--- a/deeplabcut/pose_estimation_tensorflow/core/predict_multianimal.py
+++ b/deeplabcut/pose_estimation_tensorflow/core/predict_multianimal.py
@@ -15,7 +15,7 @@ import tensorflow as tf
 from scipy.ndimage import center_of_mass, label
 from skimage.feature import peak_local_max
 
-_trapz = getattr(np, "trapezoid", np.trapz)  # NumPy 2.0+ compat; drop once NumPy 1 unsupported
+_trapz = np.trapezoid if hasattr(np, "trapezoid") else np.trapz  # NumPy 2.0+ compat; drop once NumPy 1 unsupported
 
 
 def extract_cnn_output(outputs_np, cfg):


### PR DESCRIPTION
Fix a small mistake in numpy 2.0 compatibility:

in the `getattr(np,"trapezoid", np.trapz)` compatibility shim, the default arg was always evaluated, breaking compat. This PR replaces that with conditional evaluation `np.trapezoid if hasattr(np, "trapezoid") else np.trapz`