### PR TITLE
fix(trackingutils): take the real part of eig eigenvectors in EllipseFitter

### DIFF
--- a/deeplabcut/core/trackingutils.py
+++ b/deeplabcut/core/trackingutils.py
@@ -197,7 +197,9 @@ class EllipseFitter:
         M[0] = temp[2] * 0.5
         M[1] = -temp[1]
         M[2] = temp[0] * 0.5
-        E, V = np.linalg.eig(M)
+        _, V = np.linalg.eig(M)
+        # numba types eig's eigenvectors as complex; the fit needs the real part
+        V = V.real
         cond = 4 * V[0] * V[2] - V[1] ** 2
         a1 = V[:, cond > 0][:, 0]
         a2 = T @ a1


### PR DESCRIPTION
## Why

With numpy 2, numba types the output of `np.linalg.eig` as `complex128`, so the jitted `EllipseFitter._fit` fails to type `T @ a1` (float64 matrix against a complex vector) and `fit` raises `numba.core.errors.TypingError`. The ellipse fit only ever uses real eigenvectors, so this takes the real part explicitly. On numpy 1 numba types the same call as float64 and `.real` is a no-op, so results are unchanged there.

Found while testing `dev` with numpy 2.5.3 ahead of #3499.

## Scope

- `deeplabcut/core/trackingutils.py`: `EllipseFitter._fit` takes `V.real` after `np.linalg.eig`.

## Blast Radius

`EllipseFitter` is used by the SORT ellipse tracker. Behaviour on numpy 1 is identical; on numpy 2 it goes from raising to working.

## Verification

`tests/test_trackingutils.py::test_ellipse_fitter` on this branch, Python 3.12, numba 0.67.0:

- numpy 2.5.3: fails before the change with `TypingError: '@' arguments must all have the same dtype`, passes after.
- numpy 1.26.4: passes before and after.