### PR TITLE
Skip tracklet stitching when no animals were detected

### DIFF
--- a/deeplabcut/pose_estimation_pytorch/apis/videos.py
+++ b/deeplabcut/pose_estimation_pytorch/apis/videos.py
@@ -555,6 +555,7 @@ def analyze_videos(
     # Reading video and init variables
     videos = collect_video_paths(videos, extensions=video_extensions, shuffle=in_random_order)
     h5_files_created = False  # Track if any .h5 files were created
+    videos_without_detections = []  # Videos in which no animal was ever detected
 
     for video in videos:
         if destfolder is None:
@@ -632,7 +633,7 @@ def analyze_videos(
 
             if multi_animal:
                 assemblies_path = output_path / f"{output_prefix}_assemblies.pickle"
-                _generate_assemblies_file(
+                num_assemblies = _generate_assemblies_file(
                     full_data_path=output_pkl,
                     output_path=assemblies_path,
                     num_bodyparts=len(bodyparts),
@@ -692,32 +693,44 @@ def analyze_videos(
                         )
 
                 elif auto_track:
-                    convert_detections2tracklets(
-                        config=config,
-                        videos=str(video),
-                        video_extensions=video_extensions,
-                        shuffle=shuffle,
-                        trainingsetindex=trainingsetindex,
-                        overwrite=False,
-                        identity_only=identity_only,
-                        destfolder=str(output_path),
-                        snapshot_index=snapshot_index,
-                        detector_snapshot_index=detector_snapshot_index,
-                    )
-                    stitch_tracklets(
-                        config,
-                        [str(video)],
-                        video_extensions,
-                        shuffle,
-                        trainingsetindex,
-                        n_tracks=n_tracks,
-                        animal_names=animal_names,
-                        destfolder=str(output_path),
-                        save_as_csv=save_as_csv,
-                        snapshot_index=snapshot_index,
-                        detector_snapshot_index=detector_snapshot_index,
-                    )
-                    h5_files_created = True  # .h5 file was created by stitch_tracklets
+                    # Stitching needs at least one assembly to work with. Frames
+                    # without detections are padded with -1 and dropped when the
+                    # assemblies are built, so a video in which no animal was ever
+                    # detected yields none at all.
+                    if num_assemblies == 0:
+                        videos_without_detections.append(video)
+                        logging.warning(
+                            f"No animals were detected in {video}, so there is "
+                            "nothing to track: skipping tracklet stitching. The pose "
+                            f"predictions are still available in {output_pkl}."
+                        )
+                    else:
+                        convert_detections2tracklets(
+                            config=config,
+                            videos=str(video),
+                            video_extensions=video_extensions,
+                            shuffle=shuffle,
+                            trainingsetindex=trainingsetindex,
+                            overwrite=False,
+                            identity_only=identity_only,
+                            destfolder=str(output_path),
+                            snapshot_index=snapshot_index,
+                            detector_snapshot_index=detector_snapshot_index,
+                        )
+                        stitch_tracklets(
+                            config,
+                            [str(video)],
+                            video_extensions,
+                            shuffle,
+                            trainingsetindex,
+                            n_tracks=n_tracks,
+                            animal_names=animal_names,
+                            destfolder=str(output_path),
+                            save_as_csv=save_as_csv,
+                            snapshot_index=snapshot_index,
+                            detector_snapshot_index=detector_snapshot_index,
+                        )
+                        h5_files_created = True  # .h5 file was created by stitch_tracklets
 
     if h5_files_created:
         print(
@@ -726,6 +739,12 @@ def analyze_videos(
             "If the tracking is not satisfactory for some videos, consider expanding the "
             "training set. You can use the function 'extract_outlier_frames' to extract a "
             "few representative outlier frames.\n"
+        )
+    elif videos_without_detections:
+        print(
+            f"No animals were detected in {len(videos_without_detections)} of the "
+            "analyzed video(s), so no tracking files were created for them. The pose "
+            "predictions are still available in the ``_full.pickle`` files.\n"
         )
     else:
         print(
@@ -798,8 +817,14 @@ def _generate_assemblies_file(
     output_path: Path,
     num_bodyparts: int,
     num_unique_bodyparts: int,
-) -> None:
-    """Generates the assemblies file from predictions."""
+) -> int:
+    """Generates the assemblies file from predictions.
+
+    Returns:
+        The total number of assemblies kept across all frames. This is 0 when no
+        animal was detected anywhere in the video, as frames without detections are
+        padded with -1 and filtered out below.
+    """
     if full_data_path.exists():
         with full_data_path.open("rb") as f:
             data = pickle.load(f)
@@ -815,6 +840,7 @@ def _generate_assemblies_file(
         str_width = len(keys[0]) - len("frame")
 
     assemblies = dict(single=dict())
+    num_assemblies = 0
     for frame_index in range(num_frames):
         frame_key = "frame" + str(frame_index).zfill(str_width)
         predictions = data[frame_key]
@@ -843,6 +869,7 @@ def _generate_assemblies_file(
         mask = ~np.all(preds < 0, axis=(1, 2))
         preds = preds[mask]
 
+        num_assemblies += len(preds)
         assemblies[frame_index] = preds
 
         if num_unique_bodyparts > 0:
@@ -857,6 +884,8 @@ def _generate_assemblies_file(
 
     if isinstance(data, shelving.ShelfReader):
         data.close()
+
+    return num_assemblies
 
 
 def _validate_destfolder(destfolder: str | None) -> None:

--- a/deeplabcut/refine_training_dataset/stitch.py
+++ b/deeplabcut/refine_training_dataset/stitch.py
@@ -38,6 +38,10 @@ from deeplabcut.utils import auxfun_multianimal, auxiliaryfunctions
 from deeplabcut.utils.auxfun_videos import VideoWriter, collect_video_paths
 
 
+class EmptyTrackletsError(ValueError):
+    """Raised when there are no tracklets long enough to stitch."""
+
+
 class Tracklet:
     def __init__(self, data, inds):
         """Create a Tracklet object.
@@ -452,7 +456,7 @@ class TrackletStitcher:
                     self.residuals.append(t)
 
         if not len(self.tracklets):
-            raise OSError("Tracklets are empty.")
+            raise EmptyTrackletsError("Tracklets are empty.")
 
         if prestitch_residuals:
             self._prestitch_residuals(5)  # Hard-coded but found to work very well
@@ -1181,5 +1185,5 @@ def stitch_tracklets(
                     suffix="",
                     save_as_csv=save_as_csv,
                 )
-        except FileNotFoundError as e:
+        except (FileNotFoundError, EmptyTrackletsError) as e:
             print(e, "\nSkipping...")

--- a/tests/pose_estimation_pytorch/apis/test_videos.py
+++ b/tests/pose_estimation_pytorch/apis/test_videos.py
@@ -1,5 +1,7 @@
+import pickle
 from unittest.mock import Mock
 
+import numpy as np
 import pytest
 
 import deeplabcut.pose_estimation_pytorch.apis.videos as videos
@@ -29,6 +31,39 @@ def test_generate_output_data_handles_empty_predictions():
             "key_str_width": 1,
         }
     }
+
+
+def _write_assemblies(tmp_path, predictions):
+    """Runs predictions through the real full-pickle -> assemblies chain."""
+    full_data_path = tmp_path / "full.pickle"
+    with full_data_path.open("wb") as f:
+        pickle.dump(videos._generate_output_data(POSE_CFG, predictions), f)
+
+    return videos._generate_assemblies_file(
+        full_data_path=full_data_path,
+        output_path=tmp_path / "assemblies.pickle",
+        num_bodyparts=3,
+        num_unique_bodyparts=0,
+    )
+
+
+@pytest.mark.parametrize("num_frames", [1, 3])
+def test_generate_assemblies_file_counts_no_assemblies_when_nothing_detected(tmp_path, num_frames):
+    """A frame without detections is padded with -1 by ``PadOutputs``, and those rows
+    are filtered out when the assemblies are built - so the count is 0 even though
+    the predictions list is full length.
+    """
+    predictions = [dict(bodyparts=np.full((2, 3, 3), -1.0)) for _ in range(num_frames)]
+
+    assert _write_assemblies(tmp_path, predictions) == 0
+
+
+def test_generate_assemblies_file_counts_real_assemblies(tmp_path):
+    detected = np.zeros((2, 3, 3))  # 2 individuals, 3 bodyparts, (x, y, score)
+    undetected = np.full((2, 3, 3), -1.0)
+    predictions = [dict(bodyparts=detected), dict(bodyparts=undetected)]
+
+    assert _write_assemblies(tmp_path, predictions) == 2
 
 
 def test_create_df_from_prediction_rejects_empty_predictions(tmp_path):

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -131,6 +131,23 @@ def test_stitcher_wrong_inputs(tracklet):
         _ = TrackletStitcher([tracklet], n_tracks=2, min_length=2)
 
 
+def test_empty_tracklets_error_is_a_value_error():
+    """Empty tracklets is an invalid-argument condition, consistent with the other
+    guards in ``TrackletStitcher.__init__``. Pinned because this was signalled with
+    ``OSError`` before, which read as an I/O failure.
+    """
+    assert issubclass(EmptyTrackletsError, ValueError)
+
+
+def test_stitcher_rejects_header_only_tracklets(real_tracklets):
+    """A tracklets file with a header but no tracklets is what tracklet conversion
+    produces for a video in which no animal was ever detected. Goes through
+    ``from_dict_of_dict``, the path ``from_pickle`` and ``stitch_tracklets`` use.
+    """
+    with pytest.raises(EmptyTrackletsError):
+        _ = TrackletStitcher.from_dict_of_dict({"header": real_tracklets["header"]}, n_tracks=3)
+
+
 @pytest.mark.parametrize("tracklet", make_fake_tracklets())
 def test_purify_tracklets(tracklet):
     tracklet.data = np.full_like(tracklet.data, np.nan)

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from deeplabcut.refine_training_dataset.stitch import Tracklet, TrackletStitcher
+from deeplabcut.refine_training_dataset.stitch import EmptyTrackletsError, Tracklet, TrackletStitcher
 
 TRACKLET_LEN = 1000
 TRACKLET_START = 50
@@ -125,7 +125,7 @@ def test_tracklet_affinities(tracklet):
 
 @pytest.mark.parametrize("tracklet", make_fake_tracklets())
 def test_stitcher_wrong_inputs(tracklet):
-    with pytest.raises(IOError):
+    with pytest.raises(EmptyTrackletsError):
         _ = TrackletStitcher([], n_tracks=2)
     with pytest.raises(ValueError):
         _ = TrackletStitcher([tracklet], n_tracks=2, min_length=2)


### PR DESCRIPTION
## Problem

For multi-animal analysis with `auto_track=True`, a video with no detections causes the entire operation to abort.

Undetected frames are represented by `-1` padded predictions. These entries are removed when assemblies are generated, so a fully undetected video produces an empty assemblies file. Tracking then proceeds anyway, eventually causing `TrackletStitcher` to raise `OSError("Tracklets are empty.")`.

## Changes

- Return the retained assembly count from `_generate_assemblies_file`
- Skip automatic tracking when a video contains no assemblies
- Warn that no tracking output was created while keeping the `_full.pickle` predictions available
- Introduce `EmptyTrackletsError` as a `ValueError` subclass for empty tracklet input
- Make `stitch_tracklets` skip videos that raise `EmptyTrackletsError`, allowing batch processing to continue
- Add regression tests for empty assemblies, valid assembly counts, header-only tracklets, and the exceptions

## Compatibility

Changes the exception raised for empty tracklets from `OSError` to `ValueError`. It also changes `stitch_tracklets` so that empty-tracklet videos are skipped rather than propagated as failures, including for GUI and standalone callers.
No callers in the repository currently catch either exception.

Follow-up to #3488, where handling an `OverflowError` in `_generate_output_data` revealed this failure.